### PR TITLE
Enable passing a target account to `create`

### DIFF
--- a/src/internal/accountDelegation.ts
+++ b/src/internal/accountDelegation.ts
@@ -119,28 +119,28 @@ export async function create<chain extends Chain | undefined>(
 ) {
   const { authorizeKeys, delegation, rpId, targetAccount } = parameters
 
-  let account: PrivateKeyAccount;
-  let address: Address.Address;
-  let sign: ({hash}: {hash: `0x${string}`}) => Promise<Signature.Signature>;
+  let account: PrivateKeyAccount
+  let address: Address.Address
+  let sign: ({ hash }: { hash: `0x${string}` }) => Promise<Signature.Signature>
   if (targetAccount) {
-    account = targetAccount;
+    account = targetAccount
     address = targetAccount.address
-    sign = async ({hash}: {hash: `0x${string}`}) => Signature.from(await targetAccount.sign({hash}));
+    sign = async ({ hash }: { hash: `0x${string}` }) =>
+      Signature.from(await targetAccount.sign({ hash }))
   } else {
     // We will only hold onto the private key for the duration of this lexical scope
     // (we will not persist it).
 
     // Derive the Account's address from the private key. We will use this as the
     // Transaction target, as well as for the label/id on the WebAuthn credential.
-    const privateKey = Secp256k1.randomPrivateKey();
-    account = privateKeyToAccount(privateKey);
+    const privateKey = Secp256k1.randomPrivateKey()
+    account = privateKeyToAccount(privateKey)
     address = Address.fromPublicKey(Secp256k1.getPublicKey({ privateKey }))
-    sign = async ({hash}: {hash: `0x${string}`}) => Secp256k1.sign({payload: hash, privateKey});
+    sign = async ({ hash }: { hash: `0x${string}` }) =>
+      Secp256k1.sign({ payload: hash, privateKey })
   }
 
-
   // Generate a random private key to instantiate the Account.
-
 
   // Create an identifiable label for the Account.
   const label =
@@ -175,7 +175,7 @@ export async function create<chain extends Chain | undefined>(
   )
 
   // Sign the payload.
-  const signature = await sign({hash: payload});
+  const signature = await sign({ hash: payload })
 
   // Sign an authorization to designate the delegation contract onto the Account.
   const authorization = await signAuthorization(client, {
@@ -218,7 +218,7 @@ export declare namespace create {
     /** Relying Party ID. */
     rpId?: string | undefined
     /** Target account to attach P256 key to. If no target is specified, a new Ethereum address will be created. */
-    targetAccount?: PrivateKeyAccount;
+    targetAccount?: PrivateKeyAccount
   }
 }
 


### PR DESCRIPTION
Adds support for passing a target account to `create`, to allow users to register a P256 as an authorized signer on an existing EOA, instead of only creating a new EOA for the user. If no target account is passed, the existing flow of creating a new EOA will be followed.

It seems like the target account simply needs to return its `address` and implement a secp256k1 `sign` handler for signing the 7702 authorization. In kind, I typed the target account as a viem `PrivateKeyAccount` which should support this functionality but open to any other recommendation!

**Open question**: Currently, this `create` method seems to only be used internally when the EIP1193 provider receives the `experimental_createAccount` RPC. To support adding the P256 key as a signer for the target account, the target account (and its signature handler) must also be passed to this RPC. 

Passing the signature handler in particular is a bit tricky because it can't really be passed "over the wire". Do you have a sense for what might be the best way to support this use case? Would there need to be a bit of an RPC dance between Porto's EIP1193 provider and the target account where:
1. The target account requests an authorization payload from Porto given its address
2. Porto responds with the authorization payload
3. The test account signs the authorization payload and sends it to Porto via RPC
4. Porto uses the authorization payload to register the P256 key as an authorized signer
