### PR TITLE
feat: import external account

### DIFF
--- a/.changeset/warm-dingos-hang.md
+++ b/.changeset/warm-dingos-hang.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added `experimental_prepareImportAccount` & `experimental_importAccount` JSON-RPC methods to import external accounts (EOAs).

--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Import via named export or `A` namespace (better autocomplete DX and does not im
 - `createAccount`
 - `disconnect`
 - `grantSession`
+- `importAccount`
 - `sessions`
 
 ```ts
@@ -496,6 +497,7 @@ Import via named export or `W` namespace (better autocomplete DX and does not im
 - `useCreateAccount`
 - `useDisconnect`
 - `useGrantSession`
+- `useImportAccount`
 - `useSessions`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Experimental Next-gen Account for Ethereum.
   - [`experimental_createAccount`](#experimental_createaccount)
   - [`experimental_disconnect`](#experimental_disconnect)
   - [`experimental_grantSession`](#experimental_grantsession)
+  - [`experimental_prepareImportAccount`](#experimental_prepareImportAccount)
+  - [`experimental_importAccount`](#experimental_importAccount)
   - [`experimental_sessions`](#experimental_sessions)
 - [Available ERC-5792 Capabilities](#available-erc-5792-capabilities)
   - [`atomicBatch`](#atomicbatch)
@@ -272,6 +274,81 @@ Grants a session on the account.
 
   // The ID of the session.
   id: `0x${string}`,
+}
+```
+
+### `experimental_prepareImportAccount`
+
+Returns a set of hex payloads to sign over to import an external account, and prepares values needed to fill context for the `experimental_importAccount` JSON-RPC method.
+
+#### Parameters
+
+```ts
+{
+  method: 'experimental_prepareImportAccount',
+  params: [{ 
+    // Address of the account to import.
+    address?: `0x${string}`,
+
+    // ERC-5792 capabilities to define extended behavior.
+    capabilities: {
+      // Whether to grant a session with an optional expiry.
+      // Defaults to user-configured expiry on the account.
+      grantSession?: boolean | { expiry?: number },
+    } 
+  }]
+}
+```
+
+#### Returns
+
+```ts
+{
+  // Filled context for the `experimental_importAccount` JSON-RPC method.
+  context: unknown
+
+  // Hex payloads to sign over.
+  signPayloads: `0x${string}`[]
+}
+```
+
+### `experimental_importAccount`
+
+Imports an account.
+
+#### Parameters
+
+```ts
+{
+  method: 'experimental_importAccount',
+  params: [{ 
+    // Context from the `experimental_prepareImportAccount` JSON-RPC method.
+    context: unknown, 
+
+    // Signatures over the payloads returned by `experimental_prepareImportAccount`.
+    signatures: `0x${string}`[] 
+  }]
+}
+```
+
+#### Returns
+
+```ts
+{
+  // The address of the account.
+  address: `0x${string}`,
+
+  // ERC-5792 capabilities to define extended behavior.
+  capabilities: {
+    // The sessions granted to the account.
+    sessions: {
+      // The expiry of the session.
+      expiry: number,
+
+      // The ID of the session.
+      id: `0x${string}`,
+    }[],
+  }
 }
 ```
 

--- a/examples/wagmi/src/App.tsx
+++ b/examples/wagmi/src/App.tsx
@@ -1,5 +1,5 @@
 import { W } from 'porto/wagmi'
-import { formatEther, parseEther } from 'viem'
+import { type Hex, formatEther, parseEther } from 'viem'
 import {
   type BaseError,
   useAccount,
@@ -9,6 +9,11 @@ import {
 import { useCallsStatus, useSendCalls } from 'wagmi/experimental'
 
 import { useState } from 'react'
+import {
+  generatePrivateKey,
+  privateKeyToAccount,
+  privateKeyToAddress,
+} from 'viem/accounts'
 import { ExperimentERC20 } from './contracts'
 
 export function App() {
@@ -23,7 +28,10 @@ export function App() {
           <Mint />
         </>
       ) : (
-        <Connect />
+        <>
+          <Connect />
+          <ImportAccount />
+        </>
       )}
     </>
   )
@@ -97,6 +105,79 @@ function Connect() {
         ))}
       <div>{connect.status}</div>
       <div>{connect.error?.message}</div>
+    </div>
+  )
+}
+
+function ImportAccount() {
+  const [accountData, setAccountData] = useState<{
+    privateKey: string
+    address: string
+  } | null>(null)
+  const [privateKey, setPrivateKey] = useState<string>('')
+
+  const [grantSession, setGrantSession] = useState<boolean>(true)
+
+  const connectors = useConnectors()
+  const importAccount = W.useImportAccount()
+
+  return (
+    <div>
+      <h2>Import Account</h2>
+      <p>
+        <button
+          onClick={() => {
+            const privateKey = generatePrivateKey()
+            setPrivateKey(privateKey)
+            setAccountData({
+              privateKey,
+              address: privateKeyToAddress(privateKey),
+            })
+          }}
+          type="button"
+        >
+          Create Account
+        </button>
+        {accountData && <pre>{JSON.stringify(accountData, null, 2)}</pre>}
+      </p>
+      <div>
+        <input
+          type="text"
+          value={privateKey}
+          onChange={(e) => setPrivateKey(e.target.value)}
+          placeholder="Private Key"
+          style={{ width: '300px' }}
+        />
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={grantSession}
+            onChange={() => setGrantSession((x) => !x)}
+          />
+          Grant Session
+        </label>
+      </div>
+      {connectors
+        .filter((x) => x.id === 'xyz.ithaca.porto')
+        ?.map((connector) => (
+          <button
+            key={connector.uid}
+            onClick={async () => {
+              await importAccount.mutateAsync({
+                account: privateKeyToAccount(privateKey as Hex),
+                connector,
+                grantSession,
+              })
+            }}
+            type="button"
+          >
+            Import Account
+          </button>
+        ))}
+      <div>{importAccount.status}</div>
+      <div>{importAccount.error?.message}</div>
     </div>
   )
 }

--- a/examples/wagmi/src/App.tsx
+++ b/examples/wagmi/src/App.tsx
@@ -111,12 +111,11 @@ function Connect() {
 
 function ImportAccount() {
   const [accountData, setAccountData] = useState<{
-    privateKey: string
     address: string
+    privateKey: string
   } | null>(null)
-  const [privateKey, setPrivateKey] = useState<string>('')
-
   const [grantSession, setGrantSession] = useState<boolean>(true)
+  const [privateKey, setPrivateKey] = useState<string>('')
 
   const connectors = useConnectors()
   const importAccount = W.useImportAccount()
@@ -164,13 +163,13 @@ function ImportAccount() {
         ?.map((connector) => (
           <button
             key={connector.uid}
-            onClick={async () => {
-              await importAccount.mutateAsync({
+            onClick={() =>
+              importAccount.mutate({
                 account: privateKeyToAccount(privateKey as Hex),
                 connector,
                 grantSession,
               })
-            }}
+            }
             type="button"
           >
             Import Account

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^5.5.4
       version: 5.6.3
     viem:
-      specifier: ^2.21.44
-      version: 2.21.44
+      specifier: ^2.21.51
+      version: 2.21.51
     wagmi:
       specifier: ^2.12.30
       version: 2.12.30
@@ -73,10 +73,10 @@ importers:
         version: 5.6.3
       viem:
         specifier: 'catalog:'
-        version: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+        version: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
       wagmi:
         specifier: 'catalog:'
-        version: 2.12.30(@tanstack/query-core@5.59.20)(@tanstack/react-query@5.59.20(react@18.3.1))(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
+        version: 2.12.30(@tanstack/query-core@5.59.20)(@tanstack/react-query@5.59.20(react@18.3.1))(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
 
   app:
     dependencies:
@@ -137,10 +137,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       viem:
         specifier: 'catalog:'
-        version: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+        version: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
       wagmi:
         specifier: 'catalog:'
-        version: 2.12.30(@tanstack/query-core@5.59.20)(@tanstack/react-query@5.59.20(react@18.3.1))(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
+        version: 2.12.30(@tanstack/query-core@5.59.20)(@tanstack/react-query@5.59.20(react@18.3.1))(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -177,7 +177,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       viem:
         specifier: 'catalog:'
-        version: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+        version: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -3547,8 +3547,8 @@ packages:
       react:
         optional: true
 
-  viem@2.21.44:
-    resolution: {integrity: sha512-oyLTCt7OQUetQN2m9KPNgSA//MzpnQLABAyglPKh+fAypU8cTT/hC5UyLQvaYt4WPg6dkbKOxfsahV4739pu9w==}
+  viem@2.21.51:
+    resolution: {integrity: sha512-IBZTFoo9cZvMBkFqaJq5G8Ori4IeEDe9AHE5CmOlvNw7ytkC3vdVrJ/APL+V3H4d/5i1FiV331UsckIqQLIM0w==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -4907,7 +4907,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.22.2
-      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+      viem: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -5178,7 +5178,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 3.0.1
       prettier: 3.3.3
-      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+      viem: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
       zod: 3.23.8
     optionalDependencies:
       typescript: 5.6.3
@@ -5186,16 +5186,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@wagmi/connectors@5.3.8(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(@wagmi/core@2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)':
+  '@wagmi/connectors@5.3.8(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(@wagmi/core@2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)':
     dependencies:
       '@coinbase/wallet-sdk': 4.2.1(@types/node@22.9.0)
       '@metamask/sdk': 0.30.1(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.4(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
-      '@wagmi/core': 2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))
+      '@wagmi/core': 2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))
       '@walletconnect/ethereum-provider': 2.17.0(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+      viem: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -5236,11 +5236,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/core@2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))':
+  '@wagmi/core@2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.6.3)
-      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+      viem: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
       zustand: 5.0.0(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/query-core': 5.59.20
@@ -7403,7 +7403,7 @@ snapshots:
       '@types/react': 18.3.12
       react: 18.3.1
 
-  viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8):
+  viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8):
     dependencies:
       '@noble/curves': 1.6.0
       '@noble/hashes': 1.5.0
@@ -7482,14 +7482,14 @@ snapshots:
       - supports-color
       - terser
 
-  wagmi@2.12.30(@tanstack/query-core@5.59.20)(@tanstack/react-query@5.59.20(react@18.3.1))(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8):
+  wagmi@2.12.30(@tanstack/query-core@5.59.20)(@tanstack/react-query@5.59.20(react@18.3.1))(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8):
     dependencies:
       '@tanstack/react-query': 5.59.20(react@18.3.1)
-      '@wagmi/connectors': 5.3.8(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(@wagmi/core@2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
-      '@wagmi/core': 2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))
+      '@wagmi/connectors': 5.3.8(@types/node@22.9.0)(@types/react@18.3.12)(@upstash/redis@1.34.3)(@wagmi/core@2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
+      '@wagmi/core': 2.14.5(@tanstack/query-core@5.59.20)(@types/react@18.3.12)(react@18.3.1)(typescript@5.6.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8))
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
-      viem: 2.21.44(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+      viem: 2.21.51(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,5 +11,5 @@ catalog:
   react: "^18.3.1"
   react-dom: "^18.3.1"
   typescript: "^5.5.4"
-  viem: "^2.21.44"
+  viem: "^2.21.51"
   wagmi: "^2.12.30"

--- a/src/Porto.ts
+++ b/src/Porto.ts
@@ -95,7 +95,7 @@ export function create(config: Config | undefined = {}): Porto {
                 })),
               })),
               chain: state.chain,
-            } as State
+            } as unknown as State
           },
           storage: Storage.idb,
         },

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,6 +3,7 @@ export {
   createAccount,
   disconnect,
   grantSession,
+  importAccount,
   sessions,
 } from './internal/wagmi/core.js'
 export * as A from './internal/wagmi/core.js'

--- a/src/internal/rpcSchema.ts
+++ b/src/internal/rpcSchema.ts
@@ -1,6 +1,9 @@
 import type * as Address from 'ox/Address'
 import type * as Hex from 'ox/Hex'
 import type * as RpcSchema from 'ox/RpcSchema'
+import type { Authorization } from 'viem/experimental'
+
+import type * as AccountDelegation from './accountDelegation.js'
 
 export type Schema = RpcSchema.From<
   | RpcSchema.Default
@@ -39,6 +42,20 @@ export type Schema = RpcSchema.From<
     }
   | {
       Request: {
+        method: 'experimental_importAccount'
+        params: [ImportAccountParameters]
+      }
+      ReturnType: ImportAccountReturnType
+    }
+  | {
+      Request: {
+        method: 'experimental_prepareImportAccount'
+        params: [PrepareImportAccountParameters]
+      }
+      ReturnType: PrepareImportAccountReturnType
+    }
+  | {
+      Request: {
         method: 'experimental_sessions'
         params?: [GetSessionsParameters] | undefined
       }
@@ -60,9 +77,11 @@ export type ConnectParameters = {
 
 export type ConnectReturnType = readonly {
   address: Address.Address
-  capabilities?: {
-    sessions?: GetSessionsReturnType | undefined
-  }
+  capabilities?:
+    | {
+        sessions?: GetSessionsReturnType | undefined
+      }
+    | undefined
 }[]
 
 export type CreateAccountParameters = {
@@ -89,4 +108,39 @@ export type GrantSessionParameters = {
 export type GrantSessionReturnType = {
   expiry: number
   id: Hex.Hex
+}
+
+export type ImportAccountParameters = {
+  context: PrepareImportAccountReturnType['context']
+  signatures: readonly Hex.Hex[]
+}
+
+export type ImportAccountReturnType = {
+  address: Address.Address
+  capabilities?:
+    | {
+        sessions?: GetSessionsReturnType | undefined
+      }
+    | undefined
+}
+
+export type PrepareImportAccountParameters = {
+  address: Address.Address
+  capabilities?:
+    | {
+        grantSession?:
+          | boolean
+          | Omit<GrantSessionParameters, 'address'>
+          | undefined
+      }
+    | undefined
+  label?: string | undefined
+}
+
+export type PrepareImportAccountReturnType = {
+  context: {
+    account: AccountDelegation.Account
+    authorization: Authorization
+  }
+  signPayloads: readonly Hex.Hex[]
 }

--- a/src/internal/wagmi/core.ts
+++ b/src/internal/wagmi/core.ts
@@ -5,6 +5,7 @@ import {
   ChainMismatchError,
   type EIP1193Provider,
   type Hex,
+  type PrivateKeyAccount,
 } from 'viem'
 import {
   type BaseErrorType,
@@ -282,6 +283,129 @@ export declare namespace grantSession {
     expiry: number
     id: Hex
   }
+
+  // TODO: Exhaustive ErrorType
+  type ErrorType = BaseErrorType
+}
+
+export async function importAccount<config extends Config>(
+  config: config,
+  parameters: importAccount.Parameters<config>,
+): Promise<importAccount.ReturnType> {
+  // "Register" connector if not already created
+  let connector: Connector
+  if (typeof parameters.connector === 'function') {
+    connector = config._internal.connectors.setup(parameters.connector)
+  } else connector = parameters.connector
+
+  // Check if connector is already connected
+  if (connector.uid === config.state.current)
+    throw new ConnectorAlreadyConnectedError()
+
+  if (parameters.chainId && parameters.chainId !== config.state.chainId)
+    throw new ChainMismatchError({
+      chain:
+        config.chains.find((chain) => chain.id === parameters.chainId) ??
+        ({
+          id: parameters.chainId,
+          name: `Chain ${parameters.chainId}`,
+        } as Chain),
+      currentChainId: config.state.chainId,
+    })
+
+  try {
+    config.setState((x) => ({ ...x, status: 'connecting' }))
+    connector.emitter.emit('message', { type: 'connecting' })
+
+    const provider = (await connector.getProvider()) as
+      | EIP1193Provider
+      | undefined
+    if (!provider) throw new ProviderNotFoundError()
+
+    const { account, grantSession, label } = parameters
+
+    const experimental_prepareImportAccount =
+      'experimental_prepareImportAccount'
+    type experimental_prepareImportAccount =
+      typeof experimental_prepareImportAccount
+    const { context, signPayloads } = await provider.request<{
+      Method: experimental_prepareImportAccount
+      Parameters?: RpcSchema.ExtractParams<
+        Schema,
+        experimental_prepareImportAccount
+      >
+      ReturnType: RpcSchema.ExtractReturnType<
+        Schema,
+        experimental_prepareImportAccount
+      >
+    }>({
+      method: experimental_prepareImportAccount,
+      params: [
+        { address: account.address, capabilities: { grantSession }, label },
+      ],
+    })
+
+    const signatures = await Promise.all(
+      signPayloads.map((hash) => account.sign({ hash })),
+    )
+
+    const experimental_importAccount = 'experimental_importAccount'
+    type experimental_importAccount = typeof experimental_importAccount
+    await provider.request<{
+      Method: experimental_importAccount
+      Parameters?: RpcSchema.ExtractParams<Schema, experimental_importAccount>
+      ReturnType: RpcSchema.ExtractReturnType<
+        Schema,
+        experimental_importAccount
+      >
+    }>({
+      method: experimental_importAccount,
+      params: [{ context, signatures }],
+    })
+
+    // we already connected, but call `connector.connect` so connector even listeners are set up
+    const data = await connector.connect({
+      chainId: parameters.chainId,
+      isReconnecting: true,
+    })
+    const accounts = data.accounts as readonly [Address, ...Address[]]
+
+    connector.emitter.off('connect', config._internal.events.connect)
+    connector.emitter.on('change', config._internal.events.change)
+    connector.emitter.on('disconnect', config._internal.events.disconnect)
+
+    await config.storage?.setItem('recentConnectorId', connector.id)
+    config.setState((x) => ({
+      ...x,
+      connections: new Map(x.connections).set(connector.uid, {
+        accounts,
+        chainId: data.chainId,
+        connector,
+      }),
+      current: connector.uid,
+      status: 'connected',
+    }))
+
+    return { accounts, chainId: data.chainId }
+  } catch (error) {
+    config.setState((x) => ({
+      ...x,
+      // Keep existing connector connected in case of error
+      status: x.current ? 'connected' : 'disconnected',
+    }))
+    throw error
+  }
+}
+
+export declare namespace importAccount {
+  type Parameters<config extends Config = Config> = ChainIdParameter<config> & {
+    account: PrivateKeyAccount
+    connector: Connector | CreateConnectorFn
+    grantSession?: boolean | GrantSessionParameters | undefined
+    label?: string | undefined
+  }
+
+  type ReturnType<config extends Config = Config> = ConnectReturnType<config>
 
   // TODO: Exhaustive ErrorType
   type ErrorType = BaseErrorType

--- a/src/internal/wagmi/react.ts
+++ b/src/internal/wagmi/react.ts
@@ -27,6 +27,7 @@ import {
   createAccount,
   disconnect,
   grantSession,
+  importAccount,
   sessions,
 } from './core.js'
 import { sessionsQueryKey } from './query.js'
@@ -194,6 +195,49 @@ export declare namespace useGrantSession {
     grantSession.ReturnType,
     grantSession.ErrorType,
     grantSession.Parameters<config>,
+    context
+  >
+}
+
+export function useImportAccount<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: useImportAccount.Parameters<config, context> = {},
+): useImportAccount.ReturnType<config, context> {
+  const { mutation } = parameters
+  const config = useConfig(parameters)
+  return useMutation({
+    ...mutation,
+    async mutationFn(variables) {
+      return importAccount(config as Config, variables)
+    },
+    mutationKey: ['importAccount'],
+  })
+}
+
+export declare namespace useImportAccount {
+  type Parameters<
+    config extends Config = Config,
+    context = unknown,
+  > = ConfigParameter<config> & {
+    mutation?:
+      | UseMutationParameters<
+          importAccount.ReturnType,
+          importAccount.ErrorType,
+          importAccount.Parameters<config>,
+          context
+        >
+      | undefined
+  }
+
+  type ReturnType<
+    config extends Config = Config,
+    context = unknown,
+  > = UseMutationResult<
+    importAccount.ReturnType,
+    importAccount.ErrorType,
+    importAccount.Parameters<config>,
     context
   >
 }

--- a/src/wagmi.ts
+++ b/src/wagmi.ts
@@ -3,6 +3,7 @@ export {
   useCreateAccount,
   useDisconnect,
   useGrantSession,
+  useImportAccount,
   useSessions,
 } from './internal/wagmi/react.js'
 export * as W from './internal/wagmi/react.js'


### PR DESCRIPTION
Adds ability to import an external account. Supersedes #1.

```mermaid
sequenceDiagram
    Consumer ->> Porto: experimental_prepareImportAccount(address)
    Porto -->> Consumer: (context, signPayloads)
    Consumer ->> Consumer: signatures = sign(signPayloads)
    Consumer ->> Porto: experimental_importAccount(context, signatures)
    Porto -->> Consumer: (address)
    note right of Consumer: connected!
```