### PR TITLE
fix: broken link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Porto can be used in conjunction with [Wagmi](https://wagmi.sh/) to provide a se
 
 #### 1. Set up Wagmi
 
-Get started with Wagmi by following the [official guide](https://wagmi.sh/docs/getting-started).
+Get started with Wagmi by following the [official guide](https://wagmi.sh/react/getting-started).
 
 #### 2. Set up Porto
 


### PR DESCRIPTION
This pull request fixes a broken link in the `README.md` file. The link to the Wagmi documentation was updated to point to the correct URL.

- Fixed `https://wagmi.sh/docs/getting-started` to `https://wagmi.sh/react/getting-started`.