### PR TITLE
Handle `grantSession` keys as available parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,10 @@ Grants a session on the account.
     expiry?: number
 
     // The keys to grant on the session.
+    // Defaults to a Web Crypto P256 key.
     keys?: {
-      algorithm: 'p256' | 'secp256k1',
       publicKey: `0x${string}`,
+      type: 'p256' | 'secp256k1' | 'webauthn',
     }[]
   }]
 }

--- a/contracts/src/account/ExperimentalDelegation.sol
+++ b/contracts/src/account/ExperimentalDelegation.sol
@@ -20,7 +20,8 @@ contract ExperimentalDelegation is Receiver, MultiSendCallOnly {
     /// @notice The type of key.
     enum KeyType {
         P256,
-        WebAuthnP256
+        WebAuthnP256,
+        Secp256k1
     }
 
     /// @notice A Key that can be used to authorize calls.
@@ -205,6 +206,9 @@ contract ExperimentalDelegation is Receiver, MultiSendCallOnly {
             if (key.keyType == KeyType.WebAuthnP256) {
                 WebAuthnP256.Metadata memory metadata = abi.decode(wrappedSignature.metadata, (WebAuthnP256.Metadata));
                 if (WebAuthnP256.verify(digest, metadata, wrappedSignature.signature, key.publicKey)) return success;
+            }
+            if (key.keyType == KeyType.Secp256k1 && ECDSA.verify(digest, wrappedSignature.signature, key.publicKey)) {
+                return success;
             }
         }
 

--- a/contracts/src/utils/ECDSA.sol
+++ b/contracts/src/utils/ECDSA.sol
@@ -31,7 +31,7 @@ library ECDSA {
 
         if (signer == address(0)) return false;
 
-        bytes memory publicKeyBytes = abi.encodePacked(bytes1(0x04), publicKey.x, publicKey.y);
+        bytes memory publicKeyBytes = abi.encodePacked(publicKey.x, publicKey.y);
 
         bytes32 publicKeyHash = keccak256(publicKeyBytes);
 

--- a/contracts/src/utils/ECDSA.sol
+++ b/contracts/src/utils/ECDSA.sol
@@ -12,4 +12,21 @@ library ECDSA {
         uint256 s;
         uint8 yParity;
     }
+
+    /// @notice Verifies an ECDSA signature.
+    /// @param digest 32 bytes of the signed data hash
+    /// @param signature Signature of the signer
+    /// @param publicKey Public key of the signer
+    /// @return success Represents if the operation was successful
+    function verify(bytes32 digest, Signature memory signature, PublicKey memory publicKey) internal pure returns (bool) {
+        address signer = ecrecover(digest, signature.v, signature.r, signature.s);
+
+        if (signer == address(0)) return false;
+
+        bytes memory publicKeyBytes = abi.encodePacked(bytes1(0x04), publicKey.x, publicKey.y);
+
+        bytes32 publicKeyHash = keccak256(publicKeyBytes);
+
+        return signer == address(uint160(uint256(publicKeyHash)));
+    }
 }

--- a/contracts/src/utils/ECDSA.sol
+++ b/contracts/src/utils/ECDSA.sol
@@ -18,8 +18,16 @@ library ECDSA {
     /// @param signature Signature of the signer
     /// @param publicKey Public key of the signer
     /// @return success Represents if the operation was successful
-    function verify(bytes32 digest, Signature memory signature, PublicKey memory publicKey) internal pure returns (bool) {
-        address signer = ecrecover(digest, signature.v, signature.r, signature.s);
+    function verify(bytes32 digest, Signature memory signature, PublicKey memory publicKey)
+        internal
+        pure
+        returns (bool)
+    {
+        uint8 v = signature.yParity + 27;
+        bytes32 r = bytes32(signature.r);
+        bytes32 s = bytes32(signature.s);
+
+        address signer = ecrecover(digest, v, r, s);
 
         if (signer == address(0)) return false;
 

--- a/src/internal/accountDelegation.ts
+++ b/src/internal/accountDelegation.ts
@@ -49,7 +49,7 @@ export type Calls = readonly {
   data?: Hex.Hex | undefined
 }[]
 
-export type Key = WebAuthnKey | WebCryptoKey
+export type Key = WebAuthnKey | WebCryptoKey | Secp256k1Key
 
 export type SerializedKey = {
   expiry: bigint
@@ -66,6 +66,8 @@ export type WebCryptoKey = BaseKey<
   }
 >
 
+export type Secp256k1Key = BaseKey<'secp256k1', {}>
+
 ////////////////////////////////////////////////////////////////
 // Constants
 ////////////////////////////////////////////////////////////////
@@ -73,11 +75,13 @@ export type WebCryptoKey = BaseKey<
 const keyType = {
   p256: 0,
   webauthn: 1,
+  secp256k1: 2,
 } as const
 
 const keyTypeSerialized = {
   0: 'p256',
   1: 'webauthn',
+  2: 'secp256k1',
 } as const
 
 ////////////////////////////////////////////////////////////
@@ -241,6 +245,28 @@ export declare namespace createWebCryptoKey {
   type Parameters = {
     /** Expiry for the key. */
     expiry: bigint
+  }
+}
+
+/** Gets a Secp256k1Key in the required type **/
+export function getSecp256k1Key(
+  parameters: getSecp256k1Key.Parameters,
+): Secp256k1Key {
+  const { expiry, publicKey } = parameters
+  return {
+    expiry,
+    publicKey,
+    status: 'locked',
+    type: 'secp256k1',
+  }
+}
+
+export declare namespace getSecp256k1Key {
+  type Parameters = {
+    /** Expiry for the key. */
+    expiry: bigint
+    /** Public key for the key. */
+    publicKey: PublicKey.PublicKey
   }
 }
 

--- a/src/internal/accountDelegation.ts
+++ b/src/internal/accountDelegation.ts
@@ -248,6 +248,28 @@ export declare namespace createWebCryptoKey {
   }
 }
 
+/** Gets a WebCrypto-P256 key in the required type **/
+export function getWebCryptoKey(
+  parameters: getWebCryptoKey.Parameters,
+): WebCryptoKey {
+  const { expiry, publicKey } = parameters
+  return {
+    expiry,
+    publicKey,
+    status: 'locked',
+    type: 'p256',
+  }
+}
+
+export declare namespace getWebCryptoKey {
+  type Parameters = {
+    /** Expiry for the key. */
+    expiry: bigint
+    /** Public key for the key. */
+    publicKey: PublicKey.PublicKey
+  }
+}
+
 /** Gets a Secp256k1Key in the required type **/
 export function getSecp256k1Key(
   parameters: getSecp256k1Key.Parameters,

--- a/src/internal/accountDelegation.ts
+++ b/src/internal/accountDelegation.ts
@@ -49,7 +49,11 @@ export type Calls = readonly {
   data?: Hex.Hex | undefined
 }[]
 
-export type Key = WebAuthnKey | WebCryptoKey | Secp256k1Key
+export type Key =
+  | WebAuthnKey
+  | WebCryptoKey
+  | Secp256k1Key
+  | BaseKey<'unknown', unknown>
 
 export type SerializedKey = {
   expiry: bigint
@@ -73,10 +77,12 @@ export type Secp256k1Key = BaseKey<'secp256k1', {}>
 ////////////////////////////////////////////////////////////////
 
 const keyType = {
+  unknown: -1,
   p256: 0,
   webauthn: 1,
   secp256k1: 2,
 } as const
+export type KeyType = keyof typeof keyType
 
 const keyTypeSerialized = {
   0: 'p256',
@@ -245,50 +251,6 @@ export declare namespace createWebCryptoKey {
   type Parameters = {
     /** Expiry for the key. */
     expiry: bigint
-  }
-}
-
-/** Gets a WebCrypto-P256 key in the required type **/
-export function getWebCryptoKey(
-  parameters: getWebCryptoKey.Parameters,
-): WebCryptoKey {
-  const { expiry, publicKey } = parameters
-  return {
-    expiry,
-    publicKey,
-    status: 'locked',
-    type: 'p256',
-  }
-}
-
-export declare namespace getWebCryptoKey {
-  type Parameters = {
-    /** Expiry for the key. */
-    expiry: bigint
-    /** Public key for the key. */
-    publicKey: PublicKey.PublicKey
-  }
-}
-
-/** Gets a Secp256k1Key in the required type **/
-export function getSecp256k1Key(
-  parameters: getSecp256k1Key.Parameters,
-): Secp256k1Key {
-  const { expiry, publicKey } = parameters
-  return {
-    expiry,
-    publicKey,
-    status: 'locked',
-    type: 'secp256k1',
-  }
-}
-
-export declare namespace getSecp256k1Key {
-  type Parameters = {
-    /** Expiry for the key. */
-    expiry: bigint
-    /** Public key for the key. */
-    publicKey: PublicKey.PublicKey
   }
 }
 

--- a/src/internal/provider.ts
+++ b/src/internal/provider.ts
@@ -253,16 +253,14 @@ export function from<
 
           let keysToAuthorize: AccountDelegation.Key[] = []
           if (keys) {
-            keysToAuthorize = keys.map((key) =>
-              key.algorithm === 'secp256k1'
-                ? AccountDelegation.getSecp256k1Key({
-                    expiry: BigInt(expiry),
-                    publicKey: PublicKey.fromHex(key.publicKey),
-                  })
-                : AccountDelegation.getWebCryptoKey({
-                    expiry: BigInt(expiry),
-                    publicKey: PublicKey.fromHex(key.publicKey),
-                  }),
+            keysToAuthorize = keys.map(
+              (key) =>
+                ({
+                  expiry: BigInt(expiry),
+                  publicKey: PublicKey.fromHex(key.publicKey),
+                  status: 'unlocked',
+                  type: key.type as 'unknown',
+                }) as const,
             )
           } else {
             const key = await AccountDelegation.createWebCryptoKey({

--- a/src/internal/provider.ts
+++ b/src/internal/provider.ts
@@ -251,9 +251,9 @@ export function from<
             : state.accounts[0]
           if (!account) throw new ox_Provider.UnauthorizedError()
 
-          let keysToDelegate: AccountDelegation.Key[] = []
+          let keysToAuthorize: AccountDelegation.Key[] = []
           if (keys) {
-            keysToDelegate = keys.map((key) =>
+            keysToAuthorize = keys.map((key) =>
               key.algorithm === 'secp256k1'
                 ? AccountDelegation.getSecp256k1Key({
                     expiry: BigInt(expiry),
@@ -268,13 +268,13 @@ export function from<
             const key = await AccountDelegation.createWebCryptoKey({
               expiry: BigInt(expiry),
             })
-            keysToDelegate.push(key)
+            keysToAuthorize.push(key)
           }
 
           // TODO: wait for tx to be included?
           await AccountDelegation.authorize(state.client, {
             account,
-            keys: keysToDelegate,
+            keys: keysToAuthorize,
             rpId: keystoreHost,
           })
 

--- a/src/internal/provider.ts
+++ b/src/internal/provider.ts
@@ -287,19 +287,19 @@ export function from<
               ...x,
               accounts: x.accounts.map((account, i) =>
                 i === index
-                  ? { ...account, keys: [...account.keys, ...keysToDelegate] }
+                  ? { ...account, keys: [...account.keys, ...keysToAuthorize] }
                   : account,
               ),
             }
           })
 
           emitter.emit('message', {
-            data: getActiveSessionKeys([...account.keys, ...keysToDelegate]),
+            data: getActiveSessionKeys([...account.keys, ...keysToAuthorize]),
             type: 'sessionsChanged',
           })
 
           const id = Hex.concat(
-            ...keysToDelegate.map((key) => PublicKey.toHex(key.publicKey)),
+            ...keysToAuthorize.map((key) => PublicKey.toHex(key.publicKey)),
           )
 
           return {

--- a/src/internal/provider.ts
+++ b/src/internal/provider.ts
@@ -254,10 +254,15 @@ export function from<
           let keysToDelegate: AccountDelegation.Key[] = []
           if (keys) {
             keysToDelegate = keys.map((key) =>
-              AccountDelegation.getSecp256k1Key({
-                expiry: BigInt(expiry),
-                publicKey: PublicKey.fromHex(key.publicKey),
-              }),
+              key.algorithm === 'secp256k1'
+                ? AccountDelegation.getSecp256k1Key({
+                    expiry: BigInt(expiry),
+                    publicKey: PublicKey.fromHex(key.publicKey),
+                  })
+                : AccountDelegation.getWebCryptoKey({
+                    expiry: BigInt(expiry),
+                    publicKey: PublicKey.fromHex(key.publicKey),
+                  }),
             )
           } else {
             const key = await AccountDelegation.createWebCryptoKey({

--- a/src/internal/rpcSchema.ts
+++ b/src/internal/rpcSchema.ts
@@ -99,8 +99,8 @@ export type GrantSessionParameters = {
   expiry?: number | undefined
   keys?:
     | readonly {
-        algorithm: 'p256' | 'secp256k1'
         publicKey: Hex.Hex
+        type: AccountDelegation.KeyType
       }[]
     | undefined
 }

--- a/src/internal/wagmi/core.ts
+++ b/src/internal/wagmi/core.ts
@@ -277,10 +277,12 @@ export declare namespace grantSession {
     ConnectorParameter & {
       address?: Address | undefined
       expiry?: number | undefined
-      keys?: {
-        algorithm: 'p256' | 'secp256k1'
-        publicKey: Hex
-      }[] | undefined
+      keys?:
+        | {
+            algorithm: 'p256' | 'secp256k1'
+            publicKey: Hex
+          }[]
+        | undefined
     }
 
   type ReturnType = {

--- a/src/internal/wagmi/core.ts
+++ b/src/internal/wagmi/core.ts
@@ -252,7 +252,7 @@ export async function grantSession<config extends Config>(
   config: config,
   parameters: grantSession.Parameters<config>,
 ): Promise<grantSession.ReturnType> {
-  const { address, chainId, connector, expiry } = parameters
+  const { address, chainId, connector, expiry, keys } = parameters
 
   const client = await getConnectorClient(config, {
     account: address,
@@ -268,7 +268,7 @@ export async function grantSession<config extends Config>(
     ReturnType: RpcSchema.ExtractReturnType<Schema, method>
   }>({
     method,
-    params: [{ address, expiry }],
+    params: [{ address, expiry, keys }],
   })
 }
 
@@ -277,6 +277,10 @@ export declare namespace grantSession {
     ConnectorParameter & {
       address?: Address | undefined
       expiry?: number | undefined
+      keys?: {
+        algorithm: 'p256' | 'secp256k1'
+        publicKey: Hex
+      }[] | undefined
     }
 
   type ReturnType = {

--- a/src/internal/wagmi/core.ts
+++ b/src/internal/wagmi/core.ts
@@ -21,6 +21,7 @@ import {
   disconnect as wagmi_disconnect,
 } from 'wagmi/actions'
 
+import type * as AccountDelegation from '../accountDelegation.js'
 import type {
   CreateAccountParameters,
   GrantSessionParameters,
@@ -279,8 +280,8 @@ export declare namespace grantSession {
       expiry?: number | undefined
       keys?:
         | {
-            algorithm: 'p256' | 'secp256k1'
             publicKey: Hex
+            type: AccountDelegation.KeyType
           }[]
         | undefined
     }


### PR DESCRIPTION
Adds functionality to now handle provided keys to the `grantSession` action and adds them as available keys within Porto.

Alos updates the contracts to include ecdsa signature validation

