### PR TITLE
restore address/credentialId from storage

### DIFF
--- a/src/Porto.ts
+++ b/src/Porto.ts
@@ -64,6 +64,8 @@ export function create(config: Config | undefined = {}): Porto {
         (_, get) => ({
           accounts: [],
           chain: chains[0],
+          address: undefined,
+          credentialId: undefined,
 
           // computed
           get chainId() {
@@ -87,6 +89,8 @@ export function create(config: Config | undefined = {}): Porto {
           merge,
           partialize(state) {
             return {
+              address: state.address,
+              credentialId: state.credentialId,
               accounts: state.accounts.map((account) => ({
                 ...account,
                 keys: account.keys.map((key) => ({
@@ -182,6 +186,8 @@ export type State<
 > = {
   accounts: AccountDelegation.Account[]
   chain: chains[number]
+  address: Address.Address | undefined
+  credentialId: string | undefined
   readonly chainId: chains[number]['id']
   readonly client: Client<
     Transport,

--- a/src/internal/accountDelegation.ts
+++ b/src/internal/accountDelegation.ts
@@ -157,11 +157,21 @@ export async function create<chain extends Chain | undefined>(
     privateKey,
   })
 
-  return initialize(client, {
+  const { account } = await initialize(client, {
     ...result,
     authorization,
     signature,
   })
+
+  const credentialId = result.account.keys.find(
+    (key) => key.type === 'webauthn',
+  )?.id as string
+
+  return {
+    account,
+    address,
+    credentialId,
+  }
 }
 
 export declare namespace create {
@@ -397,7 +407,6 @@ export async function load<chain extends Chain | undefined>(
   parameters: load.Parameters = {},
 ) {
   const { authorizeKeys = [], rpId } = parameters
-
   let address: Address.Address
   let raw: PublicKeyCredential
   let credentialId: string
@@ -426,7 +435,6 @@ export async function load<chain extends Chain | undefined>(
       address,
       keys: authorizeKeys ?? [],
     })
-
     const { signature, metadata, ...rest } = await WebAuthnP256.sign({
       challenge: payload,
       credentialId,
@@ -511,6 +519,8 @@ export async function load<chain extends Chain | undefined>(
       label,
       keys,
     },
+    address,
+    credentialId,
   }
 }
 

--- a/src/internal/provider.ts
+++ b/src/internal/provider.ts
@@ -62,11 +62,19 @@ export function from<
         case 'eth_requestAccounts': {
           if (!headless) throw new ox_Provider.UnsupportedMethodError()
 
-          const { account } = await AccountDelegation.load(state.client, {
-            rpId: keystoreHost,
-          })
+          const { account, address, credentialId } =
+            await AccountDelegation.load(state.client, {
+              rpId: keystoreHost,
+              address: state.address,
+              credentialId: state.credentialId,
+            })
 
-          store.setState((x) => ({ ...x, accounts: [account] }))
+          store.setState((x) => ({
+            ...x,
+            address,
+            credentialId,
+            accounts: [account],
+          }))
 
           emitter.emit('connect', { chainId: Hex.fromNumber(state.chainId) })
           return [account.address] satisfies RpcSchema.ExtractReturnType<
@@ -163,7 +171,7 @@ export function from<
               })
             : undefined
 
-          const { account } = await (async () => {
+          const { account, address, credentialId } = await (async () => {
             if (createAccount) {
               const { label } =
                 typeof createAccount === 'object' ? createAccount : {}
@@ -177,12 +185,19 @@ export function from<
             return await AccountDelegation.load(state.client, {
               authorizeKeys: key ? [key] : undefined,
               rpId: keystoreHost,
+              address: state.address,
+              credentialId: state.credentialId,
             })
           })()
 
           const sessions = getActiveSessionKeys(account.keys)
 
-          store.setState((x) => ({ ...x, accounts: [account] }))
+          store.setState((x) => ({
+            ...x,
+            address,
+            credentialId,
+            accounts: [account],
+          }))
 
           emitter.emit('connect', { chainId: Hex.fromNumber(state.chainId) })
 
@@ -208,13 +223,19 @@ export function from<
           >) ?? [{}]
 
           // TODO: wait for tx to be included/make counterfactual?
-          const { account } = await AccountDelegation.create(state.client, {
-            delegation: state.delegation,
-            label,
-            rpId: keystoreHost,
-          })
+          const { account, address, credentialId } =
+            await AccountDelegation.create(state.client, {
+              delegation: state.delegation,
+              label,
+              rpId: keystoreHost,
+            })
 
-          store.setState((x) => ({ ...x, accounts: [account] }))
+          store.setState((x) => ({
+            ...x,
+            address,
+            credentialId,
+            accounts: [account],
+          }))
 
           emitter.emit('connect', { chainId: Hex.fromNumber(state.chainId) })
           return account.address satisfies RpcSchema.ExtractReturnType<


### PR DESCRIPTION
This pull request adds address and credentialId to the state, and modifies the `create` and `load` provider functions to return the address and credentialId for caching, and ensures that the new properties are correctly propagated through the provider. 

So that on subsequent calls of 'experimental_connect', we pass in persisted address and credentialId to optimistically connect in a single prompt removing the need for the [extra WebAuthn prompt](https://github.com/ithacaxyz/porto/blob/main/src/internal/accountDelegation.ts#L408-L418).


This pull request includes several changes to the `Porto` and `accountDelegation` modules to add support for handling `address` and `credentialId` in the state. The most important changes include updating the state structure, modifying the `create` and `load` functions, and ensuring the new properties are correctly propagated through the provider.


Closes (https://github.com/ithacaxyz/porto/issues/14)

