### PR TITLE
fix typo CHANGELOG.md

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -66,7 +66,7 @@
   - This feature is work-in-progress and currently has no UI.
   - In the future, `Implementation.dialog()` will be the default behavior in Porto to communicate with a Wallet.
   - Currently, the default implementation is `Implementation.local()` – where its behavior is to perform actions locally (ie. "blind sign").
-  - In the future, it will be anticipated for App builders to use `Implementation.dialog()` (the default), and for Dialog Wallet builders to use `Implemetation.local()`.
+  - In the future, it will be anticipated for App builders to use `Implementation.dialog()` (the default), and for Dialog Wallet builders to use `Implementation.local()`.
   - Documentation for these patterns will emerge as this feature matures.
 
   If you would like to check out what the experience looks like currently with no UI:


### PR DESCRIPTION
- Corrected the typo "Implemetation" to "Implementation" in the `CHANGELOG.md` file.
