### PR TITLE
fix: Fix incorrect usage of import.meta.dirname Update preconstruct.ts

### DIFF
--- a/scripts/preconstruct.ts
+++ b/scripts/preconstruct.ts
@@ -5,7 +5,9 @@ import { getExports } from './utils/exports.js'
 // biome-ignore lint/suspicious/noConsoleLog:
 console.log('Setting up packages for development.')
 
-const packagePath = resolve(import.meta.dirname, '../src/package.json')
+import { fileURLToPath } from 'node:url';
+
+const packagePath = resolve(fileURLToPath(import.meta.url), '../src/package.json');
 const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'))
 
 // biome-ignore lint/suspicious/noConsoleLog:


### PR DESCRIPTION
I noticed that `import.meta.dirname` was being used to get the directory path of the current module. However, `import.meta` does not have a `dirname` property according to the ECMAScript standard and Node.js. This was likely a typo or misunderstanding.  

To correctly resolve the file path in a Node.js environment when using `import.meta`, we should use `import.meta.url` and convert it to a filesystem path using `fileURLToPath` from the `node:url` module.

I've updated the code to reflect this fix.