### PR TITLE
fix: fix incorrect typeof usage for className in Button.tsx

### DIFF
--- a/app/src/components/Button.tsx
+++ b/app/src/components/Button.tsx
@@ -16,7 +16,7 @@ export namespace Button {
 
   export interface Props
     extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-      VariantProps<typeof className> {
+      VariantProps<typeof Button.className>
     asChild?: boolean
   }
 


### PR DESCRIPTION
I noticed that in the Props interface, `typeof className` is being used incorrectly. Since `className` is not a type but a value (a function returned by `cva`), this approach doesn't work as intended.

Instead, we should use `typeof Button.className`, as `Button.className` holds the actual value returned by `cva`, including the variants information required for `VariantProps`. 