### PR TITLE
docs: update error link in `sdk/rpc`

### DIFF
--- a/docs/pages/sdk/rpc/index.md
+++ b/docs/pages/sdk/rpc/index.md
@@ -94,7 +94,7 @@ Example:
 
 #### Granting permissions via `wallet_connect`
 
-Permissions may be granted upon connection with the `grantPermissions` capability on the [`wallet_connect`]([#wallet_connect](https://github.com/ethereum/ERCs/blob/abd1c9f4eda2d6ad06ade0e3af314637a27d1ee7/ERCS/erc-7846.md)) JSON-RPC method.
+Permissions may be granted upon connection with the `grantPermissions` capability on the [`wallet_connect`](https://github.com/ethereum/ERCs/blob/abd1c9f4eda2d6ad06ade0e3af314637a27d1ee7/ERCS/erc-7846.md#wallet_connect) JSON-RPC method.
 
 Example:
 


### PR DESCRIPTION
Hi! I fixed a broken link in the docs/pages/sdk/rpc/index.md file.

[![image](https://github.com/user-attachments/assets/9303b8b1-2b0b-4eb3-81ae-67b99678ba61)](https://porto.sh/sdk/rpc#granting-permissions-via-wallet_connect)