### PR TITLE
feat: safari dialog fallback

### DIFF
--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -8,8 +8,6 @@ import type { Internal } from './internal/porto.js'
 /** Dialog interface. */
 export type Dialog = {
   setup: (parameters: { host: string; internal: Internal }) => {
-    messenger: Messenger.Messenger
-
     close: () => void
     destroy: () => void
     open: () => void
@@ -160,8 +158,6 @@ export function iframe() {
       const bodyStyle = Object.assign({}, document.body.style)
 
       return {
-        messenger,
-
         open() {
           if (open) return
           open = true
@@ -238,11 +234,6 @@ export function popup() {
       let messenger: Messenger.Messenger | undefined
 
       return {
-        get messenger() {
-          if (!messenger) throw new Error('messenger not initialized')
-          return messenger
-        },
-
         open() {
           const left = (window.innerWidth - width) / 2 + window.screenX
           const top = window.screenY + 100
@@ -362,8 +353,6 @@ export function experimental_inline(options: inline.Options) {
       })
 
       return {
-        messenger,
-
         open() {
           if (open) return
           open = true

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -45,7 +45,9 @@ export type Schema = [
   },
   {
     topic: 'rpc-response'
-    payload: RpcResponse.RpcResponse
+    payload: RpcResponse.RpcResponse & {
+      _request: Porto.QueuedRequest
+    }
     response: undefined
   },
   {

--- a/src/remote/Actions.ts
+++ b/src/remote/Actions.ts
@@ -17,14 +17,19 @@ export async function reject(
   const { messenger } = porto
   messenger.send(
     'rpc-response',
-    RpcResponse.from({
-      id: request.request.id,
-      jsonrpc: '2.0',
-      error: {
-        code: Provider.UserRejectedRequestError.code,
-        message: 'User rejected the request.',
+    Object.assign(
+      RpcResponse.from({
+        id: request.request.id,
+        jsonrpc: '2.0',
+        error: {
+          code: Provider.UserRejectedRequestError.code,
+          message: 'User rejected the request.',
+        },
+      }),
+      {
+        _request: request,
       },
-    }),
+    ),
   )
 }
 
@@ -60,10 +65,20 @@ export async function respond<result>(
   try {
     let result = await provider.request(request.request)
     if (selector) result = selector(result as never)
-    messenger.send('rpc-response', RpcResponse.from({ ...shared, result }))
+    messenger.send(
+      'rpc-response',
+      Object.assign(RpcResponse.from({ ...shared, result }), {
+        _request: request,
+      }),
+    )
   } catch (e) {
     const error = e as RpcResponse.BaseError
-    messenger.send('rpc-response', RpcResponse.from({ ...shared, error }))
+    messenger.send(
+      'rpc-response',
+      Object.assign(RpcResponse.from({ ...shared, error }), {
+        _request: request,
+      }),
+    )
     throw error
   }
 }


### PR DESCRIPTION
Currently, we _always_ use a popup on Safari as WebKit does [not support WebAuthn credential creation in iframes](https://github.com/WebKit/standards-positions/issues/304).

This PR adds the ability to prefer iframes for RPC methods that do not handle credential creation (e.g. `wallet_sendCalls`), and falls back to a popup if it detects an RPC method that may need credential creation (e.g. `wallet_connect`, `eth_requestAccounts`).