### PR TITLE
fix: 1password inert attribute

### DIFF
--- a/.changeset/tasty-cups-speak.md
+++ b/.changeset/tasty-cups-speak.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Fixed 1Password adding `inert` attribute to `<dialog/>`.

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -167,6 +167,19 @@ export function iframe() {
 
       const bodyStyle = Object.assign({}, document.body.style)
 
+      // 1password extension adds `inert` attribute to `dialog` and inserts itself there rendering itself unusable
+      // watch from `inert` and remove it
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.type !== 'attributes') continue
+          const name = mutation.attributeName
+          if (!name) continue
+          if (name !== 'inert') continue
+          root.removeAttribute(name)
+        }
+      })
+      observer.observe(root, { attributes: true, attributeOldValue: true })
+
       return {
         close() {
           fallback?.close()


### PR DESCRIPTION
1Password inserts itself into `<dialog />`, but also marks it `inert`

![image](https://github.com/user-attachments/assets/04ee8ada-cd20-4bfc-beff-ff0f9b16f370)