### PR TITLE
feat: method policies

### DIFF
--- a/apps/dialog/src/lib/Porto.ts
+++ b/apps/dialog/src/lib/Porto.ts
@@ -1,0 +1,8 @@
+import { Env, Porto as PortoConfig } from '@porto/apps'
+import { Storage } from 'porto'
+import { Porto } from 'porto/remote'
+
+export const porto = Porto.create({
+  ...PortoConfig.config[Env.get()],
+  storage: Storage.combine(Storage.cookie(), Storage.localStorage()),
+})

--- a/apps/dialog/src/lib/Router.ts
+++ b/apps/dialog/src/lib/Router.ts
@@ -1,4 +1,3 @@
-import { Porto } from '@porto/apps'
 import { createRouter } from '@tanstack/react-router'
 import { Provider, type RpcSchema } from 'ox'
 import type { RpcSchema as porto_RpcSchema } from 'porto'
@@ -6,8 +5,7 @@ import * as Rpc from 'porto/core/internal/typebox/rpc'
 import { Actions } from 'porto/remote'
 
 import { routeTree } from '~/routeTree.gen.ts'
-
-const porto = Porto.porto
+import { porto } from './Porto'
 
 export function parseSearchRequest<
   method extends RpcSchema.ExtractMethodName<porto_RpcSchema.Schema>,

--- a/apps/dialog/src/lib/Wagmi.ts
+++ b/apps/dialog/src/lib/Wagmi.ts
@@ -1,7 +1,5 @@
-import { Porto } from '@porto/apps'
 import { createConfig, createStorage, type Transport } from 'wagmi'
-
-const porto = Porto.porto
+import { porto } from './Porto'
 
 export const config = createConfig({
   chains: porto._internal.config.chains,

--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -1,4 +1,4 @@
-import { Porto, Token } from '@porto/apps'
+import { Token } from '@porto/apps'
 import { Button, Spinner } from '@porto/apps/components'
 import { useQuery } from '@tanstack/react-query'
 import { cx } from 'cva'
@@ -14,6 +14,7 @@ import { Call, erc20Abi, zeroAddress } from 'viem'
 import { getBalance, readContract } from 'wagmi/actions'
 
 import * as Dialog from '~/lib/Dialog'
+import { porto } from '~/lib/Porto'
 import * as Price from '~/lib/Price'
 import * as Wagmi from '~/lib/Wagmi'
 import { Layout } from '~/routes/-components/Layout'
@@ -22,8 +23,6 @@ import ArrowDownLeft from '~icons/lucide/arrow-down-left'
 import ArrowUpRight from '~icons/lucide/arrow-up-right'
 import TriangleAlert from '~icons/lucide/triangle-alert'
 import Star from '~icons/ph/star-four-bold'
-
-const porto = Porto.porto
 
 export function ActionRequest(props: ActionRequest.Props) {
   const {

--- a/apps/dialog/src/routes/-components/AddFunds.tsx
+++ b/apps/dialog/src/routes/-components/AddFunds.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from '@ariakit/react'
-import { Porto, Token } from '@porto/apps'
+import { Token } from '@porto/apps'
 import { Button } from '@porto/apps/components'
 import { useMutation } from '@tanstack/react-query'
 import { Address } from 'ox'
@@ -8,11 +8,10 @@ import { Hooks } from 'porto/remote'
 import * as React from 'react'
 import { useWaitForTransactionReceipt } from 'wagmi'
 
+import { porto } from '~/lib/Porto'
 import { Layout } from '~/routes/-components/Layout'
 import ArrowRightIcon from '~icons/lucide/arrow-right'
 import QrCodeIcon from '~icons/lucide/qr-code'
-
-const porto = Porto.porto
 
 const presetAmounts = ['25', '50', '100', '250']
 

--- a/apps/dialog/src/routes/-components/GrantPermissions.tsx
+++ b/apps/dialog/src/routes/-components/GrantPermissions.tsx
@@ -1,4 +1,3 @@
-import { Porto } from '@porto/apps'
 import { Button, Spinner } from '@porto/apps/components'
 import { Hex, type RpcSchema } from 'ox'
 import type { RpcSchema as porto_RpcSchema } from 'porto'
@@ -8,12 +7,11 @@ import { erc20Abi } from 'viem'
 import { useReadContract } from 'wagmi'
 
 import * as Dialog from '~/lib/Dialog'
+import { porto } from '~/lib/Porto'
 import { Layout } from '~/routes/-components/Layout'
 import { ValueFormatter } from '~/utils'
 import LucideKey from '~icons/lucide/key-round'
 import { NotFound } from './NotFound'
-
-const porto = Porto.porto
 
 export function GrantPermissions(props: GrantPermissions.Props) {
   const { address, permissions, loading, onApprove, onReject } = props

--- a/apps/dialog/src/routes/-components/NotFound.tsx
+++ b/apps/dialog/src/routes/-components/NotFound.tsx
@@ -1,13 +1,10 @@
-import { Porto } from '@porto/apps'
 import { Button } from '@porto/apps/components'
 import { useMutation } from '@tanstack/react-query'
 import { Json } from 'ox'
 import { Actions, Hooks } from 'porto/remote'
-
+import { porto } from '~/lib/Porto'
 import { Layout } from '~/routes/-components/Layout'
 import LucideTriangleAlert from '~icons/lucide/triangle-alert'
-
-const porto = Porto.porto
 
 export function NotFound() {
   const request = Hooks.useRequest(porto)

--- a/apps/dialog/src/routes/-components/SignIn.tsx
+++ b/apps/dialog/src/routes/-components/SignIn.tsx
@@ -1,12 +1,10 @@
-import { Porto } from '@porto/apps'
 import { Button } from '@porto/apps/components'
 import { Hooks } from 'porto/remote'
 
 import * as Dialog from '~/lib/Dialog'
+import { porto } from '~/lib/Porto'
 import { Layout } from '~/routes/-components/Layout'
 import LucideLogIn from '~icons/lucide/log-in'
-
-const porto = Porto.porto
 
 export function SignIn(props: SignIn.Props) {
   const { loading, onApprove } = props

--- a/apps/dialog/src/routes/-components/SignMessage.tsx
+++ b/apps/dialog/src/routes/-components/SignMessage.tsx
@@ -1,13 +1,11 @@
-import { Porto } from '@porto/apps'
 import { Button } from '@porto/apps/components'
 import { Address } from 'ox'
 import { Hooks } from 'porto/remote'
 
 import * as Dialog from '~/lib/Dialog'
+import { porto } from '~/lib/Porto'
 import { Layout } from '~/routes/-components/Layout'
 import LucideLogIn from '~icons/lucide/log-in'
-
-const porto = Porto.porto
 
 export function SignMessage(props: SignMessage.Props) {
   const { address, message, loading, onApprove, onReject } = props

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -1,9 +1,9 @@
-import { Porto } from '@porto/apps'
 import { createRootRoute, HeadContent, Outlet } from '@tanstack/react-router'
 import { Actions, Hooks } from 'porto/remote'
 import * as React from 'react'
 
 import * as Dialog from '~/lib/Dialog'
+import { porto } from '~/lib/Porto'
 import LucideGlobe from '~icons/lucide/globe'
 import LucideX from '~icons/lucide/x'
 
@@ -15,13 +15,13 @@ function RouteComponent() {
   React.useEffect(() => {
     // Note: we already call `porto.ready()` optimistically in `main.tsx`, but
     // we should call it here incase it didn't resolve due to a race condition.
-    Porto.porto.ready()
+    porto.ready()
   }, [])
 
   const mode = Dialog.useStore((state) => state.mode)
   const hostname = Dialog.useStore((state) => state.referrer?.origin.hostname)
   const icon = Dialog.useStore((state) => state.referrer?.icon)
-  const request = Hooks.useRequest(Porto.porto)
+  const request = Hooks.useRequest(porto)
 
   const contentRef = React.useRef<HTMLDivElement | null>(null)
   const titlebarRef = React.useRef<HTMLDivElement | null>(null)
@@ -54,7 +54,7 @@ function RouteComponent() {
           if (mode === 'popup') {
             window.resizeTo(width, totalHeight)
           } else if (mode === 'iframe' || mode === 'inline-iframe') {
-            Porto.porto.messenger.send('__internal', {
+            porto.messenger.send('__internal', {
               height: totalHeight,
               type: 'resize',
             })
@@ -109,7 +109,7 @@ function RouteComponent() {
 
           {mode !== 'inline-iframe' && (
             <button
-              onClick={() => Actions.rejectAll(Porto.porto)}
+              onClick={() => Actions.rejectAll(porto)}
               title="Close Dialog"
               type="button"
             >

--- a/apps/dialog/src/routes/dialog/eth_requestAccounts.tsx
+++ b/apps/dialog/src/routes/dialog/eth_requestAccounts.tsx
@@ -1,15 +1,12 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import type { RpcSchema } from 'ox'
 import type { RpcSchema as porto_RpcSchema } from 'porto'
 import { Actions, Hooks } from 'porto/remote'
-
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { SignIn } from '../-components/SignIn'
 import { SignUp } from '../-components/SignUp'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/eth_requestAccounts')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/eth_sendTransaction.tsx
+++ b/apps/dialog/src/routes/dialog/eth_sendTransaction.tsx
@@ -1,12 +1,9 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Actions } from 'porto/remote'
-
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { ActionRequest } from '../-components/ActionRequest'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/eth_sendTransaction')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/experimental_addFunds.tsx
+++ b/apps/dialog/src/routes/dialog/experimental_addFunds.tsx
@@ -1,11 +1,8 @@
-import { Porto } from '@porto/apps'
 import { createFileRoute } from '@tanstack/react-router'
 import { Actions } from 'porto/remote'
-
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { AddFunds } from '../-components/AddFunds'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/experimental_addFunds')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/experimental_createAccount.tsx
+++ b/apps/dialog/src/routes/dialog/experimental_createAccount.tsx
@@ -1,12 +1,9 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Actions, Hooks } from 'porto/remote'
-
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { SignUp } from '../-components/SignUp'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/experimental_createAccount')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/experimental_grantPermissions.tsx
+++ b/apps/dialog/src/routes/dialog/experimental_grantPermissions.tsx
@@ -1,12 +1,10 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Actions } from 'porto/remote'
 
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { GrantPermissions } from '../-components/GrantPermissions'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/experimental_grantPermissions')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/personal_sign.tsx
+++ b/apps/dialog/src/routes/dialog/personal_sign.tsx
@@ -1,14 +1,12 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Hex, Siwe } from 'ox'
 import { Actions } from 'porto/remote'
 import { useMemo } from 'react'
 
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { SignMessage } from '../-components/SignMessage'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/personal_sign')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/wallet_connect.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_connect.tsx
@@ -1,15 +1,13 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Actions, Hooks } from 'porto/remote'
 import { useEffect } from 'react'
 
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { GrantPermissions } from '../-components/GrantPermissions'
 import { SignIn } from '../-components/SignIn'
 import { SignUp } from '../-components/SignUp'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/wallet_connect')({
   component: RouteComponent,

--- a/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
@@ -1,15 +1,13 @@
-import { Porto } from '@porto/apps'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Address } from 'ox'
 import { Actions } from 'porto/remote'
 import * as React from 'react'
 
+import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { ActionRequest } from '../-components/ActionRequest'
 import { AddFunds } from '../-components/AddFunds'
-
-const porto = Porto.porto
 
 export const Route = createFileRoute('/dialog/wallet_sendCalls')({
   component: RouteComponent,

--- a/apps/~internal/lib/Porto.ts
+++ b/apps/~internal/lib/Porto.ts
@@ -1,5 +1,5 @@
 import { Address } from 'ox'
-import { Chains, Mode, Storage } from 'porto'
+import { Chains, Mode } from 'porto'
 import { Porto } from 'porto/remote'
 import { http } from 'viem'
 
@@ -64,8 +64,3 @@ export const dialogHosts = {
     ? 'https://stg.id.porto.sh/dialog/'
     : 'https://stg.localhost:5174/dialog/',
 } as const satisfies Record<Env.Env, string | undefined>
-
-export const porto = Porto.create({
-  ...config[Env.get()],
-  storage: Storage.combine(Storage.cookie(), Storage.localStorage()),
-})

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -1,5 +1,6 @@
 import type * as RpcRequest from 'ox/RpcRequest'
 import type * as RpcResponse from 'ox/RpcResponse'
+import type * as Porto_remote from '../remote/Porto.js'
 import * as promise from './internal/promise.js'
 import type * as Porto from './Porto.js'
 
@@ -23,12 +24,7 @@ export type Messenger = {
 }
 
 export type ReadyOptions = {
-  bypassMethods?:
-    | {
-        anyOrigin?: string[] | undefined
-        sameOrigin?: string[] | undefined
-      }
-    | undefined
+  methodPolicies?: Porto_remote.MethodPolicies | undefined
 }
 
 /** Bridge messenger. */

--- a/src/remote/Events.ts
+++ b/src/remote/Events.ts
@@ -1,5 +1,73 @@
+import * as Provider from 'ox/Provider'
 import type { Payload } from '../core/Messenger.js'
+import * as Actions from './Actions.js'
 import type * as Remote from './Porto.js'
+
+/**
+ * Event listener which is triggered when a request is ready
+ * to be handled by the dialog.
+ *
+ * @param porto - Porto instance.
+ * @param cb - Callback function.
+ * @returns Unsubscribe function.
+ */
+export function onDialogRequest(
+  porto: Pick<
+    Remote.Porto<any>,
+    '_internal' | 'methodPolicies' | 'messenger' | 'provider'
+  >,
+  cb: (payload: Remote.RemoteState['requests'][number]['request']) => void,
+) {
+  return onRequests(porto, (requests, event) => {
+    const request = requests[0]?.request
+    if (!request) return
+
+    const policy = porto.methodPolicies?.find(
+      (policy) => policy.method === request.method,
+    )
+
+    const shouldBypass = (() => {
+      if (!request) return false
+
+      const rule = policy?.modes.headless
+      if (rule) {
+        if (
+          typeof rule === 'object' &&
+          rule.sameOrigin &&
+          event.origin !== window.location.origin
+        )
+          return false
+        return true
+      }
+
+      return false
+    })()
+    if (shouldBypass) {
+      Actions.respond(porto, request).catch(() => {})
+      return
+    }
+
+    const rule = policy?.modes.dialog
+    const shouldDialog = (() => {
+      if (!policy) return true
+      if (
+        typeof rule === 'object' &&
+        rule.sameOrigin &&
+        event.origin !== window.location.origin
+      )
+        return false
+      return rule
+    })()
+    if (!shouldDialog) {
+      Actions.respond(porto, request, {
+        error: new Provider.UnsupportedMethodError(),
+      }).catch(() => {})
+      return
+    }
+
+    cb(request)
+  })
+}
 
 /**
  * Event listener which is triggered when the remote context receives


### PR DESCRIPTION
Rationale: Some requests we only want to permit on the same origin, or bypass the dialog on the same origin (ie. on `*.porto.sh`). 

Examples: 
- We only want to permit the "Grant Admin" dialog on the same origin, but disallow it on external origins.
- We want to bypass the dialog for connection methods (ie. `wallet_connect`) on the same origin, but show the dialog on external origins.