### PR TITLE
fix: sync accounts

### DIFF
--- a/apps/dialog/src/lib/Wagmi.ts
+++ b/apps/dialog/src/lib/Wagmi.ts
@@ -1,11 +1,5 @@
 import { PortoConfig } from '@porto/apps'
-import {
-  createConfig,
-  createStorage,
-  injected,
-  type Transport,
-  useConnectors,
-} from 'wagmi'
+import { createConfig, createStorage, injected, type Transport } from 'wagmi'
 import { porto } from './Porto'
 
 export const config = createConfig({
@@ -29,11 +23,6 @@ export const config = createConfig({
     {} as Record<PortoConfig.ChainId, Transport>,
   ),
 })
-
-export function useConnector() {
-  const connectors = useConnectors()
-  return connectors.find((x) => x.id === 'porto')!
-}
 
 declare module 'wagmi' {
   interface Register {

--- a/apps/dialog/src/lib/Wagmi.ts
+++ b/apps/dialog/src/lib/Wagmi.ts
@@ -1,9 +1,24 @@
 import { PortoConfig } from '@porto/apps'
-import { createConfig, createStorage, type Transport } from 'wagmi'
+import {
+  createConfig,
+  createStorage,
+  injected,
+  type Transport,
+  useConnectors,
+} from 'wagmi'
 import { porto } from './Porto'
 
 export const config = createConfig({
   chains: porto._internal.config.chains,
+  connectors: [
+    injected({
+      target: () => ({
+        id: 'porto',
+        name: 'Porto',
+        provider: porto.provider as never,
+      }),
+    }),
+  ],
   multiInjectedProviderDiscovery: false,
   storage: createStorage({ storage: localStorage }),
   transports: Object.entries(porto._internal.config.transports).reduce(
@@ -14,6 +29,11 @@ export const config = createConfig({
     {} as Record<PortoConfig.ChainId, Transport>,
   ),
 })
+
+export function useConnector() {
+  const connectors = useConnectors()
+  return connectors.find((x) => x.id === 'porto')!
+}
 
 declare module 'wagmi' {
   interface Register {

--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -41,10 +41,7 @@ const offDialogRequest = Events.onDialogRequest(
   porto,
   ({ account, request }) => {
     const connectedAccount = porto._internal.store.getState().accounts[0]
-    const needsSync =
-      account &&
-      connectedAccount &&
-      account.address !== connectedAccount.address
+    const needsSync = account && account.address !== connectedAccount?.address
 
     if (needsSync)
       Actions.connect(Wagmi.config, {

--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -34,12 +34,15 @@ const offInitialized = Events.onInitialized(porto, (payload) => {
   })
 })
 
-const offDialogRequest = Events.onDialogRequest(porto, (request) => {
-  Router.router.navigate({
-    search: (search) => ({ ...search, ...request }) as never,
-    to: '/dialog/' + (request?.method ?? ''),
-  })
-})
+const offDialogRequest = Events.onDialogRequest(
+  porto,
+  ({ account, request }) => {
+    Router.router.navigate({
+      search: (search) => ({ ...search, ...request, account }) as never,
+      to: '/dialog/' + (request?.method ?? ''),
+    })
+  },
+)
 
 porto.ready()
 

--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -1,12 +1,15 @@
 import { Env } from '@porto/apps'
 import * as Sentry from '@sentry/react'
 import { Events } from 'porto/remote'
+import { Actions } from 'porto/wagmi'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { getConnectors } from 'wagmi/actions'
 
 import * as Dialog from '~/lib/Dialog.ts'
 import { porto } from '~/lib/Porto.js'
 import * as Router from '~/lib/Router.ts'
+import * as Wagmi from '~/lib/Wagmi.ts'
 import { App } from './App.js'
 import './styles.css'
 
@@ -37,6 +40,20 @@ const offInitialized = Events.onInitialized(porto, (payload) => {
 const offDialogRequest = Events.onDialogRequest(
   porto,
   ({ account, request }) => {
+    const connectedAccount = porto._internal.store.getState().accounts[0]
+    const needsSync =
+      account &&
+      connectedAccount &&
+      account.address !== connectedAccount.address
+
+    if (needsSync)
+      Actions.connect(Wagmi.config, {
+        connector: getConnectors(Wagmi.config)[0]!,
+        credentialId: account.credentialId,
+        force: true,
+        keyId: account.keyId,
+      })
+
     Router.router.navigate({
       search: (search) => ({ ...search, ...request, account }) as never,
       to: '/dialog/' + (request?.method ?? ''),

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -129,7 +129,7 @@ function RouteComponent() {
             className="flex flex-grow *:w-full"
             key={id} // rehydrate on id changes
           >
-            {account.isReconnecting || account.isConnecting ? (
+            {account.isConnecting ? (
               <Layout loading loadingTitle="Loading...">
                 <div />
               </Layout>

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -129,12 +129,12 @@ function RouteComponent() {
             className="flex flex-grow *:w-full"
             key={id} // rehydrate on id changes
           >
-            {account.isConnected ? (
-              <Outlet />
-            ) : (
+            {account.isReconnecting || account.isConnecting ? (
               <Layout loading loadingTitle="Loading...">
                 <div />
               </Layout>
+            ) : (
+              <Outlet />
             )}
           </div>
         </div>

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -173,6 +173,9 @@ function CheckAccount({ children }: { children: React.ReactNode }) {
   React.useEffect(() => {
     if (!search.account) return
     if (isSynced) return
+
+    // If the App account is out of sync with the Dialog account,
+    // rehydrate with the Dialog account.
     connect.mutate({
       connector,
       credentialId: search.account.credentialId,

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -129,7 +129,7 @@ function RouteComponent() {
             className="flex flex-grow *:w-full"
             key={id} // rehydrate on id changes
           >
-            {account.isConnecting ? (
+            {account.isConnecting || account.isReconnecting ? (
               <Layout loading loadingTitle="Loading...">
                 <div />
               </Layout>

--- a/apps/~internal/lib/PortoConfig.ts
+++ b/apps/~internal/lib/PortoConfig.ts
@@ -79,7 +79,7 @@ export function getDialogHost(env = Env.get()): string {
       'https://' +
       import.meta.env.VITE_VERCEL_BRANCH_URL.replace(
         /(.*)(-git.*)/,
-        'idporto$2',
+        'dialogporto$2',
       ) +
       '/dialog/?env=' +
       env

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -479,6 +479,7 @@ export function handleBlur(store: Store) {
   store.setState((x) => ({
     ...x,
     requestQueue: x.requestQueue.map((x) => ({
+      account: x.account,
       error: new Provider.UserRejectedRequestError(),
       request: x.request,
       status: 'error',
@@ -496,11 +497,13 @@ export function handleResponse(
       if (queued.request.id !== response.id) return queued
       if (response.error)
         return {
+          account: queued.account,
           error: response.error,
           request: queued.request,
           status: 'error',
         } satisfies QueuedRequest
       return {
+        account: queued.account,
         request: queued.request,
         result: response.result,
         status: 'success',

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -1,3 +1,5 @@
+import type * as Address from 'ox/Address'
+import type * as Hex from 'ox/Hex'
 import type * as RpcRequest from 'ox/RpcRequest'
 import type * as RpcResponse from 'ox/RpcResponse'
 import { http } from 'viem'
@@ -196,6 +198,13 @@ export type Store<
 export type Transport = internal.Transport
 
 export type QueuedRequest<result = unknown> = {
+  account:
+    | {
+        address: Address.Address
+        credentialId?: string | undefined
+        keyId?: Hex.Hex | undefined
+      }
+    | undefined
   request: RpcRequest.RpcRequest
 } & OneOf<
   | {

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -30,16 +30,29 @@ export function dialog(parameters: dialog.Parameters = {}) {
           const request = requestStore.prepare(r as any)
 
           // When we receive a request, we need to add it to the queue.
-          store.setState((x) => ({
-            ...x,
-            requestQueue: [
-              ...x.requestQueue,
-              {
-                request,
-                status: 'pending',
-              },
-            ],
-          }))
+          store.setState((x) => {
+            const account = x.accounts[0]
+            const adminKey = account?.keys?.find(
+              (key) => key.role === 'admin' && key.type === 'webauthn-p256',
+            )
+            return {
+              ...x,
+              requestQueue: [
+                ...x.requestQueue,
+                {
+                  account: account
+                    ? {
+                        address: account.address,
+                        credentialId: (adminKey as any)?.credentialId,
+                        keyId: adminKey?.id,
+                      }
+                    : undefined,
+                  request,
+                  status: 'pending',
+                },
+              ],
+            }
+          })
 
           // We need to wait for the request to be resolved.
           return new Promise((resolve, reject) => {

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -660,10 +660,11 @@ export function from<
               return undefined
             })()
             const credentialId =
-              key?.type === 'webauthn-p256'
+              capabilities?.credentialId ??
+              (key?.type === 'webauthn-p256'
                 ? key?.privateKey?.credential?.id
-                : undefined
-            const keyId = key?.id
+                : undefined)
+            const keyId = capabilities?.keyId ?? key?.id
             const loadAccountsParams = {
               internal,
               permissions,
@@ -942,6 +943,10 @@ function getAdmins(
         return Schema.Encode(
           Rpc.experimental_getAdmins.Response.properties.keys.items,
           {
+            credentialId:
+              key.type === 'webauthn-p256'
+                ? key.privateKey?.credential?.id
+                : undefined,
             id: key.id ?? key.publicKey,
             publicKey: key.publicKey,
             type: key.type,

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -943,13 +943,14 @@ function getAdmins(
         return Schema.Encode(
           Rpc.experimental_getAdmins.Response.properties.keys.items,
           {
-            credentialId:
-              key.type === 'webauthn-p256'
-                ? key.privateKey?.credential?.id
-                : undefined,
             id: key.id ?? key.publicKey,
             publicKey: key.publicKey,
             type: key.type,
+            ...(key.type === 'webauthn-p256'
+              ? {
+                  credentialId: key.privateKey?.credential?.id,
+                }
+              : {}),
           } satisfies Rpc.experimental_getAdmins.Response['keys'][number],
         )
       } catch {

--- a/src/core/internal/typebox/request.ts
+++ b/src/core/internal/typebox/request.ts
@@ -102,7 +102,14 @@ export namespace experimental_getAdmins {
 
   export const Response = Type.Object({
     address: Primitive.Address,
-    keys: Type.Array(Type.Pick(Key.Base, ['id', 'publicKey', 'type'])),
+    keys: Type.Array(
+      Type.Intersect([
+        Type.Pick(Key.Base, ['id', 'publicKey', 'type']),
+        Type.Object({
+          credentialId: Schema.Optional(Type.String()),
+        }),
+      ]),
+    ),
   })
   export type Response = Schema.StaticDecode<typeof Response>
 }
@@ -327,7 +334,9 @@ export namespace porto_ping {
 export namespace wallet_connect {
   export const Capabilities = Type.Object({
     createAccount: Schema.Optional(C.createAccount.Request),
+    credentialId: Schema.Optional(Type.String()),
     grantPermissions: Schema.Optional(C.grantPermissions.Request),
+    keyId: Schema.Optional(Primitive.Hex),
     selectAccount: Schema.Optional(Type.Boolean()),
   })
   export type Capabilities = Schema.StaticDecode<typeof Capabilities>

--- a/src/remote/Actions.ts
+++ b/src/remote/Actions.ts
@@ -14,7 +14,7 @@ import type * as Remote from './Porto.js'
 export async function reject(
   porto: Pick<Remote.Porto<any>, 'messenger'>,
   request: Porto.QueuedRequest['request'],
-  error?: RpcResponse.BaseError | undefined,
+  error?: Provider.ProviderRpcError | RpcResponse.BaseError | undefined,
 ) {
   const error_ = error ?? new Provider.UserRejectedRequestError()
   const { messenger } = porto
@@ -44,7 +44,7 @@ export async function reject(
  */
 export async function rejectAll(
   porto: Pick<Remote.Porto<any>, 'messenger' | '_internal'>,
-  error?: RpcResponse.BaseError | undefined,
+  error?: Provider.ProviderRpcError | RpcResponse.BaseError | undefined,
 ) {
   const { _internal } = porto
   const requests = _internal.remoteStore.getState().requests

--- a/src/remote/Events.ts
+++ b/src/remote/Events.ts
@@ -1,3 +1,5 @@
+import type * as Address from 'ox/Address'
+import type * as Hex from 'ox/Hex'
 import * as Provider from 'ox/Provider'
 import type { Payload } from '../core/Messenger.js'
 import * as Actions from './Actions.js'
@@ -16,15 +18,22 @@ export function onDialogRequest(
     Remote.Porto<any>,
     '_internal' | 'methodPolicies' | 'messenger' | 'provider'
   >,
-  cb: (
-    payload: Remote.RemoteState['requests'][number]['request'] | null,
-  ) => void,
+  cb: (payload: {
+    account?:
+      | {
+          address: Address.Address
+          credentialId?: string | undefined
+          keyId?: Hex.Hex | undefined
+        }
+      | undefined
+    request: Remote.RemoteState['requests'][number]['request'] | null
+  }) => void,
 ) {
   return onRequests(porto, (requests, event) => {
-    const request = requests[0]?.request
+    const { account, request } = requests[0] ?? {}
 
     if (!request) {
-      cb(null)
+      cb({ request: null })
       return
     }
 
@@ -71,7 +80,9 @@ export function onDialogRequest(
       return
     }
 
-    cb(request)
+    const requireConnection = policy?.requireConnection ?? true
+
+    cb({ account: requireConnection ? account : undefined, request })
   })
 }
 

--- a/src/remote/Porto.ts
+++ b/src/remote/Porto.ts
@@ -28,6 +28,7 @@ export const defaultConfig = {
           sameOrigin: true,
         },
       },
+      requireConnection: false,
     },
     {
       method: 'experimental_grantAdmin',
@@ -53,6 +54,7 @@ export const defaultConfig = {
             }
           : undefined,
       },
+      requireConnection: false,
     },
     {
       method: 'wallet_createAccount',
@@ -64,6 +66,7 @@ export const defaultConfig = {
             }
           : undefined,
       },
+      requireConnection: false,
     },
     {
       method: 'wallet_prepareCalls',
@@ -181,6 +184,7 @@ export type MethodPolicy = {
         }
       | undefined
   }
+  requireConnection?: boolean | undefined
 }
 export type MethodPolicies = readonly MethodPolicy[]
 

--- a/src/wagmi/internal/core.ts
+++ b/src/wagmi/internal/core.ts
@@ -36,7 +36,7 @@ export async function connect<config extends Config>(
   } else connector = parameters.connector
 
   // Check if connector is already connected
-  if (connector.uid === config.state.current)
+  if (connector.uid === config.state.current && !parameters.force)
     throw new ConnectorAlreadyConnectedError()
 
   if (parameters.chainId && parameters.chainId !== config.state.chainId)
@@ -59,7 +59,7 @@ export async function connect<config extends Config>(
       | undefined
     if (!provider) throw new ProviderNotFoundError()
 
-    const { createAccount, grantPermissions } = parameters
+    const { createAccount, credentialId, grantPermissions, keyId } = parameters
     const method = 'wallet_connect'
     type method = typeof method
     await provider.request<{
@@ -72,7 +72,9 @@ export async function connect<config extends Config>(
         {
           capabilities: Schema.Encode(Request.wallet_connect.Capabilities, {
             createAccount,
+            credentialId,
             grantPermissions,
+            keyId,
           }),
         },
       ],
@@ -112,19 +114,11 @@ export async function connect<config extends Config>(
 }
 
 export declare namespace connect {
-  type Parameters<config extends Config = Config> = ChainIdParameter<config> & {
-    grantPermissions?:
-      | Schema.StaticDecode<
-          typeof Request.wallet_connect.Capabilities.properties.grantPermissions
-        >
-      | undefined
-    connector: Connector | CreateConnectorFn
-    createAccount?:
-      | Schema.StaticDecode<
-          typeof Request.wallet_connect.Capabilities.properties.createAccount
-        >
-      | undefined
-  }
+  type Parameters<config extends Config = Config> = ChainIdParameter<config> &
+    Schema.StaticDecode<typeof Request.wallet_connect.Capabilities> & {
+      connector: Connector | CreateConnectorFn
+      force?: boolean | undefined
+    }
 
   type ReturnType<config extends Config = Config> = ConnectReturnType<config>
 


### PR DESCRIPTION
Currently, we assume that an App and the Dialog are using the same account. However, this can become out-of-sync for a number of reasons like the user: creating another account from another app, signing out of account from manager, switching account, etc.

This PR ensures that the account coming from the App is always in sync with the Dialog by passing the address + webauthn key such that it can "rehydrate" successfully.