### PR TITLE
feat: implement relay `getCallsStatus`

### DIFF
--- a/apps/dialog/src/routes/-components/AddFunds.tsx
+++ b/apps/dialog/src/routes/-components/AddFunds.tsx
@@ -6,7 +6,7 @@ import { Address } from 'ox'
 import { Hex, Value } from 'ox'
 import { Hooks } from 'porto/remote'
 import * as React from 'react'
-import { useWaitForTransactionReceipt } from 'wagmi'
+import { useWaitForCallsStatus } from 'wagmi/experimental'
 
 import { porto } from '~/lib/Porto'
 import { Layout } from '~/routes/-components/Layout'
@@ -56,8 +56,8 @@ export function AddFunds(props: AddFunds.Props) {
     },
   })
 
-  const receipt = useWaitForTransactionReceipt({
-    hash: deposit.data?.id,
+  const receipt = useWaitForCallsStatus({
+    id: deposit.data?.id,
     query: {
       enabled: !!deposit.data?.id,
     },

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -7,6 +7,7 @@ import type * as Key from './key.js'
 import type * as PermissionsRequest from './permissionsRequest.js'
 import type * as Porto from './porto.js'
 import type * as Rpc from './typebox/rpc.js'
+import * as Schema from './typebox/schema.js'
 import type { Compute, PartialBy } from './types.js'
 
 type Request = Rpc.parseRequest.ReturnType
@@ -48,6 +49,13 @@ export type Mode = {
       /** Account. */
       account: Account.Account
     }>
+
+    getCallsStatus: (parameters: {
+      /** ID of the calls to get the status of. */
+      id: Hex.Hex
+      /** Internal properties. */
+      internal: ActionsInternal
+    }) => Promise<Schema.Static<typeof Rpc.wallet_getCallsStatus.Response>>
 
     grantAdmin: (parameters: {
       /** Account to authorize the keys for. */

--- a/src/core/internal/modes/contract.ts
+++ b/src/core/internal/modes/contract.ts
@@ -1,6 +1,7 @@
 import { Provider } from 'ox'
 import * as Address from 'ox/Address'
 import * as Bytes from 'ox/Bytes'
+import * as Hex from 'ox/Hex'
 import * as Json from 'ox/Json'
 import * as PersonalMessage from 'ox/PersonalMessage'
 import * as PublicKey from 'ox/PublicKey'
@@ -129,6 +130,32 @@ export function contract(parameters: contract.Parameters = {}) {
         address_internal = account.address
 
         return { account }
+      },
+
+      async getCallsStatus(parameters) {
+        const { id, internal } = parameters
+        const { client } = internal
+
+        const receipt = await client.request({
+          method: 'eth_getTransactionReceipt',
+          params: [id! as Hex.Hex],
+        })
+
+        const response = {
+          atomic: true,
+          chainId: Hex.fromNumber(client.chain.id),
+          id,
+          receipts: [],
+          status: 100,
+          version: '1.0',
+        }
+
+        if (!receipt) return response
+        return {
+          ...response,
+          receipts: [receipt],
+          status: receipt.status === '0x0' ? 400 : 200,
+        }
       },
 
       async grantAdmin(parameters) {

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -180,6 +180,18 @@ export function dialog(parameters: dialog.Parameters = {}) {
         }
       },
 
+      async getCallsStatus(parameters) {
+        const { internal } = parameters
+        const { store, request } = internal
+
+        if (request.method !== 'wallet_getCallsStatus')
+          throw new Error('Cannot get status for method: ' + request.method)
+
+        const provider = getProvider(store)
+        const result = await provider.request(request)
+        return result
+      },
+
       async grantAdmin(parameters) {
         const { internal } = parameters
         const { request, store } = internal

--- a/src/core/internal/provider.test.ts
+++ b/src/core/internal/provider.test.ts
@@ -11,12 +11,8 @@ import {
 } from 'ox'
 import { Mode } from 'porto'
 import { encodeFunctionData } from 'viem'
-import {
-  readContract,
-  verifyMessage,
-  verifyTypedData,
-  waitForTransactionReceipt,
-} from 'viem/actions'
+import { readContract, verifyMessage, verifyTypedData } from 'viem/actions'
+import { waitForCallsStatus } from 'viem/experimental'
 import { describe, expect, test } from 'vitest'
 import { setBalance } from '../../../test/src/actions.js'
 import {
@@ -120,8 +116,8 @@ describe.each([
 
       expect(hash).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash,
+      await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+        id: hash,
       })
 
       expect(
@@ -894,8 +890,8 @@ describe.each([
 
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+        id,
       })
 
       expect(
@@ -965,8 +961,8 @@ describe.each([
 
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+        id,
       })
 
       expect(
@@ -1038,8 +1034,8 @@ describe.each([
 
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+        id,
       })
 
       expect(
@@ -1172,8 +1168,8 @@ describe.each([
 
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+        id,
       })
 
       await expect(() =>
@@ -1261,8 +1257,8 @@ describe.each([
 
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+        id,
       })
 
       expect(
@@ -1435,6 +1431,54 @@ describe.each([
     })
   })
 
+  describe('wallet_getCallsStatus', () => {
+    test('default', async () => {
+      const { porto } = getPorto()
+      const client = Porto_internal.getClient(porto).extend(() => ({
+        mode: 'anvil',
+      }))
+
+      const { address } = await porto.provider.request({
+        method: 'experimental_createAccount',
+      })
+      await setBalance(client, {
+        address,
+        value: Value.fromEther('10000'),
+      })
+
+      const alice = Hex.random(20)
+
+      const { id } = await porto.provider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            calls: [
+              {
+                data: encodeFunctionData({
+                  abi: exp1Abi,
+                  args: [alice, 69420n],
+                  functionName: 'transfer',
+                }),
+                to: exp1Address,
+              },
+            ],
+            from: address,
+            version: '1',
+          },
+        ],
+      })
+
+      expect(id).toBeDefined()
+
+      const response = await porto.provider.request({
+        method: 'wallet_getCallsStatus',
+        params: [id],
+      })
+
+      expect(response.id).toBe(id)
+    })
+  })
+
   describe('wallet_prepareCalls → wallet_sendPreparedCalls', () => {
     describe('behavior: permissions', () => {
       test('default', async () => {
@@ -1520,8 +1564,8 @@ describe.each([
           ],
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: result[0]!.id,
+        await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+          id: result[0]!.id,
         })
 
         expect(
@@ -1621,8 +1665,8 @@ describe.each([
           ],
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: result[0]!.id,
+        await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+          id: result[0]!.id,
         })
 
         expect(
@@ -1717,8 +1761,8 @@ describe.each([
           ],
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: result[0]!.id,
+        await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+          id: result[0]!.id,
         })
 
         expect(
@@ -1808,8 +1852,8 @@ describe.each([
           ],
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: result[0]!.id,
+        await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+          id: result[0]!.id,
         })
 
         expect(
@@ -1901,8 +1945,8 @@ describe.each([
           ],
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: result[0]!.id,
+        await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+          id: result[0]!.id,
         })
 
         expect(
@@ -1989,8 +2033,8 @@ describe.each([
           ],
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: result[0]!.id,
+        await waitForCallsStatus(Porto_internal.getProviderClient(porto), {
+          id: result[0]!.id,
         })
 
         expect(

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -718,26 +718,19 @@ export function from<
 
           const client = getClient()
 
-          const receipt = await client.request({
-            method: 'eth_getTransactionReceipt',
-            params: [id! as Hex.Hex],
+          const response = await getMode().actions.getCallsStatus({
+            id,
+            internal: {
+              client,
+              config,
+              request,
+              store,
+            },
           })
 
-          const response = {
-            atomic: true,
-            chainId: Hex.fromNumber(client.chain.id),
-            id,
-            receipts: [],
-            status: 100,
-            version: '1.0',
-          } satisfies Schema.Static<typeof Rpc.wallet_getCallsStatus.Response>
-
-          if (!receipt) return response
-          return {
-            ...response,
-            receipts: [receipt],
-            status: receipt.status === '0x0' ? 400 : 200,
-          } satisfies Schema.Static<typeof Rpc.wallet_getCallsStatus.Response>
+          return response satisfies Schema.Static<
+            typeof Rpc.wallet_getCallsStatus.Response
+          >
         }
 
         case 'wallet_getCapabilities': {

--- a/src/core/internal/relay.test.ts
+++ b/src/core/internal/relay.test.ts
@@ -1,6 +1,7 @@
 import { Hex, Value } from 'ox'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
-import { readContract, waitForTransactionReceipt } from 'viem/actions'
+import { readContract } from 'viem/actions'
+import { waitForCallsStatus } from 'viem/experimental'
 import { describe, expect, test } from 'vitest'
 import * as TestActions from '../../../test/src/actions.js'
 import {
@@ -186,8 +187,8 @@ describe('sendCalls', () => {
 
     expect(id).toBeDefined()
 
-    await waitForTransactionReceipt(client, {
-      hash: id,
+    await waitForCallsStatus(client, {
+      id,
     })
 
     expect(
@@ -231,8 +232,8 @@ describe('sendCalls', () => {
 
     expect(id).toBeDefined()
 
-    await waitForTransactionReceipt(client, {
-      hash: id,
+    await waitForCallsStatus(client, {
+      id,
     })
 
     expect(
@@ -273,8 +274,8 @@ describe('sendCalls', () => {
 
     expect(id).toBeDefined()
 
-    await waitForTransactionReceipt(client, {
-      hash: id,
+    await waitForCallsStatus(client, {
+      id,
     })
 
     expect(
@@ -320,8 +321,8 @@ describe('sendCalls', () => {
 
     expect(id).toBeDefined()
 
-    await waitForTransactionReceipt(client, {
-      hash: id,
+    await waitForCallsStatus(client, {
+      id,
     })
 
     expect(
@@ -378,8 +379,8 @@ describe('sendCalls', () => {
 
     expect(id).toBeDefined()
 
-    await waitForTransactionReceipt(client, {
-      hash: id,
+    await waitForCallsStatus(client, {
+      id,
     })
 
     expect(
@@ -443,8 +444,8 @@ describe('sendCalls', () => {
 
     expect(id).toBeDefined()
 
-    await waitForTransactionReceipt(client, {
-      hash: id,
+    await waitForCallsStatus(client, {
+      id,
     })
 
     expect(
@@ -487,8 +488,8 @@ describe.each([
       })
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(client, {
+        id,
       })
 
       // 3. Verify that Account has 100 ERC20 tokens.
@@ -524,8 +525,8 @@ describe.each([
       })
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(client, {
+        id,
       })
 
       // 3. Verify that Account has 100 ERC20 tokens.
@@ -630,8 +631,8 @@ describe.each([
       })
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(client, {
+        id,
       })
 
       // 4. Verify that Account now has 3 Admin Keys.
@@ -672,8 +673,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
       }
 
@@ -694,8 +695,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 4. Verify that Account has 100 ERC20 tokens.
@@ -747,8 +748,8 @@ describe.each([
       })
       expect(id).toBeDefined()
 
-      await waitForTransactionReceipt(client, {
-        hash: id,
+      await waitForCallsStatus(client, {
+        id,
       })
 
       // 4. Verify that Account has 100 ERC20 tokens.
@@ -805,8 +806,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 3. Verify that Account has 100 ERC20 tokens.
@@ -862,8 +863,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 3. Verify that Account has 100 ERC20 tokens.
@@ -894,8 +895,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 5. Verify that Account now has 200 ERC20 tokens.
@@ -951,8 +952,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 3. Verify that Account has 100 ERC20 tokens.
@@ -983,8 +984,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 5. Verify that Account now has 200 ERC20 tokens.
@@ -1053,8 +1054,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 3. Verify that Account has 100 ERC20 tokens.
@@ -1181,8 +1182,8 @@ describe.each([
           feeToken: exp1Address,
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
       }
 
@@ -1201,8 +1202,8 @@ describe.each([
           feeToken: exp1Address,
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
       }
 
@@ -1265,8 +1266,8 @@ describe.each([
         })
         expect(id).toBeDefined()
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
 
         // 3. Verify that Account has 100 ERC20 tokens.
@@ -1296,8 +1297,8 @@ describe.each([
           key: sessionKey,
         })
 
-        await waitForTransactionReceipt(client, {
-          hash: id,
+        await waitForCallsStatus(client, {
+          id,
         })
       }
 

--- a/src/core/internal/relay/rpcSchema.ts
+++ b/src/core/internal/relay/rpcSchema.ts
@@ -24,6 +24,10 @@ export type Schema = RpcSchema_ox.From<
       ReturnType: Static<typeof Rpc.wallet_getAccounts.Response>
     }
   | {
+      Request: Static<typeof Rpc.wallet_getCallsStatus.Request>
+      ReturnType: Static<typeof Rpc.wallet_getCallsStatus.Response>
+    }
+  | {
       Request: Static<typeof Rpc.wallet_getKeys.Request>
       ReturnType: Static<typeof Rpc.wallet_getKeys.Response>
     }

--- a/src/core/internal/relay/typebox/rpc.ts
+++ b/src/core/internal/relay/typebox/rpc.ts
@@ -92,6 +92,41 @@ export namespace wallet_getAccounts {
   export type Response = Schema.StaticDecode<typeof Response>
 }
 
+export namespace wallet_getCallsStatus {
+  export const Request = Type.Object({
+    method: Type.Literal('wallet_getCallsStatus'),
+    params: Type.Tuple([Primitive.Hex]),
+  })
+  export type Request = Schema.StaticDecode<typeof Request>
+
+  export const Response = Type.Object({
+    id: Type.String(),
+    receipts: Schema.Optional(
+      Type.Array(
+        Type.Object({
+          blockHash: Primitive.Hex,
+          blockNumber: Type.Number(),
+          chainId: Type.Number(),
+          gasUsed: Type.Number(),
+          logs: Type.Array(
+            Type.Object({
+              address: Primitive.Address,
+              data: Primitive.Hex,
+              topics: Type.Array(Primitive.Hex),
+            }),
+          ),
+          status: Type.Object({
+            status: Primitive.Hex,
+          }),
+          transactionHash: Primitive.Hex,
+        }),
+      ),
+    ),
+    status: Type.Number(),
+  })
+  export type Response = Schema.StaticDecode<typeof Response>
+}
+
 export namespace wallet_getKeys {
   /** Parameters for `wallet_getKeys` request. */
   export const Parameters = Type.Object({

--- a/src/core/internal/viem/relay.test.ts
+++ b/src/core/internal/viem/relay.test.ts
@@ -10,6 +10,7 @@ import { sendCalls } from '../relay.js'
 import {
   createAccount,
   getAccounts,
+  getCallsStatus,
   getKeys,
   health,
   prepareCalls,
@@ -251,6 +252,52 @@ describe('getAccounts', () => {
     expect(result[0]?.keys[0]?.publicKey).toBe(key.publicKey)
     expect(result[0]?.keys[0]?.role).toBe(key.role)
     expect(result[0]?.keys[0]?.type).toBe('webauthnp256')
+  })
+})
+
+describe('getCallsStatus', () => {
+  test('default', async () => {
+    const key = Key.createHeadlessWebAuthnP256()
+    const account = await TestActions.createAccount(client, {
+      keys: [key],
+    })
+
+    const request = await prepareCalls(client, {
+      address: account.address,
+      calls: [
+        {
+          to: '0x0000000000000000000000000000000000000000',
+          value: 0n,
+        },
+      ],
+      capabilities: {
+        meta: {
+          feeToken,
+          keyHash: key.hash,
+          nonce: 0n,
+        },
+      },
+    })
+
+    const signature = await Key.sign(key, {
+      payload: request.digest,
+      wrap: false,
+    })
+
+    const { id } = await sendPreparedCalls(client, {
+      context: request.context,
+      signature: {
+        publicKey: key.publicKey,
+        type: 'webauthnp256',
+        value: signature,
+      },
+    })
+
+    const result = await getCallsStatus(client, {
+      id,
+    })
+
+    expect(result.status).toBe(200)
   })
 })
 

--- a/src/core/internal/viem/relay.test.ts
+++ b/src/core/internal/viem/relay.test.ts
@@ -297,7 +297,7 @@ describe('getCallsStatus', () => {
       id,
     })
 
-    expect(result.status).toBe(200)
+    expect(result.id).toBe(id)
   })
 })
 

--- a/src/core/internal/viem/relay.test.ts
+++ b/src/core/internal/viem/relay.test.ts
@@ -297,7 +297,7 @@ describe('getCallsStatus', () => {
       id,
     })
 
-    expect(result.id).toBe(id)
+    expect(result.id).toBeDefined()
   })
 })
 

--- a/src/core/internal/viem/relay.ts
+++ b/src/core/internal/viem/relay.ts
@@ -29,6 +29,7 @@ import * as EntryPoint from '../_generated/contracts/EntryPoint.js'
 import type * as RpcSchema from '../relay/rpcSchema.js'
 import * as Rpc from '../relay/typebox/rpc.js'
 import type { sendCalls } from '../relay.js'
+import * as Schema from '../typebox/schema.js'
 import { Value } from '../typebox/schema.js'
 
 /**
@@ -119,6 +120,50 @@ export namespace getAccounts {
   }
 
   export type ReturnType = Rpc.wallet_getAccounts.Response
+
+  export type ErrorType = parseSchemaError.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Gets the status of a call bundle.
+ *
+ * @example
+ * TODO
+ *
+ * @param client - The client to use.
+ * @param parameters - Parameters.
+ * @returns Result.
+ */
+export async function getCallsStatus(
+  client: Client,
+  parameters: getCallsStatus.Parameters,
+): Promise<getCallsStatus.ReturnType> {
+  const { id } = parameters
+  try {
+    const method = 'wallet_getCallsStatus' as const
+    type Schema = Extract<RpcSchema.Viem[number], { Method: typeof method }>
+    const result = await client.request<Schema>({
+      method,
+      params: [id],
+    })
+    return Value.Parse(
+      Rpc.wallet_getCallsStatus.Response,
+      result satisfies Schema.StaticEncode<
+        typeof Rpc.wallet_getCallsStatus.Response
+      >,
+    )
+  } catch (error) {
+    parseSchemaError(error)
+    throw error
+  }
+}
+
+export namespace getCallsStatus {
+  export type Parameters = {
+    id: Hex.Hex
+  }
+
+  export type ReturnType = Rpc.wallet_getCallsStatus.Response
 
   export type ErrorType = parseSchemaError.ErrorType | Errors.GlobalErrorType
 }

--- a/src/remote/Porto.ts
+++ b/src/remote/Porto.ts
@@ -61,6 +61,12 @@ export const defaultConfig = {
       },
     },
     {
+      method: 'wallet_getCallsStatus',
+      modes: {
+        headless: true,
+      },
+    },
+    {
       method: 'wallet_prepareCalls',
       modes: {
         headless: true,

--- a/test/src/actions.ts
+++ b/test/src/actions.ts
@@ -1,11 +1,8 @@
 import { type Address, Secp256k1 } from 'ox'
 import { parseEther } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import {
-  setBalance as setBalance_viem,
-  waitForTransactionReceipt,
-  writeContract,
-} from 'viem/actions'
+import { setBalance as setBalance_viem, writeContract } from 'viem/actions'
+import { waitForCallsStatus } from 'viem/experimental'
 
 import * as Account from '../../src/core/internal/account.js'
 import * as Key from '../../src/core/internal/key.js'
@@ -38,8 +35,8 @@ export async function createAccount(
       calls: [],
       feeToken: exp1Address,
     })
-    await waitForTransactionReceipt(client, {
-      hash: id as `0x${string}`,
+    await waitForCallsStatus(client, {
+      id,
     })
   }
 
@@ -96,8 +93,8 @@ export async function getUpgradedAccount(
     signatures,
   })
 
-  await waitForTransactionReceipt(client, {
-    hash: bundles[0]!.id,
+  await waitForCallsStatus(client, {
+    id: bundles[0]!.id,
   })
 
   return account
@@ -145,8 +142,8 @@ export async function setBalance(
       ],
       feeToken: exp1Address,
     })
-    await waitForTransactionReceipt(client, {
-      hash: id as `0x${string}`,
+    await waitForCallsStatus(client, {
+      id,
     })
   }
 }


### PR DESCRIPTION
Hooks up `wallet_getCallsStatus` properly internally. Uses Relay `wallet_getCallsStatus` for Relay Mode, and `eth_getTransactionReceipt` for Contract Mode.