### PR TITLE
feat: `experimental_getAccountVersion`

### DIFF
--- a/.changeset/nine-suits-appear.md
+++ b/.changeset/nine-suits-appear.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added `experimental_getAccountVersion`.

--- a/apps/docs/pages/sdk/rpc/experimental_getAccountVersion.mdx
+++ b/apps/docs/pages/sdk/rpc/experimental_getAccountVersion.mdx
@@ -1,0 +1,55 @@
+import { TryItOut } from '../../../components/TryItOut'
+
+# `experimental_getAccountVersion`
+
+Returns the current version of an account, and the latest version an account can be upgraded to.
+
+<TryItOut
+  exampleSlug="#example"
+  fn={({ provider }) => provider.request({ method: 'experimental_getAccountVersion' })}
+  transformResultCode={(code) => {
+    return 'const version = ' + code
+  }}
+/>
+
+## Request
+
+```ts
+type Request = {
+  method: 'experimental_getAccountVersion',
+  params: [{
+    /** Address of the account to get the version of. */
+    address?: `0x${string}`
+  }]
+}
+```
+
+## Response
+
+```ts
+type Response = { 
+  /** Current account version. */
+  current: string,
+  /** Latest version an account can be upgraded to. */
+  latest: string,
+}
+```
+
+## Example
+
+```ts twoslash
+import { Porto } from 'porto'
+
+const { provider } = Porto.create()
+
+const version = await provider.request({ // [!code focus]
+  method: 'experimental_getAccountVersion', // [!code focus]
+}) // [!code focus]
+```
+
+<TryItOut
+  fn={({ provider }) => provider.request({ method: 'experimental_getAccountVersion' })}
+  transformResultCode={(code) => {
+    return 'const version = ' + code
+  }}
+/>

--- a/apps/docs/vocs.config.tsx
+++ b/apps/docs/vocs.config.tsx
@@ -317,6 +317,10 @@ export default defineConfig({
             text: 'experimental_createAccount',
           },
           {
+            link: '/sdk/rpc/experimental_getAccountVersion',
+            text: 'experimental_getAccountVersion',
+          },
+          {
             link: '/sdk/rpc/experimental_getAdmins',
             text: 'experimental_getAdmins',
           },

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -67,6 +67,7 @@ export function App() {
         <Accounts />
         <Disconnect />
         <UpgradeAccount />
+        <GetAccountVersion />
         <div>
           <br />
           <hr />
@@ -341,6 +342,26 @@ function Disconnect() {
       >
         Disconnect
       </button>
+    </div>
+  )
+}
+
+function GetAccountVersion() {
+  const [result, setResult] = React.useState<unknown | null>(null)
+  return (
+    <div>
+      <h3>experimental_getAccountVersion</h3>
+      <button
+        onClick={() =>
+          porto.provider
+            .request({ method: 'experimental_getAccountVersion' })
+            .then(setResult)
+        }
+        type="button"
+      >
+        Get Account Version
+      </button>
+      {result ? <pre>{JSON.stringify(result, null, 2)}</pre> : null}
     </div>
   )
 }

--- a/src/core/RpcSchema.ts
+++ b/src/core/RpcSchema.ts
@@ -56,6 +56,10 @@ export type Schema =
           ReturnType: Static<typeof Rpc.experimental_getAdmins.Response>
         }
       | {
+          Request: Static<typeof Rpc.experimental_getAccountVersion.Request>
+          ReturnType: Static<typeof Rpc.experimental_getAccountVersion.Response>
+        }
+      | {
           Request: Static<typeof Rpc.experimental_getPermissions.Request>
           ReturnType: Static<typeof Rpc.experimental_getPermissions.Response>
         }

--- a/src/core/internal/provider.test.ts
+++ b/src/core/internal/provider.test.ts
@@ -600,6 +600,34 @@ describe.each([
     })
   })
 
+  describe('experimental_getAccountVersion', () => {
+    test('default', async () => {
+      const { porto } = getPorto()
+
+      await porto.provider.request({
+        method: 'experimental_createAccount',
+      })
+
+      const version = await porto.provider.request({
+        method: 'experimental_getAccountVersion',
+      })
+      expect(version).toMatchInlineSnapshot(`
+        {
+          "current": "0.0.2",
+          "latest": "0.0.2",
+        }
+      `)
+    })
+
+    test.todo('behavior: deployed account')
+
+    test.todo('behavior: not connected')
+
+    test.todo('behavior: outdated')
+
+    test.todo('behavior: accounts on different versions')
+  })
+
   describe('personal_sign', () => {
     // TODO(relay): counterfactual signature verification
     test.skipIf(type === 'relay')('default', async () => {

--- a/src/core/internal/provider.test.ts
+++ b/src/core/internal/provider.test.ts
@@ -619,11 +619,55 @@ describe.each([
       `)
     })
 
-    test.todo('behavior: not connected')
+    test('behavior: provided address', async () => {
+      const { porto } = getPorto()
 
-    test.todo('behavior: delegation contract not found')
+      const { address } = await porto.provider.request({
+        method: 'experimental_createAccount',
+      })
 
-    test.todo('behavior: outdated')
+      const version = await porto.provider.request({
+        method: 'experimental_getAccountVersion',
+        params: [{ address }],
+      })
+      expect(version).toMatchInlineSnapshot(`
+        {
+          "current": "0.0.2",
+          "latest": "0.0.2",
+        }
+      `)
+    })
+
+    test('behavior: not connected', async () => {
+      const { porto } = getPorto()
+
+      await expect(
+        porto.provider.request({
+          method: 'experimental_getAccountVersion',
+        }),
+      ).rejects.toMatchInlineSnapshot(
+        `[Provider.DisconnectedError: The provider is disconnected from all chains.]`,
+      )
+    })
+
+    test('behavior: account not found', async () => {
+      const { porto } = getPorto()
+
+      await porto.provider.request({
+        method: 'experimental_createAccount',
+      })
+
+      await expect(
+        porto.provider.request({
+          method: 'experimental_getAccountVersion',
+          params: [{ address: '0x0000000000000000000000000000000000000000' }],
+        }),
+      ).rejects.toMatchInlineSnapshot(
+        `[Provider.UnauthorizedError: The requested method and/or account has not been authorized by the user.]`,
+      )
+    })
+
+    test.todo('behavior: outdated account')
 
     test.todo('behavior: accounts on different versions')
   })

--- a/src/core/internal/provider.test.ts
+++ b/src/core/internal/provider.test.ts
@@ -619,9 +619,9 @@ describe.each([
       `)
     })
 
-    test.todo('behavior: deployed account')
-
     test.todo('behavior: not connected')
+
+    test.todo('behavior: delegation contract not found')
 
     test.todo('behavior: outdated')
 

--- a/src/core/internal/typebox/request.ts
+++ b/src/core/internal/typebox/request.ts
@@ -195,6 +195,25 @@ export namespace experimental_grantPermissions {
   export type Response = Schema.StaticDecode<typeof Response>
 }
 
+export namespace experimental_getAccountVersion {
+  export const Parameters = Type.Object({
+    address: Schema.Optional(Primitive.Address),
+  })
+  export type Parameters = Schema.StaticDecode<typeof Parameters>
+
+  export const Request = Type.Object({
+    method: Type.Literal('experimental_getAccountVersion'),
+    params: Schema.Optional(Type.Tuple([Parameters])),
+  })
+  export type Request = Schema.StaticDecode<typeof Request>
+
+  export const Response = Type.Object({
+    current: Type.String(),
+    latest: Type.String(),
+  })
+  export type Response = Schema.StaticDecode<typeof Response>
+}
+
 export namespace experimental_getPermissions {
   export const Parameters = Type.Object({
     address: Schema.Optional(Primitive.Address),

--- a/src/core/internal/typebox/rpc.ts
+++ b/src/core/internal/typebox/rpc.ts
@@ -14,6 +14,7 @@ export const Request = Type.Union([
   RpcRequest.eth_sendTransaction.Request,
   RpcRequest.eth_signTypedData_v4.Request,
   RpcRequest.experimental_createAccount.Request,
+  RpcRequest.experimental_getAccountVersion.Request,
   RpcRequest.experimental_getAdmins.Request,
   RpcRequest.experimental_getPermissions.Request,
   RpcRequest.experimental_grantAdmin.Request,


### PR DESCRIPTION
Adds RPC method to get the current version of an account, and the latest version an account can be upgraded to.