### PR TITLE
Fix typos

### DIFF
--- a/apps/docs/components/DemoApp.tsx
+++ b/apps/docs/components/DemoApp.tsx
@@ -27,7 +27,7 @@ import LucidePictureInPicture2 from '~icons/lucide/picture-in-picture-2'
 
 type Provider = Porto.Porto['provider']
 const pollingInterval = 800
-const successTimeout = 4_000 // time to wait until reseting success state back to default
+const successTimeout = 4_000 // time to wait until resetting success state back to default
 
 export function DemoApp() {
   const isMountedFn = useIsMounted()

--- a/src/core/internal/relay/typebox/userOp.ts
+++ b/src/core/internal/relay/typebox/userOp.ts
@@ -50,7 +50,7 @@ export const UserOp = Type.Object({
    *      `-------------------------------------'
    *
    * If the upper 16 bits of the sequence key is `0xc1d0`, then the EIP-712 has
-   * of the UserOp will exlude the chain ID.
+   * of the UserOp will exclude the chain ID.
    *
    * # Ordering
    *


### PR DESCRIPTION
This PR fixes two minor typos:
- Corrects "exlude" to "exclude" in the UserOp type documentation
- Corrects "reseting" to "resetting" in the DemoApp success timeout comment

