### PR TITLE
refactor: use asset diffs from relay; misc. refactors

### DIFF
--- a/apps/dialog/src/components/CheckBalance.tsx
+++ b/apps/dialog/src/components/CheckBalance.tsx
@@ -1,0 +1,90 @@
+import { Button } from '@porto/apps/components'
+import { UseQueryResult } from '@tanstack/react-query'
+import { Address } from 'ox'
+import { Hooks } from 'porto/remote'
+import * as React from 'react'
+import * as FeeToken from '~/lib/FeeToken'
+import { porto } from '~/lib/Porto'
+import { AddFunds } from '~/routes/-components/AddFunds'
+import { Layout } from '~/routes/-components/Layout'
+import TriangleAlert from '~icons/lucide/triangle-alert'
+
+export function CheckBalance(props: CheckBalance.Props) {
+  const { address, children, chainId, onReject, query } = props
+
+  const [step, setStep] = React.useState<'add-funds' | 'default' | 'success'>(
+    'default',
+  )
+
+  const chain = Hooks.useChain(porto, { chainId })
+  const feeToken = FeeToken.useFetch({
+    address: props.feeToken,
+    chainId: chain?.id,
+  })
+
+  const hasInsufficientBalance = query.error?.message?.includes('PaymentError')
+
+  if (!hasInsufficientBalance) return children
+  if (step === 'success') return children
+  if (step === 'add-funds')
+    return (
+      <AddFunds
+        address={address}
+        onApprove={() => {
+          setStep('success')
+          query.refetch()
+        }}
+        onReject={onReject}
+        tokenAddress={props.feeToken!}
+      />
+    )
+  return (
+    <Layout>
+      <Layout.Header>
+        <Layout.Header.Default
+          content={
+            <>You will need more {feeToken?.data?.symbol} to continue.</>
+          }
+          icon={TriangleAlert}
+          title="Insufficient balance"
+          variant="warning"
+        />
+      </Layout.Header>
+
+      <Layout.Footer>
+        <Layout.Footer.Actions>
+          <Button
+            className="flex-grow"
+            onClick={onReject}
+            type="button"
+            variant="default"
+          >
+            Cancel
+          </Button>
+
+          <Button
+            className="flex-grow"
+            onClick={() => setStep('add-funds')}
+            type="button"
+            variant="accent"
+          >
+            Add Funds
+          </Button>
+        </Layout.Footer.Actions>
+
+        {address && <Layout.Footer.Account address={address} />}
+      </Layout.Footer>
+    </Layout>
+  )
+}
+
+export namespace CheckBalance {
+  export type Props = {
+    address?: Address.Address | undefined
+    chainId?: number | undefined
+    children: React.ReactNode
+    feeToken?: Address.Address | undefined
+    onReject: () => void
+    query: UseQueryResult
+  }
+}

--- a/apps/dialog/src/lib/FeeToken.ts
+++ b/apps/dialog/src/lib/FeeToken.ts
@@ -7,6 +7,7 @@ import { porto } from './Porto.js'
 export type FeeToken = {
   address: Address.Address
   decimals: number
+  nativeRate?: bigint | undefined
   symbol: string
 }
 
@@ -40,11 +41,7 @@ export function useFetch(parameters: useFetch.Parameters) {
         throw new Error(
           `fee token ${address ?? symbol} not found. Available: ${feeTokens?.map((x) => `${x.symbol} (${x.address})`).join(', ')}`,
         )
-      return {
-        address: feeToken.address,
-        decimals: feeToken.decimals,
-        symbol: feeToken.symbol,
-      }
+      return feeToken
     },
     queryKey: [
       'FeeToken.current',

--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -2,12 +2,11 @@ import { PortoConfig } from '@porto/apps'
 import { Button, Spinner } from '@porto/apps/components'
 import { useQuery } from '@tanstack/react-query'
 import { cx } from 'cva'
-import { Address, Json, RpcSchema } from 'ox'
-import { Chains, RpcSchema as RpcSchema_porto } from 'porto'
+import { Address, Json } from 'ox'
+import { Chains } from 'porto'
 import * as Quote_relay from 'porto/core/internal/relay/typebox/quote'
 import * as Rpc from 'porto/core/internal/typebox/request'
-import * as Schema from 'porto/core/internal/typebox/schema'
-import { Account } from 'porto/internal'
+import { Account, Relay } from 'porto/internal'
 import { Hooks, Porto as Porto_ } from 'porto/remote'
 import * as React from 'react'
 import { Call } from 'viem'
@@ -25,56 +24,17 @@ import TriangleAlert from '~icons/lucide/triangle-alert'
 import Star from '~icons/ph/star-four-bold'
 
 export function ActionRequest(props: ActionRequest.Props) {
-  const { address, feeToken, loading, onApprove, onReject, request } = props
+  const { address, calls, chainId, feeToken, loading, onApprove, onReject } =
+    props
 
   const account = Hooks.useAccount(porto, { address })
   const origin = Dialog.useStore((state) => state.referrer?.origin)
-  const providerClient = Hooks.useProviderClient(porto)
 
-  const prepareCallsQuery = useQuery({
-    enabled: !!account,
-    async queryFn() {
-      if (!account) throw new Error('account is required.')
-
-      const key = Account.getKey(account, { role: 'admin' })
-      if (!key) throw new Error('no key found.')
-
-      const raw = await providerClient.request(
-        {
-          method: 'wallet_prepareCalls',
-          params: [
-            {
-              // Note: Using IIFE for inferred return type.
-              ...(() => {
-                // If the request was from an `eth_sendTransaction`, marshal it
-                // into a `wallet_sendCalls` request.
-                if (request.method === 'eth_sendTransaction') {
-                  const { chainId, data, to, value } = request.params[0]
-                  return {
-                    calls: [{ data, to: to!, value }],
-                    chainId,
-                  }
-                }
-
-                // Otherwise, we are dealing with a `wallet_sendCalls` request.
-                return request.params[0]
-              })(),
-              from: account.address,
-              key,
-            },
-          ],
-        },
-        { retryCount: 0 },
-      )
-
-      return Schema.Decode(Rpc.wallet_prepareCalls.Response, raw)
-    },
-    queryKey: [
-      'prepareCalls',
-      account?.address,
-      Json.stringify(request),
-      providerClient.uid,
-    ],
+  const prepareCallsQuery = ActionRequest.usePrepareCalls({
+    address,
+    calls,
+    chainId,
+    feeToken,
   })
 
   const assetDiff = prepareCallsQuery.data?.capabilities.assetDiff
@@ -124,7 +84,7 @@ export function ActionRequest(props: ActionRequest.Props) {
               </div>
             )}
 
-            {(prepareCallsQuery.isSuccess || prepareCallsQuery.isError) && (
+            {prepareCallsQuery.isSuccess && (
               <div className="space-y-3 rounded-lg bg-surface p-3">
                 {assetDiff && address && (
                   <ActionRequest.AssetDiff
@@ -203,10 +163,6 @@ export namespace ActionRequest {
     onApprove: () => void
     onReject: () => void
     quote?: Quote | undefined
-    request: RpcSchema.ExtractRequest<
-      RpcSchema_porto.Schema,
-      'eth_sendTransaction' | 'wallet_sendCalls'
-    >
   }
 
   export function AssetDiff(props: AssetDiff.Props) {
@@ -345,6 +301,55 @@ export namespace ActionRequest {
       chain?: Chains.Chain | undefined
       quote: Quote_relay.Quote
     }
+  }
+
+  export function usePrepareCalls<const calls extends readonly unknown[]>(
+    props: usePrepareCalls.Props<calls>,
+  ) {
+    const { address, chainId, calls } = props
+
+    const account = Hooks.useAccount(porto, { address })
+    const client = Hooks.useClient(porto, { chainId })
+    const feeToken = FeeToken.useFetch({
+      address: props.feeToken,
+      chainId,
+    })
+
+    return useQuery({
+      enabled: !!account,
+      async queryFn() {
+        if (!account) throw new Error('account is required.')
+
+        const key = Account.getKey(account, { role: 'admin' })
+        if (!key) throw new Error('no admin key found.')
+
+        return await Relay.prepareCalls(client, {
+          account,
+          calls,
+          feeToken: feeToken.data?.address,
+          key,
+        })
+      },
+      queryKey: [
+        'prepareCalls',
+        account?.address,
+        Json.stringify(calls),
+        client.uid,
+        feeToken.data?.address,
+      ],
+    })
+  }
+
+  export declare namespace usePrepareCalls {
+    export type Props<calls extends readonly unknown[] = readonly unknown[]> =
+      Pick<
+        Relay.prepareCalls.Parameters<calls>,
+        'authorizeKeys' | 'calls' | 'revokeKeys'
+      > & {
+        address?: Address.Address | undefined
+        chainId?: number | undefined
+        feeToken?: Address.Address | undefined
+      }
   }
 
   export type Quote = {

--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -3,15 +3,16 @@ import { Button, Spinner } from '@porto/apps/components'
 import { useQuery } from '@tanstack/react-query'
 import { cx } from 'cva'
 import { Address, Json, RpcSchema } from 'ox'
-import { Delegation, RpcSchema as RpcSchema_porto } from 'porto'
+import { Chains, RpcSchema as RpcSchema_porto } from 'porto'
 import * as Quote_relay from 'porto/core/internal/relay/typebox/quote'
 import * as Rpc from 'porto/core/internal/typebox/request'
 import * as Schema from 'porto/core/internal/typebox/schema'
-import { Porto as Porto_ } from 'porto/remote'
-import { Hooks } from 'porto/remote'
+import { Account } from 'porto/internal'
+import { Hooks, Porto as Porto_ } from 'porto/remote'
 import * as React from 'react'
 import { Call } from 'viem'
 
+import { CheckBalance } from '~/components/CheckBalance'
 import * as Dialog from '~/lib/Dialog'
 import * as FeeToken from '~/lib/FeeToken'
 import { porto } from '~/lib/Porto'
@@ -22,204 +23,83 @@ import ArrowDownLeft from '~icons/lucide/arrow-down-left'
 import ArrowUpRight from '~icons/lucide/arrow-up-right'
 import TriangleAlert from '~icons/lucide/triangle-alert'
 import Star from '~icons/ph/star-four-bold'
-import { AddFunds } from './AddFunds'
 
 export function ActionRequest(props: ActionRequest.Props) {
-  const { address, onReject } = props
+  const { address, feeToken, loading, onApprove, onReject, request } = props
 
-  const [step, setStep] = React.useState<
-    | {
-        props: {
-          tokenAddress: Address.Address
-        }
-        type: 'add-funds'
-      }
-    | {
-        props?:
-          | {
-              checkBalance?: boolean | undefined
-            }
-          | undefined
-        type: 'default'
-      }
-  >({
-    type: 'default',
+  const account = Hooks.useAccount(porto, { address })
+  const origin = Dialog.useStore((state) => state.referrer?.origin)
+  const providerClient = Hooks.useProviderClient(porto)
+
+  const prepareCallsQuery = useQuery({
+    enabled: !!account,
+    async queryFn() {
+      if (!account) throw new Error('account is required.')
+
+      const key = Account.getKey(account, { role: 'admin' })
+      if (!key) throw new Error('no key found.')
+
+      const raw = await providerClient.request(
+        {
+          method: 'wallet_prepareCalls',
+          params: [
+            {
+              // Note: Using IIFE for inferred return type.
+              ...(() => {
+                // If the request was from an `eth_sendTransaction`, marshal it
+                // into a `wallet_sendCalls` request.
+                if (request.method === 'eth_sendTransaction') {
+                  const { chainId, data, to, value } = request.params[0]
+                  return {
+                    calls: [{ data, to: to!, value }],
+                    chainId,
+                  }
+                }
+
+                // Otherwise, we are dealing with a `wallet_sendCalls` request.
+                return request.params[0]
+              })(),
+              from: account.address,
+              key,
+            },
+          ],
+        },
+        { retryCount: 0 },
+      )
+
+      return Schema.Decode(Rpc.wallet_prepareCalls.Response, raw)
+    },
+    queryKey: [
+      'prepareCalls',
+      account?.address,
+      Json.stringify(request),
+      providerClient.uid,
+    ],
   })
 
-  if (step.type === 'add-funds')
-    return (
-      <AddFunds
-        {...step.props}
-        address={address}
-        onApprove={() =>
-          setStep({ props: { checkBalance: false }, type: 'default' })
-        }
-        onReject={onReject}
-      />
-    )
+  const assetDiff = prepareCallsQuery.data?.capabilities.assetDiff
+  const quote = prepareCallsQuery.data?.capabilities.quote
+
   return (
-    <ActionRequest.Inner
-      {...props}
-      {...step.props}
-      onAddFunds={({ token }) => {
-        setStep({
-          props: { tokenAddress: token },
-          type: 'add-funds',
-        })
-      }}
-    />
-  )
-}
-
-export namespace ActionRequest {
-  export type Props = Omit<Inner.Props, 'onAddFunds'>
-
-  export function Inner(props: Inner.Props) {
-    const {
-      address,
-      calls,
-      chainId,
-      checkBalance = true,
-      loading,
-      onAddFunds,
-      onApprove,
-      onReject,
-      request,
-    } = props
-
-    const account = Hooks.useAccount(porto, { address })
-    const chain = Hooks.useChain(porto, { chainId })
-    const client = Hooks.useClient(porto)
-    const feeToken = FeeToken.useFetch({
-      address: props.feeToken,
-      chainId: chain?.id,
-    })
-    const origin = Dialog.useStore((state) => state.referrer?.origin)
-    const providerClient = Hooks.useProviderClient(porto)
-
-    // TODO: use eventual Wagmi Hook (`usePrepareCalls`).
-    const prepareCalls = useQuery({
-      async queryFn() {
-        if (!account) throw new Error('account is required.')
-
-        const key = account.keys?.find(
-          (key) => key.role === 'admin' && key.privateKey,
-        )
-        if (!key) throw new Error('no key found.')
-
-        // TODO: use eventual Viem Action (`prepareCalls`).
-        const raw = await providerClient.request(
-          {
-            method: 'wallet_prepareCalls',
-            params: [
-              {
-                // Note: Using IIFE for inferred return type.
-                ...(() => {
-                  // If the request was from an `eth_sendTransaction`, marshal it
-                  // into a `wallet_sendCalls` request.
-                  if (request.method === 'eth_sendTransaction') {
-                    const { chainId, data, to, value } = request.params[0]
-                    return {
-                      calls: [{ data, to: to!, value }],
-                      chainId,
-                    }
-                  }
-
-                  // Otherwise, we are dealing with a `wallet_sendCalls` request.
-                  return request.params[0]
-                })(),
-                key,
-              },
-            ],
-          },
-          { retryCount: 0 },
-        )
-
-        return Schema.Decode(Rpc.wallet_prepareCalls.Response, raw)
-      },
-      queryKey: [
-        'prepareCalls',
-        account?.address,
-        Json.stringify(request),
-        providerClient.uid,
-      ],
-    })
-
-    // TODO: extract from a `quote` capability on `wallet_prepareCalls` response
-    //       instead of introspecting the context.
-    const quote = useQuote(porto, {
-      chainId,
-      context: prepareCalls.data?.context,
-    })
-
-    const fiatFee = Price.useFiatPrice({
-      value: quote?.fee.native.value,
-    })
-    const tokenFee = quote?.fee
-
-    const simulate = useQuery({
-      gcTime: 0,
-      queryFn: async () => {
-        const { balances, results } = await Delegation.simulate(client, {
-          account: account!.address!,
-          calls,
-        })
-        const failure = results.find((x) => x.status === 'failure')
-        if (failure) throw failure.error
-        return { balances, results }
-      },
-      queryKey: ['simulate', client.uid, Json.stringify(calls)],
-      staleTime: 0,
-    })
-    const balances =
-      simulate.data?.balances.filter((x) => x.value.diff !== 0n) ?? []
-
-    const hasInsufficientBalance =
-      checkBalance && prepareCalls.error?.message?.includes('PaymentError')
-
-    const status = React.useMemo(() => {
-      if (hasInsufficientBalance) return 'insufficient-balance'
-      if (prepareCalls.isPending || simulate.isPending) return 'pending'
-      if (prepareCalls.isError || simulate.isError) return 'error'
-      if (prepareCalls.isSuccess || simulate.isSuccess) return 'success'
-      return 'idle'
-    }, [
-      hasInsufficientBalance,
-      prepareCalls.isError,
-      prepareCalls.isPending,
-      prepareCalls.isSuccess,
-      simulate.isError,
-      simulate.isPending,
-      simulate.isSuccess,
-    ])
-
-    const warning = status === 'insufficient-balance' || status === 'error'
-
-    return (
+    <CheckBalance
+      address={address}
+      feeToken={feeToken}
+      onReject={onReject}
+      query={prepareCallsQuery}
+    >
       <Layout loading={loading} loadingTitle="Sending...">
         <Layout.Header>
           <Layout.Header.Default
             content={<>Review the action to perform below.</>}
-            icon={warning ? TriangleAlert : Star}
+            icon={prepareCallsQuery.isError ? TriangleAlert : Star}
             title="Action Request"
-            variant={warning ? 'warning' : 'default'}
+            variant={prepareCallsQuery.isError ? 'warning' : 'default'}
           />
         </Layout.Header>
 
         <Layout.Content>
           <div className="space-y-3">
-            {status === 'insufficient-balance' && (
-              <div className="rounded-lg bg-warningTint px-3 py-2 text-warning">
-                <div className="font-medium text-[14px]">
-                  Insufficient balance
-                </div>
-                <p className="text-[14px] text-primary">
-                  You will need more {feeToken?.data?.symbol} to continue.
-                </p>
-              </div>
-            )}
-
-            {status === 'pending' && (
+            {prepareCallsQuery.isPending && (
               <div className="space-y-2 rounded-lg bg-surface p-3">
                 <div className="flex size-[24px] w-full items-center justify-center">
                   <Spinner className="text-secondary" />
@@ -227,7 +107,7 @@ export namespace ActionRequest {
               </div>
             )}
 
-            {status === 'error' && (
+            {prepareCallsQuery.isError && (
               <div className="rounded-lg bg-warningTint px-3 py-2 text-warning">
                 <div className="font-medium text-[14px]">Error</div>
                 <div className="space-y-2 text-[14px] text-primary">
@@ -244,151 +124,23 @@ export namespace ActionRequest {
               </div>
             )}
 
-            {(status === 'success' || status === 'error') && (
+            {(prepareCallsQuery.isSuccess || prepareCallsQuery.isError) && (
               <div className="space-y-3 rounded-lg bg-surface p-3">
-                {balances.length > 0 && (
-                  <>
-                    <div className="space-y-2">
-                      {balances.map((balance) => {
-                        const { token, value } = balance
-                        if (value.diff === BigInt(0)) return null
-
-                        const { decimals, symbol } = token
-
-                        const receiving = value.diff > BigInt(0)
-                        const formatted = ValueFormatter.format(
-                          value.diff,
-                          decimals,
-                        )
-
-                        const Icon = receiving ? ArrowDownLeft : ArrowUpRight
-
-                        return (
-                          <div
-                            className="flex items-center gap-2 font-medium"
-                            key={token.address}
-                          >
-                            <div
-                              className={cx(
-                                'flex size-[24px] items-center justify-center rounded-full',
-                                {
-                                  'bg-destructiveTint': !receiving,
-                                  'bg-successTint': receiving,
-                                },
-                              )}
-                            >
-                              <Icon
-                                className={cx('size-4 text-current', {
-                                  'text-destructive': !receiving,
-                                  'text-success': receiving,
-                                })}
-                              />
-                            </div>
-                            <div>
-                              {receiving ? 'Receive' : 'Send'}{' '}
-                              <span
-                                className={
-                                  receiving
-                                    ? 'text-success'
-                                    : 'text-destructive'
-                                }
-                              >
-                                {formatted}
-                              </span>{' '}
-                              {symbol}
-                            </div>
-                          </div>
-                        )
-                      })}
-                    </div>
-                    <div className="h-[1px] w-full bg-gray6" />
-                  </>
+                {assetDiff && address && (
+                  <ActionRequest.AssetDiff
+                    address={address}
+                    assetDiff={assetDiff}
+                  />
                 )}
 
-                <div className="space-y-1">
-                  <div
-                    className={cx(
-                      'flex h-[32px] justify-between text-[14px] leading-4',
-                      {
-                        'h-[inherit] leading-[inherit]':
-                          fiatFee.isFetched || !quote,
-                      },
-                    )}
-                  >
-                    <span className="text-[14px] text-secondary leading-4">
-                      Fees (est.)
-                    </span>
-                    <div className="text-right">
-                      {fiatFee.isFetched || !quote ? (
-                        <>
-                          <div className="font-medium leading-4">
-                            {fiatFee?.data?.display ?? 'Unknown'}
-                          </div>
-                          {tokenFee && (
-                            <div className="leading-4">
-                              <span className="text-secondary text-xs">
-                                {tokenFee.display}
-                              </span>
-                            </div>
-                          )}
-                        </>
-                      ) : (
-                        <span className="font-medium text-secondary">
-                          Loading...
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="flex justify-between text-[14px]">
-                    <span className="text-[14px] text-secondary">
-                      Duration (est.)
-                    </span>
-                    <span className="font-medium">2 seconds</span>
-                  </div>
-
-                  {chain?.name && (
-                    <div className="flex justify-between text-[14px]">
-                      <span className="text-[14px] text-secondary">
-                        Network
-                      </span>
-                      <span className="font-medium">{chain?.name}</span>
-                    </div>
-                  )}
-                </div>
+                {quote && <ActionRequest.Details quote={quote} />}
               </div>
             )}
           </div>
         </Layout.Content>
 
         <Layout.Footer>
-          {status === 'insufficient-balance' && (
-            <Layout.Footer.Actions>
-              <Button
-                className="flex-grow"
-                onClick={onReject}
-                type="button"
-                variant="default"
-              >
-                Cancel
-              </Button>
-
-              <Button
-                className="flex-grow"
-                onClick={() =>
-                  onAddFunds({
-                    token: feeToken.data!.address,
-                  })
-                }
-                type="button"
-                variant="accent"
-              >
-                Add Funds
-              </Button>
-            </Layout.Footer.Actions>
-          )}
-
-          {status === 'success' && (
+          {prepareCallsQuery.isSuccess && (
             <Layout.Footer.Actions>
               <Button
                 className="flex-grow"
@@ -410,7 +162,7 @@ export namespace ActionRequest {
             </Layout.Footer.Actions>
           )}
 
-          {status === 'error' && (
+          {prepareCallsQuery.isError && (
             <Layout.Footer.Actions>
               <Button
                 className="flex-grow"
@@ -436,107 +188,233 @@ export namespace ActionRequest {
           )}
         </Layout.Footer>
       </Layout>
+    </CheckBalance>
+  )
+}
+
+export namespace ActionRequest {
+  export type Props = {
+    address?: Address.Address | undefined
+    calls: readonly Call[]
+    chainId?: number | undefined
+    checkBalance?: boolean | undefined
+    feeToken?: Address.Address | undefined
+    loading?: boolean | undefined
+    onApprove: () => void
+    onReject: () => void
+    quote?: Quote | undefined
+    request: RpcSchema.ExtractRequest<
+      RpcSchema_porto.Schema,
+      'eth_sendTransaction' | 'wallet_sendCalls'
+    >
+  }
+
+  export function AssetDiff(props: AssetDiff.Props) {
+    const { address } = props
+
+    const account = Hooks.useAccount(porto, { address })
+
+    const balances = React.useMemo(() => {
+      if (!props.assetDiff) return []
+
+      let balances = []
+      for (const [account_, values] of props.assetDiff) {
+        if (account_ !== account?.address) continue
+        for (const value of values) {
+          balances.push({
+            ...value,
+            account: account_,
+          })
+        }
+      }
+      return balances
+    }, [props.assetDiff, account?.address])
+
+    return (
+      <>
+        <div className="space-y-2">
+          {balances.map((balance) => {
+            const { address, decimals, symbol, value } = balance
+            if (value === BigInt(0)) return null
+
+            const receiving = value > BigInt(0)
+            const formatted = ValueFormatter.format(value, decimals)
+
+            const Icon = receiving ? ArrowDownLeft : ArrowUpRight
+
+            return (
+              <div
+                className="flex items-center gap-2 font-medium"
+                key={address}
+              >
+                <div
+                  className={cx(
+                    'flex size-[24px] items-center justify-center rounded-full',
+                    {
+                      'bg-destructiveTint': !receiving,
+                      'bg-successTint': receiving,
+                    },
+                  )}
+                >
+                  <Icon
+                    className={cx('size-4 text-current', {
+                      'text-destructive': !receiving,
+                      'text-success': receiving,
+                    })}
+                  />
+                </div>
+                <div>
+                  {receiving ? 'Receive' : 'Send'}{' '}
+                  <span
+                    className={receiving ? 'text-success' : 'text-destructive'}
+                  >
+                    {formatted}
+                  </span>{' '}
+                  {symbol}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+        {balances.length > 0 && <div className="h-[1px] w-full bg-gray6" />}
+      </>
     )
   }
 
-  export namespace Inner {
+  export namespace AssetDiff {
     export type Props = {
-      address?: Address.Address | undefined
-      calls: readonly Call[]
-      chainId?: number | undefined
-      checkBalance?: boolean | undefined
-      feeToken?: Address.Address | undefined
-      loading?: boolean | undefined
-      onAddFunds: (p: { token: Address.Address }) => void
-      onApprove: () => void
-      onReject: () => void
-      quote?: Quote | undefined
-      request: RpcSchema.ExtractRequest<
-        RpcSchema_porto.Schema,
-        'eth_sendTransaction' | 'wallet_sendCalls'
-      >
+      address: Address.Address
+      assetDiff: Rpc.wallet_prepareCalls.Response['capabilities']['assetDiff']
     }
   }
-}
+  export function Details(props: Details.Props) {
+    const quote = useQuote(porto, props.quote)
+    const chain = Hooks.useChain(porto, { chainId: props.quote.chainId })
+    const fiatFee = Price.useFiatPrice({
+      value: quote?.fee.native.value,
+    })
+    const tokenFee = quote?.fee
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+    return (
+      <div className="space-y-1">
+        <div
+          className={cx('flex h-[32px] justify-between text-[14px] leading-4', {
+            'h-[inherit] leading-[inherit]': fiatFee.isFetched || !quote,
+          })}
+        >
+          <span className="text-[14px] text-secondary leading-4">
+            Fees (est.)
+          </span>
+          <div className="text-right">
+            {fiatFee.isFetched || !quote ? (
+              <>
+                <div className="font-medium leading-4">
+                  {fiatFee?.data?.display ?? 'Unknown'}
+                </div>
+                {tokenFee && (
+                  <div className="leading-4">
+                    <span className="text-secondary text-xs">
+                      {tokenFee.display}
+                    </span>
+                  </div>
+                )}
+              </>
+            ) : (
+              <span className="font-medium text-secondary">Loading...</span>
+            )}
+          </div>
+        </div>
 
-export type Quote = {
-  fee: Price.Price & {
-    native: Price.Price
+        <div className="flex justify-between text-[14px]">
+          <span className="text-[14px] text-secondary">Duration (est.)</span>
+          <span className="font-medium">2 seconds</span>
+        </div>
+
+        {chain?.name && (
+          <div className="flex justify-between text-[14px]">
+            <span className="text-[14px] text-secondary">Network</span>
+            <span className="font-medium">{chain?.name}</span>
+          </div>
+        )}
+      </div>
+    )
   }
-  ttl: number
-}
 
-/**
- * Hook to extract a quote from a `wallet_prepareCalls` context.
- *
- * @param porto - Porto instance.
- * @param parameters - Parameters.
- * @returns Quote.
- */
-export function useQuote<
-  chains extends readonly [PortoConfig.Chain, ...PortoConfig.Chain[]],
->(
-  porto: Pick<Porto_.Porto<chains>, '_internal'>,
-  parameters: useQuote.Parameters,
-): Quote | undefined {
-  const { chainId } = parameters
-  const context = parameters.context as Quote_relay.Quote | undefined
-  const { op, nativeFeeEstimate, txGas, ttl } = context ?? {}
-  const { paymentToken, paymentMaxAmount } = op ?? {}
+  export namespace Details {
+    export type Props = {
+      chain?: Chains.Chain | undefined
+      quote: Quote_relay.Quote
+    }
+  }
 
-  const chain = Hooks.useChain(porto, { chainId })!
-  const feeToken = FeeToken.useFetch({
-    address: paymentToken,
-    chainId: chain.id,
-  })
+  export type Quote = {
+    fee: Price.Price & {
+      native: Price.Price
+    }
+    ttl: number
+  }
 
-  const fee = React.useMemo(() => {
-    if (!nativeFeeEstimate || !txGas || !paymentMaxAmount || !feeToken.data)
-      return undefined
+  /**
+   * Hook to extract a quote from a `wallet_prepareCalls` context.
+   *
+   * @param porto - Porto instance.
+   * @param parameters - Parameters.
+   * @returns Quote.
+   */
+  export function useQuote<
+    chains extends readonly [PortoConfig.Chain, ...PortoConfig.Chain[]],
+  >(
+    porto: Pick<Porto_.Porto<chains>, '_internal'>,
+    quote: Quote_relay.Quote,
+  ): Quote | undefined {
+    const { chainId, op, nativeFeeEstimate, txGas, ttl } = quote ?? {}
+    const { paymentToken, paymentMaxAmount } = op ?? {}
 
-    const nativeConfig = {
-      address: '0x0000000000000000000000000000000000000000',
-      decimals: chain.nativeCurrency.decimals,
-      symbol: chain.nativeCurrency.symbol,
-      value: nativeFeeEstimate.maxFeePerGas * txGas,
-    } as const
+    const chain = Hooks.useChain(porto, { chainId })!
+    const feeToken = FeeToken.useFetch({
+      address: paymentToken,
+      chainId: chain.id,
+    })
 
-    const config = paymentToken
-      ? {
-          ...feeToken.data,
-          value: paymentMaxAmount,
-        }
-      : nativeConfig
+    const fee = React.useMemo(() => {
+      if (!nativeFeeEstimate || !txGas || !paymentMaxAmount || !feeToken.data)
+        return undefined
 
-    const fee = Price.from(config)
-    const native = Price.from(nativeConfig)
+      const nativeConfig = {
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: chain.nativeCurrency.decimals,
+        symbol: chain.nativeCurrency.symbol,
+        value: nativeFeeEstimate.maxFeePerGas * txGas,
+      } as const
+
+      const config = paymentToken
+        ? {
+            ...feeToken.data,
+            value: paymentMaxAmount,
+          }
+        : nativeConfig
+
+      const fee = Price.from(config)
+      const native = Price.from(nativeConfig)
+      return {
+        ...fee,
+        native,
+      }
+    }, [
+      chain.nativeCurrency.decimals,
+      chain.nativeCurrency.symbol,
+      feeToken.data,
+      nativeFeeEstimate,
+      txGas,
+      paymentMaxAmount,
+      paymentToken,
+    ])
+
+    if (!fee) return undefined
+    if (!ttl) return undefined
     return {
-      ...fee,
-      native,
+      fee,
+      ttl,
     }
-  }, [
-    chain.nativeCurrency.decimals,
-    chain.nativeCurrency.symbol,
-    feeToken.data,
-    nativeFeeEstimate,
-    txGas,
-    paymentMaxAmount,
-    paymentToken,
-  ])
-
-  if (!fee) return undefined
-  if (!ttl) return undefined
-  return {
-    fee,
-    ttl,
-  }
-}
-
-export namespace useQuote {
-  export type Parameters = {
-    chainId?: number | undefined
-    context: unknown
   }
 }

--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -239,7 +239,9 @@ export namespace ActionRequest {
   export namespace AssetDiff {
     export type Props = {
       address: Address.Address
-      assetDiff: Rpc.wallet_prepareCalls.Response['capabilities']['assetDiff']
+      assetDiff: NonNullable<
+        Rpc.wallet_prepareCalls.Response['capabilities']
+      >['assetDiff']
     }
   }
   export function Details(props: Details.Props) {

--- a/apps/dialog/src/routes/-components/GrantAdmin.tsx
+++ b/apps/dialog/src/routes/-components/GrantAdmin.tsx
@@ -7,6 +7,7 @@ import { Hooks } from 'porto/remote'
 import { CheckBalance } from '~/components/CheckBalance'
 import * as Dialog from '~/lib/Dialog'
 import { porto } from '~/lib/Porto'
+import * as Relay from '~/lib/Relay'
 import { Layout } from '~/routes/-components/Layout'
 import { StringFormatter } from '~/utils'
 import TriangleAlert from '~icons/lucide/triangle-alert'
@@ -19,7 +20,7 @@ export function GrantAdmin(props: GrantAdmin.Props) {
   const account = Hooks.useAccount(porto)
   const origin = Dialog.useStore((state) => state.referrer?.origin)
 
-  const prepareCallsQuery = ActionRequest.usePrepareCalls({
+  const prepareCallsQuery = Relay.usePrepareCalls({
     authorizeKeys: [Key.from(authorizeKey)],
     feeToken,
   })

--- a/apps/dialog/src/routes/-components/GrantAdmin.tsx
+++ b/apps/dialog/src/routes/-components/GrantAdmin.tsx
@@ -2,19 +2,18 @@ import { Button } from '@porto/apps/components'
 import { useQuery } from '@tanstack/react-query'
 import { Hex } from 'ox'
 import type * as Address from 'ox/Address'
-import { Key, Relay } from 'porto/internal'
+import { Account, Key, Relay } from 'porto/internal'
 import { Hooks } from 'porto/remote'
-import * as React from 'react'
 
+import { CheckBalance } from '~/components/CheckBalance'
 import * as Dialog from '~/lib/Dialog'
 import * as FeeToken from '~/lib/FeeToken'
 import { porto } from '~/lib/Porto'
-import * as Price from '~/lib/Price'
 import { Layout } from '~/routes/-components/Layout'
 import { StringFormatter } from '~/utils'
 import TriangleAlert from '~icons/lucide/triangle-alert'
 import WalletIcon from '~icons/lucide/wallet-cards'
-import * as ActionRequest from './ActionRequest'
+import { ActionRequest } from './ActionRequest'
 
 export function GrantAdmin(props: GrantAdmin.Props) {
   const { authorizeKey, loading, onApprove, onReject } = props
@@ -28,24 +27,20 @@ export function GrantAdmin(props: GrantAdmin.Props) {
   })
   const origin = Dialog.useStore((state) => state.referrer?.origin)
 
-  const prepareCalls = useQuery({
-    enabled: !!account && !!chain,
+  const prepareCallsQuery = useQuery({
+    enabled: !!account,
     queryFn: async () => {
-      if (!account || !chain) throw new Error('Account and chain required')
+      if (!account) throw new Error('account is required')
 
-      const adminKey = account.keys?.find(
-        (key) => key.role === 'admin' && key.privateKey,
-      )
-      if (!adminKey) throw new Error('Admin key not found')
+      const key = Account.getKey(account, { role: 'admin' })
+      if (!key) throw new Error('key not found')
 
-      const { context } = await Relay.prepareCalls(client, {
+      return await Relay.prepareCalls(client, {
         account,
         authorizeKeys: [Key.from(authorizeKey)],
         feeToken: feeToken?.address,
-        key: adminKey,
+        key,
       })
-
-      return context
     },
     queryKey: [
       'prepareCalls',
@@ -56,148 +51,106 @@ export function GrantAdmin(props: GrantAdmin.Props) {
     ],
   })
 
-  const quote = ActionRequest.useQuote(porto, {
-    chainId: chain?.id,
-    context: prepareCalls.data,
-  })
-
-  const fiatFee = Price.useFiatPrice({
-    value: quote?.fee.native.value,
-  })
-
-  const status = React.useMemo(() => {
-    if (prepareCalls.isPending) return 'pending'
-    if (prepareCalls.isError) return 'error'
-    if (prepareCalls.isSuccess) return 'success'
-    return 'idle'
-  }, [prepareCalls.isError, prepareCalls.isPending, prepareCalls.isSuccess])
-
-  const warning = status === 'error'
+  const quote = prepareCallsQuery.data?.capabilities.quote
 
   return (
-    <Layout loading={loading} loadingTitle="Authorizing...">
-      <Layout.Header>
-        <Layout.Header.Default
-          content={
-            <div>
-              You will allow this account to recover your passkey if it is ever
-              lost.
-            </div>
-          }
-          icon={warning ? TriangleAlert : undefined}
-          title="Add backup method"
-          variant={warning ? 'warning' : 'default'}
-        />
-      </Layout.Header>
-      <Layout.Content>
-        <div className="space-y-3">
-          {status === 'error' && (
-            <div className="rounded-lg bg-warningTint px-3 py-2 text-warning">
-              <div className="font-medium text-[14px]">Error</div>
-              <div className="space-y-2 text-[14px] text-primary">
-                <p>
-                  An error occurred while calculating fees. This may be due to
-                  network issues or insufficient funds.
-                </p>
-                <p>
-                  Contact{' '}
-                  <span className="font-medium">{origin?.hostname}</span> if
-                  this issue persists.
-                </p>
+    <CheckBalance onReject={onReject} query={prepareCallsQuery}>
+      <Layout loading={loading} loadingTitle="Authorizing...">
+        <Layout.Header>
+          <Layout.Header.Default
+            content={
+              <div>
+                You will allow this account to recover your passkey if it is
+                ever lost.
               </div>
-            </div>
-          )}
-
-          <div className="flex items-center justify-center rounded-md bg-surface p-2">
-            {account?.address && (
-              <div className="flex items-center gap-2">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-jade4">
-                  <WalletIcon className="h-4 w-4 text-jade9" />
+            }
+            icon={prepareCallsQuery.isError ? TriangleAlert : undefined}
+            title="Add backup method"
+            variant={prepareCallsQuery.isError ? 'warning' : 'default'}
+          />
+        </Layout.Header>
+        <Layout.Content>
+          <div className="space-y-3">
+            {prepareCallsQuery.isError && (
+              <div className="rounded-lg bg-warningTint px-3 py-2 text-warning">
+                <div className="font-medium text-[14px]">Error</div>
+                <div className="space-y-2 text-[14px] text-primary">
+                  <p>
+                    An error occurred while calculating fees. This may be due to
+                    network issues or insufficient funds.
+                  </p>
+                  <p>
+                    Contact{' '}
+                    <span className="font-medium">{origin?.hostname}</span> if
+                    this issue persists.
+                  </p>
                 </div>
-                <span className="font-medium font-mono text-base">
-                  {StringFormatter.truncate(authorizeKey.publicKey)}
-                </span>
               </div>
             )}
-          </div>
-        </div>
-      </Layout.Content>
 
-      <Layout.Content>
-        <p className="mb-1 text-[14px] text-secondary">More details</p>
-        <div className="space-y-2 rounded-md bg-surface p-3">
-          <div className="flex h-[38px] items-start justify-between">
-            <span className="text-[14px] text-secondary leading-4">
-              Fees (est.)
-            </span>
-            <div className="text-right text-[14px]">
-              {fiatFee.isFetched ? (
-                <>
-                  <div className="font-medium leading-4">
-                    {fiatFee.data?.display}
+            <div className="flex items-center justify-center rounded-md bg-surface p-2">
+              {account?.address && (
+                <div className="flex items-center gap-2">
+                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-jade4">
+                    <WalletIcon className="h-4 w-4 text-jade9" />
                   </div>
-                  {quote?.fee && (
-                    <div>
-                      <span className="text-secondary text-xs">
-                        {quote.fee.display}
-                      </span>
-                    </div>
-                  )}
-                </>
-              ) : (
-                <span className="font-medium text-secondary">Loading...</span>
+                  <span className="font-medium font-mono text-base">
+                    {StringFormatter.truncate(authorizeKey.publicKey)}
+                  </span>
+                </div>
               )}
             </div>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-[14px] text-secondary">Duration (est.)</span>
-            <span className="font-medium text-[14px]">2 seconds</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-[14px] text-secondary">Network</span>
-            <span className="font-medium text-[14px]">{chain?.name}</span>
-          </div>
-        </div>
-      </Layout.Content>
 
-      <Layout.Footer>
-        <Layout.Footer.Actions>
-          {status === 'error' ? (
-            <>
-              <Button className="flex-1" onClick={onReject} type="button">
-                Cancel
-              </Button>
-              <Button
-                className="flex-1"
-                onClick={onApprove}
-                type="button"
-                variant="default"
-              >
-                Attempt anyway
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button className="flex-1" onClick={onReject} type="button">
-                Cancel
-              </Button>
-              <Button
-                className="flex-1"
-                onClick={onApprove}
-                type="button"
-                variant="accent"
-              >
-                Add
-              </Button>
-            </>
+            {quote && (
+              <>
+                <p className="mb-1 text-[14px] text-secondary">More details</p>
+                <div className="rounded-md bg-surface p-3">
+                  <ActionRequest.Details quote={quote} />
+                </div>
+              </>
+            )}
+          </div>
+        </Layout.Content>
+
+        <Layout.Footer>
+          <Layout.Footer.Actions>
+            {prepareCallsQuery.isError ? (
+              <>
+                <Button className="flex-1" onClick={onReject} type="button">
+                  Cancel
+                </Button>
+                <Button
+                  className="flex-1"
+                  onClick={onApprove}
+                  type="button"
+                  variant="default"
+                >
+                  Attempt anyway
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button className="flex-1" onClick={onReject} type="button">
+                  Cancel
+                </Button>
+                <Button
+                  className="flex-1"
+                  onClick={onApprove}
+                  type="button"
+                  variant="accent"
+                >
+                  Add
+                </Button>
+              </>
+            )}
+          </Layout.Footer.Actions>
+
+          {account?.address && (
+            <Layout.Footer.Account address={account.address} />
           )}
-        </Layout.Footer.Actions>
-
-        {account?.address && (
-          <Layout.Footer.Account address={account.address} />
-        )}
-      </Layout.Footer>
-    </Layout>
+        </Layout.Footer>
+      </Layout>
+    </CheckBalance>
   )
 }
 

--- a/apps/dialog/src/routes/dialog/eth_sendTransaction.tsx
+++ b/apps/dialog/src/routes/dialog/eth_sendTransaction.tsx
@@ -35,7 +35,6 @@ function RouteComponent() {
       loading={respond.isPending}
       onApprove={() => respond.mutate()}
       onReject={() => Actions.reject(porto, request)}
-      request={request}
     />
   )
 }

--- a/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
@@ -36,7 +36,6 @@ function RouteComponent() {
       loading={respond.isPending}
       onApprove={() => respond.mutate()}
       onReject={() => Actions.reject(porto, request!)}
-      request={request}
     />
   )
 }

--- a/apps/~internal/lib/Query.ts
+++ b/apps/~internal/lib/Query.ts
@@ -1,5 +1,5 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
-import { MutationCache, QueryClient } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 
 export const client: QueryClient = new QueryClient({
   defaultOptions: {
@@ -9,16 +9,6 @@ export const client: QueryClient = new QueryClient({
       retry: 0,
     },
   },
-  /**
-   * @see https://tkdodo.eu/blog/react-query-error-handling#putting-it-all-together
-   */
-  mutationCache: new MutationCache({
-    onSettled: () => {
-      if (client.isMutating() === 1) {
-        return client.invalidateQueries()
-      }
-    },
-  }),
 })
 
 export const persister = createSyncStoragePersister({

--- a/src/core/internal/account.ts
+++ b/src/core/internal/account.ts
@@ -96,7 +96,7 @@ export function getKey(
   account: Account,
   parameters: getKey.Parameters,
 ): Key.Key | undefined {
-  const { key } = parameters
+  const { key, role } = parameters
 
   // Extract from `key` parameter.
   if (typeof key === 'object') return key
@@ -104,7 +104,9 @@ export function getKey(
   // Extract from `account.keys` (with optional `key` index).
   if (account.keys && account.keys.length > 0) {
     if (typeof key === 'number') return account.keys[key]
-    return account.keys.find((key) => key.privateKey)
+    return account.keys.find(
+      (key) => key.privateKey && (!role || key.role === role),
+    )
   }
 
   return undefined
@@ -113,6 +115,7 @@ export function getKey(
 export declare namespace getKey {
   type Parameters = {
     key?: number | Key.Key | undefined
+    role?: Key.Key['role'] | undefined
   }
 }
 

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -117,6 +117,10 @@ export type Mode = {
     }) => Promise<{
       /** Account to execute the calls with. */
       account: Account.Account
+      /** Capabilities. */
+      capabilities?:
+        | Rpc.wallet_prepareCalls.Response['capabilities']
+        | undefined
       /** Context for `sendPreparedCalls` */
       context: PrepareCallsContext
       /** Key that will sign over the digest. */

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -296,16 +296,20 @@ export function relay(parameters: relay.Parameters = {}) {
 
         const feeToken = await resolveFeeToken(internal, parameters)
 
-        const { context, digest } = await Relay.prepareCalls(client, {
-          account,
-          calls,
-          feeToken: feeToken.address,
-          key,
-          pre,
-        })
+        const { capabilities, context, digest } = await Relay.prepareCalls(
+          client,
+          {
+            account,
+            calls,
+            feeToken: feeToken.address,
+            key,
+            pre,
+          },
+        )
 
         return {
           account,
+          capabilities,
           context: {
             ...context,
             account,

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -821,6 +821,7 @@ export function from<
             })
 
           return Schema.Encode(Rpc.wallet_prepareCalls.Response, {
+            capabilities: rest.capabilities,
             chainId: Hex.fromNumber(client.chain.id),
             context: {
               ...rest.context,

--- a/src/core/internal/relay.ts
+++ b/src/core/internal/relay.ts
@@ -293,7 +293,7 @@ export async function prepareCalls<const calls extends readonly unknown[]>(
     },
   })
   return {
-    capabilities,
+    capabilities: { ...capabilities, quote: context },
     context: { ...context, key },
     digest,
   } as const
@@ -331,7 +331,9 @@ export namespace prepareCalls {
   } & Omit<Capabilities.meta.Request, 'keyHash'>
 
   export type ReturnType = {
-    capabilities: Actions.prepareCalls.ReturnType['capabilities']
+    capabilities: Actions.prepareCalls.ReturnType['capabilities'] & {
+      quote: Actions.prepareCalls.ReturnType['context']
+    }
     context: Actions.prepareCalls.ReturnType['context'] & {
       key: Parameters['key']
     }

--- a/src/core/internal/relay/typebox/rpc.ts
+++ b/src/core/internal/relay/typebox/rpc.ts
@@ -283,9 +283,11 @@ export namespace wallet_prepareCalls {
           Primitive.Address,
           Type.Array(
             Type.Object({
-              address: Primitive.Address,
+              address: Schema.Optional(
+                Type.Union([Primitive.Address, Type.Null()]),
+              ),
               decimals: Type.Number(),
-              name: Type.String(),
+              name: Schema.Optional(Type.Union([Type.String(), Type.Null()])),
               symbol: Type.String(),
               value: Type.Transform(Type.String())
                 .Decode((value) => BigInt(value))

--- a/src/core/internal/relay/typebox/rpc.ts
+++ b/src/core/internal/relay/typebox/rpc.ts
@@ -276,6 +276,25 @@ export namespace wallet_prepareCalls {
 
   /** Capabilities for `wallet_prepareCalls` response. */
   export const ResponseCapabilities = Type.Object({
+    /** Asset diff. */
+    assetDiff: Schema.Optional(
+      Type.Array(
+        Type.Tuple([
+          Primitive.Address,
+          Type.Array(
+            Type.Object({
+              address: Primitive.Address,
+              decimals: Type.Number(),
+              name: Type.String(),
+              symbol: Type.String(),
+              value: Type.Transform(Type.String())
+                .Decode((value) => BigInt(value))
+                .Encode((value) => value.toString()),
+            }),
+          ),
+        ]),
+      ),
+    ),
     /** Keys authorized on the account. */
     authorizeKeys: Schema.Optional(
       Type.Union([C.authorizeKeys.Response, Type.Null()]),
@@ -378,6 +397,7 @@ export namespace wallet_feeTokens {
       Type.Object({
         address: Primitive.Address,
         decimals: Type.Number(),
+        nativeRate: Schema.Optional(Primitive.BigInt),
         symbol: Type.String(),
       }),
     ),

--- a/src/core/internal/typebox/request.ts
+++ b/src/core/internal/typebox/request.ts
@@ -1,3 +1,5 @@
+import * as Quote from '../relay/typebox/quote.js'
+import * as Rpc_relay from '../relay/typebox/rpc.js'
 import * as C from './capabilities.js'
 import * as Key from './key.js'
 import * as Permissions from './permissions.js'
@@ -499,7 +501,12 @@ export namespace wallet_prepareCalls {
   export type Request = Schema.StaticDecode<typeof Request>
 
   export const Response = Type.Object({
-    capabilities: Schema.Optional(Type.Record(Type.String(), Type.Any())),
+    capabilities: Type.Intersect([
+      Rpc_relay.wallet_prepareCalls.ResponseCapabilities,
+      Type.Object({
+        quote: Schema.Optional(Quote.Quote),
+      }),
+    ]),
     chainId: Primitive.Hex,
     context: Type.Object({
       account: Type.Object({

--- a/src/core/internal/typebox/request.ts
+++ b/src/core/internal/typebox/request.ts
@@ -501,12 +501,14 @@ export namespace wallet_prepareCalls {
   export type Request = Schema.StaticDecode<typeof Request>
 
   export const Response = Type.Object({
-    capabilities: Type.Intersect([
-      Rpc_relay.wallet_prepareCalls.ResponseCapabilities,
-      Type.Object({
-        quote: Schema.Optional(Quote.Quote),
-      }),
-    ]),
+    capabilities: Schema.Optional(
+      Type.Intersect([
+        Rpc_relay.wallet_prepareCalls.ResponseCapabilities,
+        Type.Object({
+          quote: Schema.Optional(Quote.Quote),
+        }),
+      ]),
+    ),
     chainId: Primitive.Hex,
     context: Type.Object({
       account: Type.Object({


### PR DESCRIPTION
This PR refactors a few things:

- Use new `assetDiff` capability from Relay, instead of our own via `eth_simulateV1`.
- Adds `CheckBalance` HoC to assert if the account has a sufficient balance to pay for fees.
- Refactors `prepareCalls` queries inside `ActionRequest` & `GrantAdmin` into a reusable `usePrepareCalls` Hook.