### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/promote-apps.yml
+++ b/.github/workflows/promote-apps.yml
@@ -12,7 +12,7 @@ jobs:
         matrix:
           app: [dialog, docs, manage, playground, wagmi]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
Maintenance update to actions/checkout@v4 to align with the current runner stack; nothing else modified.