### PR TITLE
refactor: permission fee limits

### DIFF
--- a/apps/docs/pages/sdk/api/porto/create.mdx
+++ b/apps/docs/pages/sdk/api/porto/create.mdx
@@ -99,6 +99,13 @@ List of supported chains.
 See [`Chains`](#TODO) for a list of Porto-supported chains.
 :::
 
+### feeToken
+
+- **Type:** `"0x${string}"`
+- **Default:** `"0x0000000000000000000000000000000000000000"` (ETH)
+
+Token to use to pay for fees. Defaults to ETH.
+
 ### mode
 
 - **Type:** `Mode.Mode{:ts}`

--- a/apps/~internal/lib/PortoConfig.ts
+++ b/apps/~internal/lib/PortoConfig.ts
@@ -9,14 +9,12 @@ const config = {
   anvil: {
     chains: [Chains.anvil],
     mode: Mode.rpcServer({
-      feeToken: 'EXP',
       persistPreCalls: false,
     }),
   },
   dev: {
     chains: [Chains.portoDev],
     mode: Mode.rpcServer({
-      feeToken: 'EXP',
       persistPreCalls: false,
     }),
     storageKey: 'porto.store.dev',

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -10,13 +10,13 @@ import * as Chains from './Chains.js'
 import type * as internal from './internal/porto.js'
 import * as Provider from './internal/provider.js'
 import type { ExactPartial, OneOf } from './internal/types.js'
-import * as Key from './Key.js'
 import * as Mode from './Mode.js'
 import * as Storage from './Storage.js'
 
 export const defaultConfig = {
   announceProvider: true,
   chains: [Chains.baseSepolia],
+  feeToken: 'EXP',
   mode: typeof window !== 'undefined' ? Mode.dialog() : Mode.rpcServer(),
   storage: typeof window !== 'undefined' ? Storage.idb() : Storage.memory(),
   storageKey: 'porto.store',
@@ -55,6 +55,7 @@ export function create(
     announceProvider:
       parameters.announceProvider ?? defaultConfig.announceProvider,
     chains,
+    feeToken: parameters.feeToken ?? defaultConfig.feeToken,
     mode: parameters.mode ?? defaultConfig.mode,
     storage: parameters.storage ?? defaultConfig.storage,
     storageKey: parameters.storageKey ?? defaultConfig.storageKey,
@@ -67,8 +68,7 @@ export function create(
         (_) => ({
           accounts: [],
           chainId: config.chains[0].id,
-          feeToken: undefined,
-          permissionFeeSpendLimit: undefined,
+          feeToken: config.feeToken,
           requestQueue: [],
         }),
         {
@@ -88,7 +88,6 @@ export function create(
               })),
               chainId: state.chainId,
               feeToken: state.feeToken,
-              permissionFeeSpendLimit: state.permissionFeeSpendLimit,
             } as unknown as State
           },
           storage: config.storage,
@@ -153,6 +152,11 @@ export type Config<
    */
   chains: chains
   /**
+   * Token to use to pay for fees.
+   * @default 'ETH'
+   */
+  feeToken?: State['feeToken'] | undefined
+  /**
    * Mode to use.
    * @default Mode.dialog()
    */
@@ -195,10 +199,7 @@ export type State<
 > = {
   accounts: readonly Account.Account[]
   chainId: chains[number]['id']
-  feeToken: string | undefined
-  permissionFeeSpendLimit:
-    | Record<string, Pick<Key.SpendPermission, 'limit' | 'period'>>
-    | undefined
+  feeToken: 'ETH' | 'EXP' | undefined
   requestQueue: readonly QueuedRequest[]
 }
 

--- a/src/core/RpcServer.test.ts
+++ b/src/core/RpcServer.test.ts
@@ -717,67 +717,6 @@ describe.each([
         }),
       ).toBe(100n)
     })
-
-    test('batch authorize + spend', async () => {
-      // 1. Initialize Account with Admin Key.
-      const key = Key.createHeadlessWebAuthnP256()
-      const account = await initializeAccount(client, {
-        keys: [key],
-      })
-
-      // 2. Authorize a new Session Key.
-      const newKey = Key.createP256({
-        permissions: {
-          calls: [{ to: exp1Address }],
-          spend: [
-            {
-              limit: Value.fromEther('110'),
-              period: 'week',
-              token: exp1Address,
-            },
-          ],
-        },
-        role: 'session',
-      })
-
-      const alice = Hex.random(20)
-
-      // 3. Spend 5 EXP tokens to Account with new Session Key.
-      const { id } = await Rpc.sendCalls(client, {
-        account,
-        calls: [
-          {
-            abi: exp1Abi,
-            args: [alice, Value.fromEther('100')],
-            functionName: 'transfer',
-            to: exp1Address,
-          },
-        ],
-        feeToken: exp1Address,
-        key: newKey,
-        preCalls: [
-          {
-            authorizeKeys: [newKey],
-            key,
-          },
-        ],
-      })
-      expect(id).toBeDefined()
-
-      await waitForCallsStatus(client, {
-        id,
-      })
-
-      // 4. Verify that Account has 100 ERC20 tokens.
-      expect(
-        await readContract(client, {
-          abi: exp1Abi,
-          address: exp1Address,
-          args: [alice],
-          functionName: 'balanceOf',
-        }),
-      ).toBe(Value.fromEther('100'))
-    })
   })
 
   describe('behavior: call permissions', () => {

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -76,6 +76,13 @@ export type Mode = {
       Typebox.Static<typeof RpcSchema.wallet_getCallsStatus.Response>
     >
 
+    getPermissions: (parameters: {
+      /** Account to authorize the keys for. */
+      account: Account.Account
+      /** Internal properties. */
+      internal: ActionsInternal
+    }) => Promise<RpcSchema.experimental_getPermissions.Response>
+
     grantAdmin: (parameters: {
       /** Account to authorize the keys for. */
       account: Account.Account

--- a/src/core/internal/modes/contract.ts
+++ b/src/core/internal/modes/contract.ts
@@ -16,6 +16,7 @@ import * as DelegationContract from '../_generated/contracts/Delegation.js'
 import * as Call from '../call.js'
 import * as Delegation from '../delegation.js'
 import * as Mode from '../mode.js'
+import * as Permissions from '../permissions.js'
 import * as PermissionsRequest from '../permissionsRequest.js'
 import type * as Porto from '../porto.js'
 
@@ -203,6 +204,17 @@ export function contract(parameters: contract.Parameters = {}) {
           receipts: [receipt],
           status: receipt.status === '0x0' ? 400 : 200,
         }
+      },
+
+      async getPermissions(parameters) {
+        const { account, internal } = parameters
+        const { client } = internal
+
+        if (!account.keys) return []
+        return Permissions.getActiveFromKeys(account.keys, {
+          address: account.address,
+          chainId: client.chain.id,
+        })
       },
 
       async grantAdmin(parameters) {

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -237,6 +237,23 @@ export function dialog(parameters: dialog.Parameters = {}) {
         return result
       },
 
+      async getPermissions(parameters) {
+        const { internal } = parameters
+        const { store, request } = internal
+
+        if (request.method !== 'experimental_getPermissions')
+          throw new Error(
+            'Cannot get permissions for method: ' + request.method,
+          )
+
+        const provider = getProvider(store)
+        const result = await provider.request(request)
+        return Typebox.Decode(
+          RpcSchema_porto.experimental_getPermissions.Response,
+          result,
+        )
+      },
+
       async grantAdmin(parameters) {
         const { internal } = parameters
         const { request, store } = internal

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -695,6 +695,7 @@ export function resolvePermissions(
       if (Address.isEqual(token, feeToken.address))
         return {
           ...spend,
+          // Subtract fee limit from the spend limit.
           limit: spend.limit - ((feeLimit as any)[feeToken.symbol] ?? 0n),
         }
       return spend
@@ -727,6 +728,7 @@ export function resolvePermissionsRequest(
     if (Address.isEqual(token, feeToken.address))
       return {
         ...spend,
+        // Add fee limit to the spend limit.
         limit: spend.limit + ((feeLimit as any)[feeToken.symbol] ?? 0n),
       }
     return spend

--- a/src/core/internal/permissions.ts
+++ b/src/core/internal/permissions.ts
@@ -31,6 +31,33 @@ export declare namespace fromKey {
   }
 }
 
+export function getActiveFromKeys(
+  keys: readonly Key.Key[],
+  options: getActiveFromKeys.Options,
+): readonly Permissions[] {
+  const { address, chainId } = options
+
+  return keys
+    .map((key) => {
+      if (key.role !== 'session') return undefined
+      if (key.expiry > 0 && key.expiry < BigInt(Math.floor(Date.now() / 1000)))
+        return undefined
+      try {
+        return fromKey(key, { address, chainId })
+      } catch {
+        return undefined
+      }
+    })
+    .filter(Boolean) as never
+}
+
+export declare namespace getActiveFromKeys {
+  export type Options = {
+    address: Address.Address
+    chainId?: number | undefined
+  }
+}
+
 export function toKey(permissions: Permissions): Key.Key {
   const { expiry, key } = permissions
   return Key.from({

--- a/src/core/internal/permissionsRequest.ts
+++ b/src/core/internal/permissionsRequest.ts
@@ -30,43 +30,12 @@ export declare namespace fromKey {
 
 export async function toKey(
   request: PermissionsRequest | undefined,
-  options?: toKey.Options,
 ): Promise<Key.Key | undefined> {
   if (!request) return undefined
 
-  const { feeToken } = options ?? {}
-
-  const feeSpendPermission = feeToken?.permissionSpendLimit
-    ? ({
-        ...feeToken.permissionSpendLimit,
-        token: feeToken.address,
-      } satisfies Key.SpendPermission)
-    : undefined
-
   const expiry = request.expiry ?? 0
   const type = request.key?.type ?? 'secp256k1'
-
-  // TODO: remove once spend permissions on fees are supported. this is a workaround
-  //       and it definitely not prod ready.
-  const spendPermissions_tmp = request.permissions?.spend?.map((permission) => {
-    if (
-      feeSpendPermission?.token &&
-      permission.token &&
-      Address.isEqual(permission.token, feeSpendPermission.token)
-    ) {
-      return {
-        ...permission,
-        limit: permission.limit + feeSpendPermission.limit,
-      }
-    }
-    return permission
-  })
-  const permissions = {
-    ...request.permissions,
-    ...(spendPermissions_tmp && {
-      spend: spendPermissions_tmp,
-    }),
-  }
+  const permissions = request.permissions
   const publicKey = request?.key?.publicKey ?? '0x'
 
   const key = Key.from({
@@ -82,26 +51,4 @@ export async function toKey(
     ...key,
     role: 'session',
   })
-}
-
-export declare namespace toKey {
-  export type Options = {
-    /**
-     * Fee token to use for permission requests.
-     */
-    feeToken?:
-      | {
-          /**
-           * Fee token address.
-           */
-          address?: Address.Address | undefined
-          /**
-           * Spending limit to pay for fees on this key.
-           */
-          permissionSpendLimit?:
-            | Pick<Key.SpendPermission, 'limit' | 'period'>
-            | undefined
-        }
-      | undefined
-  }
 }

--- a/src/remote/Porto.ts
+++ b/src/remote/Porto.ts
@@ -38,6 +38,12 @@ export const defaultConfig = {
       },
     },
     {
+      method: 'experimental_getPermissions',
+      modes: {
+        headless: true,
+      },
+    },
+    {
       method: 'experimental_grantAdmin',
       modes: {
         dialog: {

--- a/test/src/porto.ts
+++ b/test/src/porto.ts
@@ -29,10 +29,7 @@ const rpcUrl = Anvil.enabled
 export function getPorto(
   parameters: {
     mode?: (parameters: {
-      feeToken?: Mode.rpcServer.Parameters['feeToken'] | undefined
-      permissionFeeSpendLimit?:
-        | Mode.rpcServer.Parameters['permissionFeeSpendLimit']
-        | undefined
+      permissionsFeeLimit: Record<string, bigint>
       mock: boolean
     }) => Mode.Mode | undefined
   } = {},
@@ -41,13 +38,9 @@ export function getPorto(
   const porto = Porto.create({
     chains: [chain],
     mode: mode({
-      feeToken: 'EXP',
       mock: true,
-      permissionFeeSpendLimit: {
-        EXP: {
-          limit: Value.fromEther('100'),
-          period: 'day',
-        },
+      permissionsFeeLimit: {
+        EXP: Value.fromEther('100'),
       },
     }),
     storage: Storage.memory(),


### PR DESCRIPTION
Fixes a UI issue where an end-user would see the "fee" spend limit added onto the "execution" spend limit (e.g. "11 EXP per day" instead of "10 EXP per day").