### PR TITLE
refactor: permissions fee limit

### DIFF
--- a/apps/docs/pages/sdk/api/porto/create.mdx
+++ b/apps/docs/pages/sdk/api/porto/create.mdx
@@ -99,6 +99,13 @@ List of supported chains.
 See [`Chains`](#TODO) for a list of Porto-supported chains.
 :::
 
+### feeToken
+
+- **Type:** `"0x${string}"`
+- **Default:** `"0x0000000000000000000000000000000000000000"` (ETH)
+
+Token to use to pay for fees. Defaults to ETH.
+
 ### mode
 
 - **Type:** `Mode.Mode{:ts}`

--- a/apps/~internal/lib/PortoConfig.ts
+++ b/apps/~internal/lib/PortoConfig.ts
@@ -9,14 +9,12 @@ const config = {
   anvil: {
     chains: [Chains.anvil],
     mode: Mode.rpcServer({
-      feeToken: 'EXP',
       persistPreCalls: false,
     }),
   },
   dev: {
     chains: [Chains.portoDev],
     mode: Mode.rpcServer({
-      feeToken: 'EXP',
       persistPreCalls: false,
     }),
     storageKey: 'porto.store.dev',

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -10,13 +10,13 @@ import * as Chains from './Chains.js'
 import type * as internal from './internal/porto.js'
 import * as Provider from './internal/provider.js'
 import type { ExactPartial, OneOf } from './internal/types.js'
-import * as Key from './Key.js'
 import * as Mode from './Mode.js'
 import * as Storage from './Storage.js'
 
 export const defaultConfig = {
   announceProvider: true,
   chains: [Chains.baseSepolia],
+  feeToken: 'EXP',
   mode: typeof window !== 'undefined' ? Mode.dialog() : Mode.rpcServer(),
   storage: typeof window !== 'undefined' ? Storage.idb() : Storage.memory(),
   storageKey: 'porto.store',
@@ -55,6 +55,7 @@ export function create(
     announceProvider:
       parameters.announceProvider ?? defaultConfig.announceProvider,
     chains,
+    feeToken: parameters.feeToken ?? defaultConfig.feeToken,
     mode: parameters.mode ?? defaultConfig.mode,
     storage: parameters.storage ?? defaultConfig.storage,
     storageKey: parameters.storageKey ?? defaultConfig.storageKey,
@@ -67,8 +68,7 @@ export function create(
         (_) => ({
           accounts: [],
           chainId: config.chains[0].id,
-          feeToken: undefined,
-          permissionFeeSpendLimit: undefined,
+          feeToken: config.feeToken,
           requestQueue: [],
         }),
         {
@@ -88,7 +88,6 @@ export function create(
               })),
               chainId: state.chainId,
               feeToken: state.feeToken,
-              permissionFeeSpendLimit: state.permissionFeeSpendLimit,
             } as unknown as State
           },
           storage: config.storage,
@@ -153,6 +152,11 @@ export type Config<
    */
   chains: chains
   /**
+   * Token to use to pay for fees.
+   * @default 'ETH'
+   */
+  feeToken?: State['feeToken'] | undefined
+  /**
    * Mode to use.
    * @default Mode.dialog()
    */
@@ -195,10 +199,7 @@ export type State<
 > = {
   accounts: readonly Account.Account[]
   chainId: chains[number]['id']
-  feeToken: string | undefined
-  permissionFeeSpendLimit:
-    | Record<string, Pick<Key.SpendPermission, 'limit' | 'period'>>
-    | undefined
+  feeToken: 'ETH' | 'EXP' | undefined
   requestQueue: readonly QueuedRequest[]
 }
 

--- a/src/core/RpcServer.ts
+++ b/src/core/RpcServer.ts
@@ -443,7 +443,7 @@ export async function prepareUpgradeAccount(
   client: Client,
   parameters: prepareUpgradeAccount.Parameters,
 ) {
-  const { address, feeToken } = parameters
+  const { address, feeToken, sessionFeeLimit } = parameters
 
   const { contracts } = await Actions.getCapabilities(client)
 
@@ -464,6 +464,7 @@ export async function prepareUpgradeAccount(
       key.role === 'session'
         ? resolvePermissions(key, {
             feeToken,
+            sessionFeeLimit,
           })
         : undefined
     return Key.toRpcServer(
@@ -527,6 +528,8 @@ export declare namespace prepareUpgradeAccount {
     keys:
       | readonly Key.Key[]
       | ((p: { ids: readonly Hex.Hex[] }) => MaybePromise<readonly Key.Key[]>)
+    /** Session fee limit. */
+    sessionFeeLimit?: bigint | undefined
   }
 
   export type ReturnType = Omit<

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -20,7 +20,7 @@ import type { Client } from '../porto.js'
 import * as PreCalls from '../preCalls.js'
 import * as RpcServer_viem from '../viem/actions.js'
 
-export const defaultSessionFeeLimit = {
+export const defaultPermissionsFeeLimit = {
   ETH: Value.fromEther('0.0001'),
   EXP: Value.fromEther('1'),
 }
@@ -37,7 +37,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
   const config = parameters
   const {
     mock,
-    sessionFeeLimit = defaultSessionFeeLimit,
+    permissionsFeeLimit = defaultPermissionsFeeLimit,
     persistPreCalls = true,
   } = config
 
@@ -84,7 +84,9 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
 
         if (id) id_internal = id
 
-        const feeToken = await resolveFeeToken(internal, { sessionFeeLimit })
+        const feeToken = await resolveFeeToken(internal, {
+          permissionsFeeLimit,
+        })
         const authorizeKey = await PermissionsRequest.toKey(permissions)
 
         const preCalls = authorizeKey
@@ -184,7 +186,9 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           config: { storage },
         } = internal
 
-        const feeToken = await resolveFeeToken(internal, { sessionFeeLimit })
+        const feeToken = await resolveFeeToken(internal, {
+          permissionsFeeLimit,
+        })
 
         // Parse permissions request into a structured key.
         const authorizeKey = await PermissionsRequest.toKey(permissions)
@@ -243,7 +247,9 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           return { credentialId, keyId }
         })()
 
-        const feeToken = await resolveFeeToken(internal, { sessionFeeLimit })
+        const feeToken = await resolveFeeToken(internal, {
+          permissionsFeeLimit,
+        })
 
         const [accounts, authorizeKey] = await Promise.all([
           RpcServer.getAccounts(client, { keyId }),
@@ -344,7 +350,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
 
         const feeToken = await resolveFeeToken(internal, {
           ...parameters,
-          sessionFeeLimit,
+          permissionsFeeLimit,
         })
 
         const authorizeKey = await PermissionsRequest.toKey(permissions)
@@ -367,7 +373,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
 
               return [key, ...(authorizeKey ? [authorizeKey] : [])]
             },
-            sessionFeeLimit: feeToken.sessionFeeLimit,
+            permissionsFeeLimit: feeToken.permissionsFeeLimit,
           },
         )
 
@@ -602,7 +608,7 @@ export declare namespace rpcServer {
     /**
      * Fee limit to use for permissions.
      */
-    sessionFeeLimit?: Record<string, bigint> | undefined
+    permissionsFeeLimit?: Record<string, bigint> | undefined
     /**
      * Whether to store pre-calls in a persistent storage.
      *
@@ -632,8 +638,8 @@ async function getAuthorizeKeyPreCalls(
     authorizeKeys: [authorizeKey],
     feeToken: feeToken.address,
     key: adminKey,
+    permissionsFeeLimit: feeToken.permissionsFeeLimit,
     preCalls: true,
-    sessionFeeLimit: feeToken.sessionFeeLimit,
   })
   const signature = await Key.sign(adminKey, {
     payload: digest,
@@ -648,7 +654,7 @@ namespace getAuthorizeKeyPreCalls {
     authorizeKey: Key.Key
     feeToken: {
       address: Address.Address
-      sessionFeeLimit?: bigint | undefined
+      permissionsFeeLimit?: bigint | undefined
     }
   }
 }
@@ -658,7 +664,7 @@ async function resolveFeeToken(
   parameters?:
     | {
         feeToken?: Address.Address | undefined
-        sessionFeeLimit?: Record<string, bigint> | undefined
+        permissionsFeeLimit?: Record<string, bigint> | undefined
       }
     | undefined,
 ) {
@@ -678,8 +684,8 @@ async function resolveFeeToken(
     return feeToken.symbol === 'ETH'
   })
 
-  const sessionFeeLimit = feeToken?.symbol
-    ? parameters?.sessionFeeLimit?.[feeToken.symbol]
+  const permissionsFeeLimit = feeToken?.symbol
+    ? parameters?.permissionsFeeLimit?.[feeToken.symbol]
     : undefined
 
   if (!feeToken)
@@ -689,7 +695,7 @@ async function resolveFeeToken(
   return {
     address: feeToken.address,
     decimals: feeToken.decimals,
-    sessionFeeLimit,
+    permissionsFeeLimit,
     symbol: feeToken.symbol,
   }
 }

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -1,4 +1,4 @@
-import type * as Address from 'ox/Address'
+import * as Address from 'ox/Address'
 import * as Bytes from 'ox/Bytes'
 import * as Hex from 'ox/Hex'
 import * as Json from 'ox/Json'
@@ -11,7 +11,6 @@ import * as WebAuthnP256 from 'ox/WebAuthnP256'
 import { waitForCallsStatus } from 'viem/actions'
 import * as Account from '../../Account.js'
 import * as Key from '../../Key.js'
-import type * as Porto from '../../Porto.js'
 import * as RpcServer from '../../RpcServer.js'
 import * as Call from '../call.js'
 import * as Delegation from '../delegation.js'
@@ -21,23 +20,10 @@ import type { Client } from '../porto.js'
 import * as PreCalls from '../preCalls.js'
 import * as RpcServer_viem from '../viem/actions.js'
 
-export const defaultConfig = {
-  feeToken: 'EXP',
-  permissionFeeSpendLimit: {
-    ETH: {
-      limit: Value.fromEther('0.0001'),
-      period: 'day',
-    },
-    EXP: {
-      limit: Value.fromEther('5'),
-      period: 'day',
-    },
-    EXP1: {
-      limit: Value.fromEther('5'),
-      period: 'day',
-    },
-  },
-} as const satisfies rpcServer.Parameters
+export const permissionsFeeLimit = {
+  ETH: Value.fromEther('0.0001'),
+  EXP: Value.fromEther('1'),
+}
 
 /**
  * Mode for a WebAuthn-based environment that interacts with the Porto
@@ -48,8 +34,12 @@ export const defaultConfig = {
  * @returns Mode.
  */
 export function rpcServer(parameters: rpcServer.Parameters = {}) {
-  const config = { ...defaultConfig, ...parameters }
-  const { mock, persistPreCalls = true } = config
+  const config = parameters
+  const {
+    mock,
+    permissionsFeeLimit: feeLimit = permissionsFeeLimit,
+    persistPreCalls = true,
+  } = config
 
   let id_internal: Hex.Hex | undefined
 
@@ -94,17 +84,15 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
 
         if (id) id_internal = id
 
-        const feeToken = await resolveFeeToken(internal)
-        const authorizeKey = await PermissionsRequest.toKey(permissions, {
-          feeToken,
-        })
+        const feeToken = await resolveFeeToken(internal, { feeLimit })
+        const authorizeKey = await PermissionsRequest.toKey(permissions)
 
         const preCalls = authorizeKey
           ? // TODO(rpcServer): remove double webauthn sign.
             await getAuthorizeKeyPreCalls(client, {
               account,
               authorizeKey,
-              feeToken: feeToken.address,
+              feeToken,
             })
           : []
         if (persistPreCalls)
@@ -190,24 +178,22 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
 
       async grantPermissions(parameters) {
-        const { account, permissions, internal } = parameters
+        const { account, internal, permissions } = parameters
         const {
           client,
           config: { storage },
         } = internal
 
-        const feeToken = await resolveFeeToken(internal)
+        const feeToken = await resolveFeeToken(internal, { feeLimit })
 
         // Parse permissions request into a structured key.
-        const authorizeKey = await PermissionsRequest.toKey(permissions, {
-          feeToken,
-        })
+        const authorizeKey = await PermissionsRequest.toKey(permissions)
         if (!authorizeKey) throw new Error('key to authorize not found.')
 
         const preCalls = await getAuthorizeKeyPreCalls(client, {
           account,
           authorizeKey,
-          feeToken: feeToken.address,
+          feeToken,
         })
         if (persistPreCalls)
           await PreCalls.add(preCalls, {
@@ -257,13 +243,11 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           return { credentialId, keyId }
         })()
 
-        const feeToken = await resolveFeeToken(internal)
+        const feeToken = await resolveFeeToken(internal, { feeLimit })
 
         const [accounts, authorizeKey] = await Promise.all([
           RpcServer.getAccounts(client, { keyId }),
-          PermissionsRequest.toKey(permissions, {
-            feeToken,
-          }),
+          PermissionsRequest.toKey(permissions),
         ])
         if (!accounts[0]) throw new Error('account not found')
 
@@ -294,7 +278,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           ? await getAuthorizeKeyPreCalls(client, {
               account,
               authorizeKey,
-              feeToken: feeToken.address,
+              feeToken,
             })
           : []
         if (persistPreCalls)
@@ -358,11 +342,12 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
         const { address, internal, permissions } = parameters
         const { client } = internal
 
-        const feeToken = await resolveFeeToken(internal, parameters)
-
-        const authorizeKey = await PermissionsRequest.toKey(permissions, {
-          feeToken,
+        const feeToken = await resolveFeeToken(internal, {
+          ...parameters,
+          feeLimit,
         })
+
+        const authorizeKey = await PermissionsRequest.toKey(permissions)
         const { context, digests } = await RpcServer.prepareUpgradeAccount(
           client,
           {
@@ -597,34 +582,11 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
     },
     name: 'rpc',
-    setup(parameters) {
-      const { internal } = parameters
-      const { store } = internal
-      const { feeToken = 'ETH', permissionFeeSpendLimit } = config
-
-      function setState() {
-        store.setState((x) => ({
-          ...x,
-          feeToken,
-          permissionFeeSpendLimit,
-        }))
-      }
-
-      if (store.persist.hasHydrated()) setState()
-      else store.persist.onFinishHydration(() => setState())
-
-      return () => {}
-    },
   })
 }
 
 export declare namespace rpcServer {
   type Parameters = {
-    /**
-     * Fee token to use by default (e.g. "USDC", "ETH").
-     * @default "ETH"
-     */
-    feeToken?: Porto.State['feeToken'] | undefined
     /**
      * Keystore host (WebAuthn relying party).
      * @default 'self'
@@ -637,9 +599,9 @@ export declare namespace rpcServer {
      */
     mock?: boolean | undefined
     /**
-     * Spending limit to pay for fees on permissions.
+     * Fee limit to use for permissions.
      */
-    permissionFeeSpendLimit?: Porto.State['permissionFeeSpendLimit'] | undefined
+    permissionsFeeLimit?: Record<string, bigint> | undefined
     /**
      * Whether to store pre-calls in a persistent storage.
      *
@@ -650,47 +612,6 @@ export declare namespace rpcServer {
      * @default true
      */
     persistPreCalls?: boolean | undefined
-  }
-}
-
-async function resolveFeeToken(
-  internal: Mode.ActionsInternal,
-  parameters?:
-    | {
-        feeToken?: Address.Address | undefined
-      }
-    | undefined,
-) {
-  const { client, store } = internal
-  const { chain } = client
-  const { feeToken: defaultFeeToken, permissionFeeSpendLimit } =
-    store.getState()
-  const { feeToken: address } = parameters ?? {}
-
-  const chainId = Hex.fromNumber(chain.id)
-
-  const feeTokens = await RpcServer_viem.getCapabilities(client).then(
-    (capabilities) => capabilities.fees.tokens[chainId],
-  )
-  const feeToken = feeTokens?.find((feeToken) => {
-    if (address) return feeToken.address === address
-    if (defaultFeeToken) return defaultFeeToken === feeToken.symbol
-    return feeToken.symbol === 'ETH'
-  })
-
-  const permissionSpendLimit = feeToken?.symbol
-    ? permissionFeeSpendLimit?.[feeToken.symbol]
-    : undefined
-
-  if (!feeToken)
-    throw new Error(
-      `fee token ${address ?? defaultFeeToken} not found. Available: ${feeTokens?.map((x) => `${x.symbol} (${x.address})`).join(', ')}`,
-    )
-  return {
-    address: feeToken.address,
-    decimals: feeToken.decimals,
-    permissionSpendLimit,
-    symbol: feeToken.symbol,
   }
 }
 
@@ -708,9 +629,10 @@ async function getAuthorizeKeyPreCalls(
   const { context, digest } = await RpcServer.prepareCalls(client, {
     account,
     authorizeKeys: [authorizeKey],
-    feeToken,
+    feeToken: feeToken.address,
     key: adminKey,
     preCalls: true,
+    sessionFeeLimit: feeToken.sessionFeeLimit,
   })
   const signature = await Key.sign(adminKey, {
     payload: digest,
@@ -723,6 +645,50 @@ namespace getAuthorizeKeyPreCalls {
   export type Parameters = {
     account: Account.Account
     authorizeKey: Key.Key
-    feeToken?: Address.Address | undefined
+    feeToken: {
+      address: Address.Address
+      sessionFeeLimit?: bigint | undefined
+    }
+  }
+}
+
+async function resolveFeeToken(
+  internal: Mode.ActionsInternal,
+  parameters?:
+    | {
+        feeLimit?: Record<string, bigint> | undefined
+        feeToken?: Address.Address | undefined
+      }
+    | undefined,
+) {
+  const { client, store } = internal
+  const { chain } = client
+  const { feeToken: defaultFeeToken } = store.getState()
+  const { feeToken: address, feeLimit } = parameters ?? {}
+
+  const chainId = Hex.fromNumber(chain.id)
+
+  const feeTokens = await RpcServer_viem.getCapabilities(client).then(
+    (capabilities) => capabilities.fees.tokens[chainId],
+  )
+  const feeToken = feeTokens?.find((feeToken) => {
+    if (address) return Address.isEqual(feeToken.address, address)
+    if (defaultFeeToken) return defaultFeeToken === feeToken.symbol
+    return feeToken.symbol === 'ETH'
+  })
+
+  const sessionFeeLimit = feeToken?.symbol
+    ? feeLimit?.[feeToken.symbol]
+    : undefined
+
+  if (!feeToken)
+    throw new Error(
+      `fee token ${address ?? defaultFeeToken} not found. Available: ${feeTokens?.map((x) => `${x.symbol} (${x.address})`).join(', ')}`,
+    )
+  return {
+    address: feeToken.address,
+    decimals: feeToken.decimals,
+    sessionFeeLimit,
+    symbol: feeToken.symbol,
   }
 }

--- a/test/src/porto.ts
+++ b/test/src/porto.ts
@@ -29,10 +29,7 @@ const rpcUrl = Anvil.enabled
 export function getPorto(
   parameters: {
     mode?: (parameters: {
-      feeToken?: Mode.rpcServer.Parameters['feeToken'] | undefined
-      permissionFeeSpendLimit?:
-        | Mode.rpcServer.Parameters['permissionFeeSpendLimit']
-        | undefined
+      permissionsFeeLimit: Record<string, bigint>
       mock: boolean
     }) => Mode.Mode | undefined
   } = {},
@@ -41,13 +38,9 @@ export function getPorto(
   const porto = Porto.create({
     chains: [chain],
     mode: mode({
-      feeToken: 'EXP',
       mock: true,
-      permissionFeeSpendLimit: {
-        EXP: {
-          limit: Value.fromEther('100'),
-          period: 'day',
-        },
+      permissionsFeeLimit: {
+        EXP: Value.fromEther('100'),
       },
     }),
     storage: Storage.memory(),


### PR DESCRIPTION
Fixes a UI issue where an end-user would see the "fee" spend limit added onto the "execution" spend limit (e.g. "11 EXP per day" instead of "10 EXP per day").