### PR TITLE
feat: insecure origin fallback

### DIFF
--- a/.changeset/plain-dolls-remain.md
+++ b/.changeset/plain-dolls-remain.md
@@ -1,0 +1,6 @@
+---
+"porto": patch
+---
+
+Fall back to popup if iframe is embedded on an insecure origin (HTTP) so consumers
+can use Porto out-of-the-box.

--- a/apps/docs/pages/sdk/index.mdx
+++ b/apps/docs/pages/sdk/index.mdx
@@ -120,3 +120,44 @@ const { accounts } = await porto.provider.request({
 ```
 
 See [RPC Reference](/sdk/rpc) for a list of all available methods.
+
+## Secure Origins (HTTPS)
+
+Porto is designed to be used on secure origins (HTTPS). If you are using HTTP,
+Porto will fallback to using a popup instead of an iframe. This is because
+WebAuthn is not supported on iframes embedded on insecure origins (HTTP).
+
+Web frameworks typically default to HTTP in development environments. You
+will need to ensure to turn on HTTPS in development to leverage the Porto iframe.
+
+### Vite
+
+HTTPS can be enabled on Vite's dev server by installing and configuring the `vite-plugin-mkcert` plugin.
+
+```bash
+npm i vite-plugin-mkcert
+```
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import mkcert from 'vite-plugin-mkcert' // [!code ++]
+
+export default defineConfig({
+  plugins: [
+    mkcert(), // [!code ++]
+    react(),
+  ],
+})
+```
+
+### Next.js
+
+HTTPS can be enabled on Next.js' dev server by setting the `--experimental-https` flag on the `next dev` command.
+
+```bash
+next dev --experimental-https
+```
+
+
+

--- a/src/core/internal/logger.ts
+++ b/src/core/internal/logger.ts
@@ -1,0 +1,42 @@
+export function create(options: create.Options = {}) {
+  const { prefix = '[Porto]' } = options
+
+  const memo = new Set<string>()
+
+  return {
+    error: createLogFn(console.error, { prefix }),
+    errorOnce: createLogFn(console.error, { memo, prefix }),
+    log: createLogFn(console.log, { prefix }),
+    logOnce: createLogFn(console.log, { memo, prefix }),
+    warn: createLogFn(console.warn, { prefix }),
+    warnOnce: createLogFn(console.warn, { memo, prefix }),
+  }
+}
+
+export declare namespace create {
+  type Options = {
+    prefix?: string
+  }
+}
+
+export const logger = create()
+
+function createLogFn<fn extends (...args: any[]) => void>(
+  fn: fn,
+  options: createLogFn.Options = {},
+) {
+  const { memo, prefix } = options
+  return (...messages: string[]) => {
+    const message = messages.join(' ')
+    if (memo?.has(message)) return
+    memo?.add(message)
+    fn(`${prefix} ${message}`)
+  }
+}
+
+export declare namespace createLogFn {
+  type Options = {
+    memo?: Set<string> | undefined
+    prefix?: string
+  }
+}

--- a/src/core/internal/logger.ts
+++ b/src/core/internal/logger.ts
@@ -34,7 +34,7 @@ function createLogFn<fn extends (...args: any[]) => void>(
   }
 }
 
-export declare namespace createLogFn {
+declare namespace createLogFn {
   type Options = {
     memo?: Set<string> | undefined
     prefix?: string


### PR DESCRIPTION
Currently, consumers [can't get Porto up and running out-of-the-box](https://github.com/ithacaxyz/porto/issues/235) in development environments as WebAuthn does not work on iframes embedded on insecure origins (including localhost). 

This introduces a fall back to a popup so that developers can get up and running right away, with a console warning to encourage the dev to enable HTTPS. 

