### PR TITLE
docs: add link to wallet_prepareCalls

### DIFF
--- a/apps/docs/pages/rpc-server/snippets/fees.mdx
+++ b/apps/docs/pages/rpc-server/snippets/fees.mdx
@@ -2,4 +2,4 @@
 
 Execution of bundles are paid for by the fee payer, which defaults to the EOA. This can be overriden using `feePayer`.
 
-Fees are paid in `feeToken`, which is specified in the capabilities of `wallet_prepareCalls`. The fee token must be supported on the target chain. The list of supported tokens on each network can be found in the response of [`wallet_getCapabilities`](/rpc-server/wallet_getCapabilities).
+Fees are paid in `feeToken`, which is specified in the capabilities of [`wallet_prepareCalls`](/rpc-server/wallet_prepareCalls). The fee token must be supported on the target chain. The list of supported tokens on each network can be found in the response of [`wallet_getCapabilities`](/rpc-server/wallet_getCapabilities).


### PR DESCRIPTION
missing link, we do this for `wallet_getCapabilities` in the next sentence