### PR TITLE
Fix broken example links in Discover Accounts guide

### DIFF
--- a/apps/docs/pages/sdk/guides/discover-accounts.mdx
+++ b/apps/docs/pages/sdk/guides/discover-accounts.mdx
@@ -145,8 +145,8 @@ You have now successfully set up functionality to sign in and sign out of Porto 
 
 Check out the following examples:
 
-- [Next.js](https://github.com/ithacaxyz/porto/tree/main/examples/nextjs)
-- [Vite (React)](https://github.com/ithacaxyz/porto/tree/main/examples/vite)
+- [Next.js](https://github.com/ithacaxyz/porto/tree/main/examples/next)
+- [Vite (React)](https://github.com/ithacaxyz/porto/tree/main/examples/vite-react)
 
 ::::
 


### PR DESCRIPTION
Replaced outdated links to the Next.js and Vite example projects with correct paths (examples/next and examples/vite-react) in the Discover Accounts documentation. This ensures users are directed to the actual example folders in the repository.