### PR TITLE
chore: ignore DeprecationWarning warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,4 +3,4 @@ link-workspace-packages=deep
 provenance=false
 enable-pre-post-scripts=true
 strict-peer-dependencies=false
-node-options='--disable-warning=ExperimentalWarning'
+node-options='--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'


### PR DESCRIPTION
ignores `DeprecationWarning`:

```sh
(node:15886) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated.
Please use Object.assign() instead.
(Use `node --trace-deprecation ...` to show where the warning was created)