### PR TITLE
docs: add bun support

### DIFF
--- a/apps/docs/components/HomePage.tsx
+++ b/apps/docs/components/HomePage.tsx
@@ -1370,6 +1370,7 @@ function Install() {
           <Install.Radio value="npm" />
           <Install.Radio value="pnpm" />
           <Install.Radio value="yarn" />
+          <Install.Radio value="bun" />
         </Ariakit.RadioGroup>
         <div className="font-[300] font-mono text-[15px] text-gray12 tracking-[-2.8%] max-[486px]:text-[12px]">
           <span className="text-gray8">{'>'}</span>{' '}
@@ -1396,7 +1397,7 @@ namespace Install {
 
   declare namespace Radio {
     export type Props = {
-      value: 'npm' | 'pnpm' | 'yarn'
+      value: 'npm' | 'pnpm' | 'yarn' | 'bun'
     }
   }
 }


### PR DESCRIPTION
This pull request adds bun support to Porto's docs / homepage. 

![Screenshot 2025-05-28 at 14 35 23](https://github.com/user-attachments/assets/c15e4af5-cdbd-4eb3-aa56-9e2e8a80d1fd)
