### PR TITLE
fix: improve `methodPolicies` instantiation

### DIFF
--- a/.changeset/hungry-hounds-lay.md
+++ b/.changeset/hungry-hounds-lay.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Improved `methodPolicies` handling in Dialog renderer.

--- a/.changeset/lucky-phones-clean.md
+++ b/.changeset/lucky-phones-clean.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added `waitForReady` property to `Bridge` messenger. This will return a pending promise if the receiving end has not instantiated yet, and will immediately resolve if it has.

--- a/apps/~internal/lib/PortoConfig.ts
+++ b/apps/~internal/lib/PortoConfig.ts
@@ -62,7 +62,7 @@ const dialogHosts = {
     : 'https://prod.localhost:5174/dialog/',
   stg: import.meta.env.PROD
     ? 'https://stg.id.porto.sh/dialog/'
-    : 'https://stg.localhost:5174/dialog/',
+    : 'https://localhost:5174/dialog/',
 } as const satisfies Record<Env.Env, string | undefined>
 
 export function getConfig(

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -149,12 +149,8 @@ export function iframe(options: iframe.Options = {}) {
         waitForReady: true,
       })
 
-      let methodPolicies: Messenger.ReadyOptions['methodPolicies'] | undefined
-
       messenger.on('ready', (options) => {
         const { chainId } = options
-
-        if (!methodPolicies) methodPolicies = options?.methodPolicies
 
         store.setState((x) => ({
           ...x,
@@ -249,6 +245,8 @@ export function iframe(options: iframe.Options = {}) {
           iframe.style.display = 'block'
         },
         async syncRequests(requests) {
+          const { methodPolicies } = await messenger.waitForReady()
+
           const headless = requests?.every(
             (request) =>
               methodPolicies?.find(

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -31,6 +31,7 @@ export type ReadyOptions = {
 /** Bridge messenger. */
 export type Bridge = Messenger & {
   ready: (options: ReadyOptions) => void
+  waitForReady: () => Promise<ReadyOptions>
 }
 
 /** Messenger schema. */
@@ -161,8 +162,8 @@ export function bridge(parameters: bridge.Parameters): Bridge {
 
   let pending = false
 
-  const ready = promise.withResolvers<void>()
-  from_.on('ready', () => ready.resolve())
+  const ready = promise.withResolvers<ReadyOptions>()
+  from_.on('ready', ready.resolve)
 
   const messenger = from({
     destroy() {
@@ -189,6 +190,9 @@ export function bridge(parameters: bridge.Parameters): Bridge {
     ...messenger,
     ready(options) {
       messenger.send('ready', options)
+    },
+    waitForReady() {
+      return ready.promise
     },
   }
 }
@@ -222,6 +226,9 @@ export function noop(): Bridge {
       return Promise.resolve(undefined as never)
     },
     sendAsync() {
+      return Promise.resolve(undefined as never)
+    },
+    waitForReady() {
       return Promise.resolve(undefined as never)
     },
   }


### PR DESCRIPTION
Encountered a scenario where `methodPolicies` would resolve as `undefined` if the dialog had not been instantiated yet. This refactors `methodPolicies` declaration by depending on a `waitForReady` promise that resolves with `ReadyOptions#methodPolicies` from the `"ready"` event.