### PR TITLE
fix(docs): check NFT price against balance first

### DIFF
--- a/apps/docs/components/Connect.tsx
+++ b/apps/docs/components/Connect.tsx
@@ -10,7 +10,9 @@ import LucideWallet from '~icons/lucide/wallet'
 import { Button } from './Button'
 import { permissions } from './HomePage'
 
-const idOrigin = `https://${Env.get()}.id.porto.sh`
+const idOrigin = import.meta.env.DEV
+  ? `https://${Env.get()}.localhost:5174`
+  : `https://${Env.get()}.id.porto.sh`
 
 export function Connect(props: Connect.Props) {
   const { variant = 'default', signInText = 'Sign in' } = props
@@ -33,7 +35,7 @@ export function Connect(props: Connect.Props) {
           className="gap-2"
           render={
             // biome-ignore lint/a11y/useAnchorContent:
-            <a href={idOrigin} />
+            <a href={idOrigin} rel="noreferrer" target="_blank" />
           }
           size={size}
         >

--- a/apps/docs/components/HomePage.tsx
+++ b/apps/docs/components/HomePage.tsx
@@ -1,5 +1,4 @@
 import * as Ariakit from '@ariakit/react'
-import { Env } from '@porto/apps'
 import { LogoLockup, Toast } from '@porto/apps/components'
 import { exp1Config, exp2Config, expNftConfig } from '@porto/apps/contracts'
 import { cx } from 'cva'
@@ -32,8 +31,6 @@ import LucideTrash2 from '~icons/lucide/trash-2'
 import LucideX from '~icons/lucide/x'
 import { config } from '../wagmi.config'
 import { Button } from './Button'
-
-const env = Env.get()
 
 export function HomePage() {
   const [isMounted, setIsMounted] = React.useState(false)
@@ -540,6 +537,8 @@ function SignIn(props: { chainId: ChainId; next: () => void }) {
 export function BuyNow(props: { chainId: ChainId; next: () => void }) {
   const { chainId, next } = props
 
+  const SNEAKER_COST = Value.fromEther('10')
+
   const { address } = useAccount()
   const { data: exp1Balance } = useReadContract({
     abi: exp1Config.abi,
@@ -554,7 +553,7 @@ export function BuyNow(props: { chainId: ChainId; next: () => void }) {
   // Since we use USDC as the fee token in production,
   // we will mint EXP to the user if they don't have any
   // in the call bundle.
-  const shouldMintExp = exp1Balance === 0n && env === 'prod'
+  const shouldMintExp = exp1Balance && exp1Balance < SNEAKER_COST
 
   const { data, isPending, sendCalls } = useSendCalls({
     mutation: {


### PR DESCRIPTION
(1) Update "Portal ID":
- Make the "Portal ID" link work for `localhost` too,
- Open ID page in new tab.


(2) Check mint-ability:
- Check NFT minting cost against demo user balance,
- If user has less than what it costs, fund them first.

This can close ithacaxyz/relay#746. Eventually we should also sho display a more scoped message in the dialog where user is given option to "Confirm anyway"