### PR TITLE
docs(sdk): add missing space in perms demo

### DIFF
--- a/apps/docs/components/HomePage.tsx
+++ b/apps/docs/components/HomePage.tsx
@@ -766,7 +766,7 @@ export function SendTip(props: {
       </div>
 
       <div className="flex w-full justify-between px-1.5">
-        <div className="-tracking-[2.8%] text-[14px] text-gray9">Received</div>
+        <div className="-tracking-[2.8%] text-[14px] text-gray9">Received</div>{' '}
         <div className="-tracking-[2.8%] font-medium text-[14px] text-gray9">
           <span className="text-gray12">
             {ValueFormatter.format(exp1Balance ?? 0)}


### PR DESCRIPTION
Currently looks like this: 
<img width="700" alt="image" src="https://github.com/user-attachments/assets/7e0301bc-50f0-44ab-a4c0-444a766ca063" />
