### PR TITLE
docs(rpc-server): use twoslash for awesome types

### DIFF
--- a/apps/docs/pages/rpc-server/wallet_getCallsStatus.md
+++ b/apps/docs/pages/rpc-server/wallet_getCallsStatus.md
@@ -21,32 +21,38 @@ It provides some off-chain context to the array of inner transaction `receipts`.
 
 The parameter is a call bundle ID, as returned by e.g. [`wallet_sendPreparedCalls`].
 
-```ts
+```ts twoslash
+import { Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_getCallsStatus',
   // the call bundle ID
-  params: [`0x${string}`],
+  params: [Hex],
 }
 ```
 
 ## Response
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Response = {
-  id: `0x${string}`,
+  id: Hex,
   status: number, // See "Status Codes"
   receipts?: {
     logs: {
-      chainId: `0x${string}`,
-      address: `0x${string}`,
-      data: `0x${string}`,
-      topics: `0x${string}`[],
+      chainId: Hex,
+      address: Address,
+      data: Hex,
+      topics: Hex[],
     }[],
-    status: `0x${string}`, // Hex 1 or 0 for success or failure, respectively
-    blockHash?: `0x${string}`,
-    blockNumber?: `0x${string}`,
-    gasUsed: `0x${string}`,
-    transactionHash: `0x${string}`,
+    status: Hex, // Hex 1 or 0 for success or failure, respectively
+    blockHash?: Hash,
+    blockNumber?: Hex,
+    gasUsed: Hex,
+    transactionHash: Hash,
   }[],
 }
 ```

--- a/apps/docs/pages/rpc-server/wallet_getCapabilities.md
+++ b/apps/docs/pages/rpc-server/wallet_getCapabilities.md
@@ -4,11 +4,14 @@ Gets supported [EIP-5792 Capabilities](https://eips.ethereum.org/EIPS/eip-5792#w
 
 ## Request
 
-```ts
+```ts twoslash
+import { Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_getCapabilities',
   // the chain ids
-  params: `0x${string}`[],
+  params: Hex[],
 }
 ```
 
@@ -19,37 +22,40 @@ A map of chain IDs to the capabilities supported by the RPC server on those chai
 - contract addresses (`contracts`)
 - fee configuration (`fees`), such as supported fee tokens (`fees.tokens`), and quote lifetimes (`fees.quoteConfig.ttl`)
 
-```ts
+```ts twoslash
+import { Address, Hex } from 'viem'
+
+// ---cut---
 type Response = {
   // the chain ID as hex
-  [`0x${string}`]: {
+  [chainId: Hex]: {
     contracts: {
       accountRegistry: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       },
       delegationImplementation: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       },
       delegationProxy: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       },
       entrypoint: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       },
       legacyDelegations?: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       }[],
       legacyEntrypoints?: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       }[],
       simulator: {
-        address: `0x${string}`,
+        address: Address,
         version?: string,
       },
     },
@@ -68,13 +74,13 @@ type Response = {
       },
       // the recipient of fees
       // if this is the zero address, fees are accumulated in the entrypoint
-      recipient: `0x${string}`,
+      recipient: Address,
       tokens: {
-        address: `0x${string}`,
+        address: Address,
         decimals: number,
         kind: 'USDC' | 'USDT' | 'ETH',
         // the rate of the fee token to native tokens
-        nativeRate: `0x${string}`,
+        nativeRate: Hex,
         symbol: string,
       }[],
     },

--- a/apps/docs/pages/rpc-server/wallet_getKeys.md
+++ b/apps/docs/pages/rpc-server/wallet_getKeys.md
@@ -4,12 +4,15 @@ Get all keys for an account.
 
 ## Request
 
-```ts
+```ts twoslash
+import { Address, Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_getKeys',
   params: [{
-    address: `0x${string}`,
-    chainId: `0x${string}`,
+    address: Address,
+    chainId: Hex,
   }],
 }
 ```
@@ -18,26 +21,29 @@ type Request = {
 
 Each key associated with an account, along with the permissions set on the keys.
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Response = {
   // key hash
-  hash: `0x${string}`,
+  hash: Hash,
   key: {
     expiry?: number,
     type: 'p256' | 'webauthnp256' | 'secp256k1',
     role: 'admin' | 'normal' | 'session',
-    publicKey: `0x${string}`,
+    publicKey: Hex,
   },
   permissions: ({
     type: 'call',
     selector: string,
-    to: `0x${string}`,
+    to: Address,
   } | {
     type: 'spend',
     limit: number,
     period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year',
     // defaults to the native token (address zero)
-    token?: `0x${string}`,
+    token?: Address,
   })[],
 }[]
 ```

--- a/apps/docs/pages/rpc-server/wallet_prepareCalls.mdx
+++ b/apps/docs/pages/rpc-server/wallet_prepareCalls.mdx
@@ -43,19 +43,22 @@ The fee token the user wishes to pay for execution of the intent is specified in
 
 The key the user wishes to sign the intent with is specified in `key`.
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_prepareCalls',
   params: [{
     calls: {
-      to: `0x${string}`,
-      value: `0x${string}`,
-      bytes: `0x${string}`,
+      to: Address,
+      value: Hex,
+      bytes: Hex,
     }[],
-    chainId: `0x${string}`,
+    chainId: Hex,
     // The address of the account sending the bundle.
     // It can be omitted in the case of a precall, see "PreCalls".
-    from?: `0x${string}`,
+    from?: Address,
     capabilities: {
       authorizeKeys: {
         // See "Keys"
@@ -63,19 +66,19 @@ type Request = {
           expiry?: number,
           type: 'p256' | 'webauthnp256' | 'secp256k1',
           role: 'admin' | 'normal' | 'session',
-          publicKey: `0x${string}`,
+          publicKey: Hex,
         },
         permissions: ({
           type: 'call',
           // See "Selectors"
           selector: string,
-          to: `0x${string}`,
+          to: Address,
         } | {
           type: 'spend',
           limit: number,
           period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year',
           // defaults to the native token (address zero)
-          token?: `0x${string}`,
+          token?: Address,
         })[],
       }[],
       meta: {
@@ -83,21 +86,21 @@ type Request = {
         // Defaults to the account the bundle is for.
         //
         // See "Fees".
-        feePayer?: `0x${string}`,
-        feeToken: `0x${string}`,
-        nonce?: `0x${string}`,
+        feePayer?: Address,
+        feeToken: Address,
+        nonce?: Hex,
       },
       // Set of keys to revoke.
       revokeKeys: {
-        hash: `0x${string}`,
-        id?: `0x${string}`,
+        hash: Hash,
+        id?: Address,
       }[],
       // See "PreCalls"
       preCalls: {
-        eoa: `0x${string}`,
-        executionData: `0x${string}`,
-        nonce: `0x${string}`,
-        signature: `0x${string}`,
+        eoa: Address,
+        executionData: Hex,
+        nonce: Hex,
+        signature: Hex,
       }[],
       preCall?: boolean,
     },
@@ -106,7 +109,7 @@ type Request = {
     // It can be omitted in the case of a precall, see "PreCalls".
     key?: {
       type: 'p256' | 'webauthnp256' | 'secp256k1',
-      publicKey: `0x${string}`,
+      publicKey: Hex,
       // Whether the bundle digest will be prehashed by the key.
       prehash: boolean,
     },
@@ -127,7 +130,10 @@ The payment fields in `context.quote.op` that are relevant to figure out what th
 
 If `totalPaymentAmount - prePaymentAmount` is non-0, the remainder of the fees will be paid after the intent is executed.
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex, TypedData } from 'viem'
+
+// ---cut---
 type Response = {
   // The context returned depending on whether
   // a precall or normal bundle was prepared.
@@ -137,91 +143,91 @@ type Response = {
   // relay is returned.
   context: {
     quote: {
-      chainId: `0x${string}`,
+      chainId: Hex,
       intent: {
-        eoa: `0x${string}`,
-        executionData: `0x${string}`,
-        nonce: `0x${string}`,
-        payer: `0x${string}`,
-        paymentToken: `0x${string}`,
-        prePaymentMaxAmount: `0x${string}`,
-        totalPaymentMaxAmount: `0x${string}`,
-        combinedGas: `0x${string}`,
-        encodedPreCalls: `0x${string}`[],
-        initData: `0x${string}`,
-        prePaymentAmount: `0x${string}`,
-        totalPaymentAmount: `0x${string}`,
-        paymentRecipient: `0x${string}`,
-        signature: `0x${string}`,
-        paymentSignature: `0x${string}`,
-        supportedAccountImplementation: `0x${string}`,
+        eoa: Address,
+        executionData: Hex,
+        nonce: Hex,
+        payer: Address,
+        paymentToken: Address,
+        prePaymentMaxAmount: Hex,
+        totalPaymentMaxAmount: Hex,
+        combinedGas: Hex,
+        encodedPreCalls: Hex[],
+        initData: Hex,
+        prePaymentAmount: Hex,
+        totalPaymentAmount: Hex,
+        paymentRecipient: Address,
+        signature: Hex,
+        paymentSignature: Hex,
+        supportedAccountImplementation: Address,
       },
-      txGas: `0x${string}`,
+      txGas: Hex,
       nativeFeeEstimate: {
         maxFeePerGas: number,
         maxPriorityFeePerGas: number,
       },
       // UNIX timestamp the quote expires at.
       ttl: number,
-      authorizationAddress?: `0x${string}`,
-      entrypoint: `0x${string}`,
+      authorizationAddress?: Address,
+      entrypoint: Address,
       // The RPC servers signature over the quote.
       signature: {
-        y_parity: bool,
-        r: `0x${string}`,
-        s: `0x${string}`,
+        y_parity: boolean,
+        r: Hex,
+        s: Hex,
       },
       // The hash of the quote.
-      hash: `0x${string}`,
+      hash: Hash,
     },
   } | {
     preCall: {
-      eoa: `0x${string}`,
-      executionData: `0x${string}`,
-      nonce: `0x${string}`,
-      signature: `0x${string}`,
+      eoa: Address,
+      executionData: Hex,
+      nonce: Hex,
+      signature: Hex,
     },
   },
   // the digest of the bundle that the user needs to sign
-  digest: `0x${string}`,
+  digest: Hash,
   // EIP-712 typed data of the precall or bundle.
-  typedData: any,
+  typedData: TypedData,
   // capabilities assigned to the account
   capabilities: {
     authorizeKeys: {
       // key hash
-      hash: `0x${string}`,
+      hash: Hash,
       // See "Keys"
       key: {
         expiry?: number,
         type: 'p256' | 'webauthnp256' | 'secp256k1',
         role: 'admin' | 'normal' | 'session',
-        publicKey: `0x${string}`,
+        publicKey: Hex,
       },
       permissions: ({
         type: 'call',
         // See "Selectors"
         selector: string,
-        to: `0x${string}`,
+        to: Address,
       } | {
         type: 'spend',
         limit: number,
         period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year',
         // defaults to the native token (address zero)
-        token?: `0x${string}`,
+        token?: Address,
       })[],
     }[],
     // Key revocations.
     revokeKeys: {
-      hash: `0x${string}`,
-      id?: `0x${string}`
+      hash: Hash,
+      id?: Address
     }[],
     // Simulated asset diffs, where the first element of the tuple is the recipient or sender.
     assetDiff: [
-       `0x${string}`,
+       Address,
        {
          // Omitted if this is the native token.
-         address?: `0x${string}`,
+         address?: Address,
          decimals?: number,
          direction: 'incoming' | 'outgoing',
          name?: string,
@@ -238,7 +244,7 @@ type Response = {
   // It can be omitted in the case of a precall, see "PreCalls".
   key?: {
     type: 'p256' | 'webauthnp256' | 'secp256k1',
-    publicKey: `0x${string}`,
+    publicKey: Hex,
     // Whether the bundle digest will be prehashed by the key.
     prehash: boolean,
   },

--- a/apps/docs/pages/rpc-server/wallet_prepareUpgradeAccount.mdx
+++ b/apps/docs/pages/rpc-server/wallet_prepareUpgradeAccount.mdx
@@ -16,12 +16,15 @@ This method is intended to be used in conjunction with [`wallet_upgradeAccount`]
 
 ## Request
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_prepareUpgradeAccount',
   params: [{
-    address: `0x${string}`,
-    chainId: `0x${string}`,
+    address: Address,
+    chainId: Hex,
     capabilities: {
       authorizeKeys: {
         // See "Keys"
@@ -29,26 +32,26 @@ type Request = {
           expiry?: number,
           type: 'p256' | 'webauthnp256' | 'secp256k1',
           role: 'admin' | 'normal' | 'session',
-          publicKey: `0x${string}`,
+          publicKey: Hex,
         },
         permissions: ({
           type: 'call',
           // See "Selectors"
           selector: string,
-          to: `0x${string}`,
+          to: Address,
         } | {
           type: 'spend',
           limit: number,
           period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year',
           // defaults to the native token (address zero)
-          token?: `0x${string}`,
+          token?: Address,
         })[],
       }[],
-      delegation: `0x${string}`,
+      delegation: Address,
       // defaults to the EOA
-      feePayer?: `0x${string}`,
+      feePayer?: Address,
       // defaults to the native token
-      feeToken?: `0x${string}`,
+      feeToken?: Address,
     },
   }],
 }
@@ -58,7 +61,10 @@ type Request = {
 
 Please refer to [`wallet_prepareCalls`] for a detailed explanation of the response.
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex, TypedData } from 'viem'
+
+// ---cut---
 type Response = {
   // The context returned depending on whether
   // a precall or normal bundle was prepared.
@@ -68,84 +74,84 @@ type Response = {
   // relay is returned.
   context: {
     quote: {
-      chainId: `0x${string}`,
+      chainId: Hex,
       intent: {
-        eoa: `0x${string}`,
-        executionData: `0x${string}`,
-        nonce: `0x${string}`,
-        payer: `0x${string}`,
-        paymentToken: `0x${string}`,
-        prePaymentMaxAmount: `0x${string}`,
-        totalPaymentMaxAmount: `0x${string}`,
-        combinedGas: `0x${string}`,
-        encodedPreCalls: `0x${string}`[],
-        initData: `0x${string}`,
-        prePaymentAmount: `0x${string}`,
-        totalPaymentAmount: `0x${string}`,
-        paymentRecipient: `0x${string}`,
-        signature: `0x${string}`,
-        paymentSignature: `0x${string}`,
-        supportedAccountImplementation: `0x${string}`,
+        eoa: Address,
+        executionData: Hex,
+        nonce: Hex,
+        payer: Address,
+        paymentToken: Address,
+        prePaymentMaxAmount: Hex,
+        totalPaymentMaxAmount: Hex,
+        combinedGas: Hex,
+        encodedPreCalls: Hex[],
+        initData: Hex,
+        prePaymentAmount: Hex,
+        totalPaymentAmount: Hex,
+        paymentRecipient: Address,
+        signature: Hex,
+        paymentSignature: Hex,
+        supportedAccountImplementation: Address,
       },
-      txGas: `0x${string}`,
+      txGas: Hex,
       nativeFeeEstimate: {
         maxFeePerGas: number,
         maxPriorityFeePerGas: number,
       },
       // UNIX timestamp the quote expires at.
       ttl: number,
-      authorizationAddress?: `0x${string}`,
-      entrypoint: `0x${string}`,
+      authorizationAddress?: Address,
+      entrypoint: Address,
       // The RPC servers signature over the quote.
       signature: {
-        y_parity: bool,
-        r: `0x${string}`,
-        s: `0x${string}`,
+        y_parity: boolean,
+        r: Hex,
+        s: Hex,
       },
       // The hash of the quote.
-      hash: `0x${string}`,
+      hash: Hash,
     },
   },
   // the digest of the bundle that the user needs to sign
-  digest: `0x${string}`,
+  digest: Hash,
   // EIP-712 typed data of the precall or bundle.
-  typedData: any,
+  typedData: TypedData,
   // capabilities assigned to the account
   capabilities: {
     authorizeKeys: {
       // key hash
-      hash: `0x${string}`,
+      hash: Hash,
       // See "Keys"
       key: {
         expiry?: number,
         type: 'p256' | 'webauthnp256' | 'secp256k1',
         role: 'admin' | 'normal' | 'session',
-        publicKey: `0x${string}`,
+        publicKey: Hex,
       },
       permissions: ({
         type: 'call',
         // See "Selectors"
         selector: string,
-        to: `0x${string}`,
+        to: Address,
       } | {
         type: 'spend',
         limit: number,
         period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year',
         // defaults to the native token (address zero)
-        token?: `0x${string}`,
+        token?: Address,
       })[],
     }[],
     // Key revocations.
     revokeKeys: {
-      hash: `0x${string}`,
-      id?: `0x${string}`
+      hash: Hash,
+      id?: Address
     }[],
     // Simulated asset diffs, where the first element of the tuple is the recipient or sender.
     assetDiff: [
-       `0x${string}`,
+       Address,
        {
          // Omitted if this is the native token.
-         address?: `0x${string}`,
+         address?: Address,
          decimals?: number,
          direction: 'incoming' | 'outgoing',
          name?: string,

--- a/apps/docs/pages/rpc-server/wallet_sendPreparedCalls.mdx
+++ b/apps/docs/pages/rpc-server/wallet_sendPreparedCalls.mdx
@@ -16,62 +16,65 @@ This method is intended to be used in conjunction with [`wallet_prepareCalls`](/
 
 ## Request
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_sendPreparedCalls',
   params: [{
     capabilities?: {
       // This will be passed to `feePayer` if specified for additional on-chain verification.
-      feeSignature?: `0x${string}`,
+      feeSignature?: Hex,
     },
     context: {
       quote: {
-        chainId: `0x${string}`,
+        chainId: Hex,
         intent: {
-          eoa: `0x${string}`,
-          executionData: `0x${string}`,
-          nonce: `0x${string}`,
-          payer: `0x${string}`,
-          paymentToken: `0x${string}`,
-          prePaymentMaxAmount: `0x${string}`,
-          totalPaymentMaxAmount: `0x${string}`,
-          combinedGas: `0x${string}`,
-          encodedPreCalls: `0x${string}`[],
-          initData: `0x${string}`,
-          prePaymentAmount: `0x${string}`,
-          totalPaymentAmount: `0x${string}`,
-          paymentRecipient: `0x${string}`,
-          signature: `0x${string}`,
-          paymentSignature: `0x${string}`,
-          supportedAccountImplementation: `0x${string}`,
+          eoa: Address,
+          executionData: Hex,
+          nonce: Hex,
+          payer: Address,
+          paymentToken: Address,
+          prePaymentMaxAmount: Hex,
+          totalPaymentMaxAmount: Hex,
+          combinedGas: Hex,
+          encodedPreCalls: Hex[],
+          initData: Hex,
+          prePaymentAmount: Hex,
+          totalPaymentAmount: Hex,
+          paymentRecipient: Address,
+          signature: Hex,
+          paymentSignature: Hex,
+          supportedAccountImplementation: Address,
         },
-        txGas: `0x${string}`,
+        txGas: Hex,
         nativeFeeEstimate: {
           maxFeePerGas: number,
           maxPriorityFeePerGas: number,
         },
         // UNIX timestamp the quote expires at.
         ttl: number,
-        authorizationAddress?: `0x${string}`,
-        entrypoint: `0x${string}`,
+        authorizationAddress?: Address,
+        entrypoint: Address,
         // The RPC servers signature over the quote.
         signature: {
           y_parity: boolean,
-          r: `0x${string}`,
-          s: `0x${string}`,
+          r: Hex,
+          s: Hex,
         },
         // The hash of the quote.
-        hash: `0x${string}`,
+        hash: Hash,
       },
     },
     // The key that signed the bundle. See "Keys".
     key: {
       type: 'p256' | 'webauthnp256' | 'secp256k1',
-      publicKey: `0x${string}`,
+      publicKey: Hex,
       // Whether the bundle digest will be prehashed by the key.
       prehash: boolean,
     },
-    signature: `0x${string}`,
+    signature: Hex,
   }],
 }
 ```
@@ -80,10 +83,13 @@ type Request = {
 
 A bundle ID for use with [`wallet_getCallsStatus`].
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Response = {
   // The bundle ID
-  id: `0x${string}`
+  id: Hex
 }
 ```
 

--- a/apps/docs/pages/rpc-server/wallet_upgradeAccount.md
+++ b/apps/docs/pages/rpc-server/wallet_upgradeAccount.md
@@ -8,63 +8,66 @@ This method is intended to be used in conjunction with [`wallet_prepareUpgradeAc
 
 ## Request
 
-```ts
+```ts twoslash
+import { Address, Hash, Hex } from 'viem'
+
+// ---cut---
 type Request = {
   method: 'wallet_upgradeAccount',
   params: [{
     // As returned by `wallet_prepareUpgradeAccount`
     context: {
       quote: {
-        chainId: `0x${string}`,
+        chainId: Hex,
         intent: {
-          eoa: `0x${string}`,
-          executionData: `0x${string}`,
-          nonce: `0x${string}`,
-          payer: `0x${string}`,
-          paymentToken: `0x${string}`,
-          prePaymentMaxAmount: `0x${string}`,
-          totalPaymentMaxAmount: `0x${string}`,
-          combinedGas: `0x${string}`,
-          encodedPreCalls: `0x${string}`[],
-          initData: `0x${string}`,
-          prePaymentAmount: `0x${string}`,
-          totalPaymentAmount: `0x${string}`,
-          paymentRecipient: `0x${string}`,
-          signature: `0x${string}`,
-          paymentSignature: `0x${string}`,
-          supportedAccountImplementation: `0x${string}`,
+          eoa: Address,
+          executionData: Hex,
+          nonce: Hex,
+          payer: Address,
+          paymentToken: Address,
+          prePaymentMaxAmount: Hex,
+          totalPaymentMaxAmount: Hex,
+          combinedGas: Hex,
+          encodedPreCalls: Hex[],
+          initData: Hex,
+          prePaymentAmount: Hex,
+          totalPaymentAmount: Hex,
+          paymentRecipient: Address,
+          signature: Hex,
+          paymentSignature: Hex,
+          supportedAccountImplementation: Address,
         },
-        txGas: `0x${string}`,
+        txGas: Hex,
         nativeFeeEstimate: {
           maxFeePerGas: number,
           maxPriorityFeePerGas: number,
         },
         // UNIX timestamp the quote expires at.
         ttl: number,
-        authorizationAddress?: `0x${string}`,
-        entrypoint: `0x${string}`,
+        authorizationAddress?: Address,
+        entrypoint: Address,
         // The RPC servers signature over the quote.
         signature: {
-          y_parity: bool,
-          r: `0x${string}`,
-          s: `0x${string}`,
+          y_parity: boolean,
+          r: Hex,
+          s: Hex,
         },
         // The hash of the quote.
-        hash: `0x${string}`,
+        hash: Hash,
       },
     },
     // signature over the intent digest from `wallet_prepareUpgradeAccount`
-    signature: `0x${string}`,
+    signature: Hex,
     // The EIP-7702 authorization signed with the root EOA key.
     authorization: {
       // usually 0 to allow for replayability
-      chainId: `0x${string}`,
+      chainId: Hex,
       // the contract the account delegates to
-      address: `0x${string}`,
-      nonce: `0x${string}`,
-      yParity: `0x${string}`,
-      r: `0x${string}`,
-      s: `0x${string}`,
+      address: Address,
+      nonce: Hex,
+      yParity: Hex,
+      r: Hex,
+      s: Hex,
     },
   }],
 }
@@ -74,10 +77,13 @@ type Request = {
 
 A series of bundle IDs for use with [`wallet_getCallsStatus`].
 
-```ts
+```ts twoslash
+import { Hex } from 'viem'
+
+// ---cut---
 type Response = {
   bundles: {
-    id: `0x${string}`
+    id: Hex
   }[],
 }
 ```


### PR DESCRIPTION
Uses twoslash to add better types in the RPC server reference. I only converted some of the pages, as the remaining are likely to disappear