### PR TITLE
feat(manager) : add eth/native-token transfer support for porto id

### DIFF
--- a/apps/manager/src/hooks/useBlockscoutApi.ts
+++ b/apps/manager/src/hooks/useBlockscoutApi.ts
@@ -3,11 +3,11 @@ import { useQuery } from '@tanstack/react-query'
 import { Address } from 'ox'
 import { anvil, portoDev } from 'porto/core/Chains'
 import * as React from 'react'
+import { zeroAddress } from 'viem'
 import { useAccount, useChainId, useWatchBlockNumber } from 'wagmi'
 import { base, baseSepolia } from 'wagmi/chains'
 import { urlWithCorsBypass } from '~/lib/Constants'
 import { useReadBalances } from './useReadBalances'
-import { zeroAddress } from 'viem'
 
 export function addressApiEndpoint(chainId: PortoConfig.ChainId) {
   if (chainId === anvil.id || chainId === portoDev.id)
@@ -19,40 +19,43 @@ export function addressApiEndpoint(chainId: PortoConfig.ChainId) {
 }
 
 export function filterEthTransfers(ethCallsData: { items: any[] }) {
-  const filteredEthCalls = ethCallsData.items.filter((tx: { to: { is_contract: any }; value: string | number }) =>
-        tx.to.is_contract == false && tx.value !== '0'
-      );
+  const filteredEthCalls = ethCallsData.items.filter(
+    (tx: { to: { is_contract: any }; value: string | number }) =>
+      tx.to.is_contract === false && tx.value !== '0',
+  )
 
-      const sanitizedEthCalls: TokenTransfer[] = filteredEthCalls.map((tx: any) => ({
-        block_hash: tx.block_hash,
-        block_number: tx.block_number,
-        from: tx.from,
-        log_index: tx.log_index ?? 0,
-        method: '',
-        timestamp: tx.timestamp,
-        to: tx.to,
-        token: {
-          address: zeroAddress,
-          circulating_market_cap: 0,
-          decimals: '18',
-          exchange_rate: 0,
-          holders: '0',
-          icon_url: '',
-          name: 'Ether',
-          symbol: 'ETH',
-          total_supply: '0',
-          type: 'ETH',
-          volume_24h: 0,
-        },
-        total: {
-          decimals: '18',
-          value: tx.value,
-        },
-        transaction_hash: tx.transaction_hash,
-        type: 'coin-transfer',
-      }));
+  const sanitizedEthCalls: TokenTransfer[] = filteredEthCalls.map(
+    (tx: any) => ({
+      block_hash: tx.block_hash,
+      block_number: tx.block_number,
+      from: tx.from,
+      log_index: tx.log_index ?? 0,
+      method: '',
+      timestamp: tx.timestamp,
+      to: tx.to,
+      token: {
+        address: zeroAddress,
+        circulating_market_cap: 0,
+        decimals: '18',
+        exchange_rate: 0,
+        holders: '0',
+        icon_url: '',
+        name: 'Ether',
+        symbol: 'ETH',
+        total_supply: '0',
+        type: 'ETH',
+        volume_24h: 0,
+      },
+      total: {
+        decimals: '18',
+        value: tx.value,
+      },
+      transaction_hash: tx.transaction_hash,
+      type: 'coin-transfer',
+    }),
+  )
 
-  return sanitizedEthCalls;
+  return sanitizedEthCalls
 }
 
 export function useAddressTransfers({
@@ -80,9 +83,12 @@ export function useAddressTransfers({
       const url = `${apiEndpoint}/addresses/${userAddress}/token-transfers`
       const response = await fetch(urlWithCorsBypass(url))
 
-      let internalTxns = await fetch(urlWithCorsBypass(`${apiEndpoint}/addresses/${userAddress}/internal-transactions`))
-      const ethTransfers = filterEthTransfers(await internalTxns.json());
-
+      let internalTxns = await fetch(
+        urlWithCorsBypass(
+          `${apiEndpoint}/addresses/${userAddress}/internal-transactions`,
+        ),
+      )
+      const ethTransfers = filterEthTransfers(await internalTxns.json())
 
       const data = (await response.json()) as {
         items: Array<TokenTransfer>
@@ -94,10 +100,10 @@ export function useAddressTransfers({
         next_page_params: null,
       }
 
-      data.items = [...data.items, ...ethTransferData.items];
+      data.items = [...data.items, ...ethTransferData.items]
       data.items.sort((a, b) => {
-        return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
-      });
+        return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      })
 
       return {
         items: data.items,

--- a/apps/manager/src/hooks/useBlockscoutApi.ts
+++ b/apps/manager/src/hooks/useBlockscoutApi.ts
@@ -7,6 +7,7 @@ import { useAccount, useChainId, useWatchBlockNumber } from 'wagmi'
 import { base, baseSepolia } from 'wagmi/chains'
 import { urlWithCorsBypass } from '~/lib/Constants'
 import { useReadBalances } from './useReadBalances'
+import { zeroAddress } from 'viem'
 
 export function addressApiEndpoint(chainId: PortoConfig.ChainId) {
   if (chainId === anvil.id || chainId === portoDev.id)
@@ -15,6 +16,43 @@ export function addressApiEndpoint(chainId: PortoConfig.ChainId) {
     return 'https://base-sepolia.blockscout.com/api/v2'
   if (chainId === base.id) return 'https://base.blockscout.com/api/v2'
   throw new Error(`Unsupported chainId: ${chainId}`)
+}
+
+export function filterEthTransfers(ethCallsData: { items: any[] }) {
+  const filteredEthCalls = ethCallsData.items.filter((tx: { to: { is_contract: any }; value: string | number }) =>
+        tx.to.is_contract == false && tx.value !== '0'
+      );
+
+      const sanitizedEthCalls: TokenTransfer[] = filteredEthCalls.map((tx: any) => ({
+        block_hash: tx.block_hash,
+        block_number: tx.block_number,
+        from: tx.from,
+        log_index: tx.log_index ?? 0,
+        method: '',
+        timestamp: tx.timestamp,
+        to: tx.to,
+        token: {
+          address: zeroAddress,
+          circulating_market_cap: 0,
+          decimals: '18',
+          exchange_rate: 0,
+          holders: '0',
+          icon_url: '',
+          name: 'Ether',
+          symbol: 'ETH',
+          total_supply: '0',
+          type: 'ETH',
+          volume_24h: 0,
+        },
+        total: {
+          decimals: '18',
+          value: tx.value,
+        },
+        transaction_hash: tx.transaction_hash,
+        type: 'coin-transfer',
+      }));
+
+  return sanitizedEthCalls;
 }
 
 export function useAddressTransfers({
@@ -42,10 +80,25 @@ export function useAddressTransfers({
       const url = `${apiEndpoint}/addresses/${userAddress}/token-transfers`
       const response = await fetch(urlWithCorsBypass(url))
 
+      let internalTxns = await fetch(urlWithCorsBypass(`${apiEndpoint}/addresses/${userAddress}/internal-transactions`))
+      const ethTransfers = filterEthTransfers(await internalTxns.json());
+
+
       const data = (await response.json()) as {
         items: Array<TokenTransfer>
         next_page_params: null
       }
+
+      const ethTransferData = {
+        items: ethTransfers,
+        next_page_params: null,
+      }
+
+      data.items = [...data.items, ...ethTransferData.items];
+      data.items.sort((a, b) => {
+        return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+      });
+
       return {
         items: data.items,
         next_page_params: data.next_page_params,

--- a/apps/manager/src/hooks/useTokenInfo.ts
+++ b/apps/manager/src/hooks/useTokenInfo.ts
@@ -43,3 +43,10 @@ export function useErc721Info(address?: Address.Address | undefined) {
     scopeKey: address,
   })
 }
+
+export function useETHInfo() {
+  return {data:{
+    name: 'Ether',
+    symbol: 'ETH',
+  }}
+}

--- a/apps/manager/src/hooks/useTokenInfo.ts
+++ b/apps/manager/src/hooks/useTokenInfo.ts
@@ -45,8 +45,10 @@ export function useErc721Info(address?: Address.Address | undefined) {
 }
 
 export function useETHInfo() {
-  return {data:{
-    name: 'Ether',
-    symbol: 'ETH',
-  }}
+  return {
+    data: {
+      name: 'Ether',
+      symbol: 'ETH',
+    },
+  }
 }

--- a/apps/manager/src/hooks/useTokenStandard.ts
+++ b/apps/manager/src/hooks/useTokenStandard.ts
@@ -1,14 +1,20 @@
 import { Address } from 'ox'
-import { erc20Abi } from 'viem'
+import { erc20Abi, zeroAddress } from 'viem'
 import { useReadContracts } from 'wagmi'
 
-export type TokenStandard = { standard: 'ERC20' } | { standard: 'ERC721' }
+export type TokenStandard = { standard: 'ERC20' } | { standard: 'ERC721' } | { standard: 'ETH' }
 
 /**
  * Simplified: call `decimals()` via useReadContracts.
  * If it returns a number → ERC-20, otherwise → ERC-721.
+ * If the address is zeroAddress, return ETH.
  */
 export function useTokenStandard(address?: Address.Address) {
+
+  if (address == zeroAddress) {
+    return {standard: 'ETH'} as TokenStandard
+  }
+
   const response = useReadContracts({
     allowFailure: false,
     contracts: [

--- a/apps/manager/src/hooks/useTokenStandard.ts
+++ b/apps/manager/src/hooks/useTokenStandard.ts
@@ -2,7 +2,10 @@ import { Address } from 'ox'
 import { erc20Abi, zeroAddress } from 'viem'
 import { useReadContracts } from 'wagmi'
 
-export type TokenStandard = { standard: 'ERC20' } | { standard: 'ERC721' } | { standard: 'ETH' }
+export type TokenStandard =
+  | { standard: 'ERC20' }
+  | { standard: 'ERC721' }
+  | { standard: 'ETH' }
 
 /**
  * Simplified: call `decimals()` via useReadContracts.
@@ -10,9 +13,8 @@ export type TokenStandard = { standard: 'ERC20' } | { standard: 'ERC721' } | { s
  * If the address is zeroAddress, return ETH.
  */
 export function useTokenStandard(address?: Address.Address) {
-
-  if (address == zeroAddress) {
-    return {standard: 'ETH'} as TokenStandard
+  if (address === zeroAddress) {
+    return { standard: 'ETH' } as TokenStandard
   }
 
   const response = useReadContracts({

--- a/apps/manager/src/routes/-components/Dashboard.tsx
+++ b/apps/manager/src/routes/-components/Dashboard.tsx
@@ -56,7 +56,9 @@ function TokenSymbol({
   const { data: tokenInfo } =
     tokenStandard.standard === 'ERC20'
       ? useErc20Info(address)
-      : tokenStandard.standard === 'ETH' ? useETHInfo() : useErc721Info(address)
+      : tokenStandard.standard === 'ETH'
+        ? useETHInfo()
+        : useErc721Info(address)
 
   if (!address) return null
 
@@ -809,31 +811,32 @@ function AssetRow({
     )
       return
 
-    if (address == zeroAddress){
+    if (address === zeroAddress) {
       sendCalls.sendCalls({
-      calls: [
-        {
-          to: sendFormState.values.sendRecipient as Address.Address,
-          value: Value.from(sendFormState.values.sendAmount, 18)
-        },
-      ],
-    })
-    }else{
-    sendCalls.sendCalls({
-      calls: [
-        {
-          data: encodeFunctionData({
-            abi: erc20Abi,
-            args: [
-              sendFormState.values.sendRecipient,
-              Value.from(sendFormState.values.sendAmount, decimals),
-            ],
-            functionName: 'transfer',
-          }),
-          to: address,
-        },
-      ],
-    })}
+        calls: [
+          {
+            to: sendFormState.values.sendRecipient as Address.Address,
+            value: Value.from(sendFormState.values.sendAmount, 18),
+          },
+        ],
+      })
+    } else {
+      sendCalls.sendCalls({
+        calls: [
+          {
+            data: encodeFunctionData({
+              abi: erc20Abi,
+              args: [
+                sendFormState.values.sendRecipient,
+                Value.from(sendFormState.values.sendAmount, decimals),
+              ],
+              functionName: 'transfer',
+            }),
+            to: address,
+          },
+        ],
+      })
+    }
   }
 
   const ref = React.useRef<HTMLTableCellElement | null>(null)

--- a/apps/manager/src/routes/-components/Dashboard.tsx
+++ b/apps/manager/src/routes/-components/Dashboard.tsx
@@ -10,7 +10,7 @@ import { Porto } from 'porto'
 import { Hooks } from 'porto/wagmi'
 import * as React from 'react'
 import { toast } from 'sonner'
-import { encodeFunctionData, erc20Abi, formatEther } from 'viem'
+import { encodeFunctionData, erc20Abi, formatEther, zeroAddress } from 'viem'
 import {
   useAccount,
   useChainId,
@@ -25,7 +25,7 @@ import { TruncatedAddress } from '~/components/TruncatedAddress'
 import { useAddressTransfers } from '~/hooks/useBlockscoutApi'
 import { useClickOutside } from '~/hooks/useClickOutside'
 import { useSwapAssets } from '~/hooks/useSwapAssets'
-import { useErc20Info, useErc721Info } from '~/hooks/useTokenInfo'
+import { useErc20Info, useErc721Info, useETHInfo } from '~/hooks/useTokenInfo'
 import { useTokenStandard } from '~/hooks/useTokenStandard'
 import {
   ArrayUtils,
@@ -56,7 +56,7 @@ function TokenSymbol({
   const { data: tokenInfo } =
     tokenStandard.standard === 'ERC20'
       ? useErc20Info(address)
-      : useErc721Info(address)
+      : tokenStandard.standard === 'ETH' ? useETHInfo() : useErc721Info(address)
 
   if (!address) return null
 
@@ -808,6 +808,17 @@ function AssetRow({
       !sendFormState.values.sendAmount
     )
       return
+
+    if (address == zeroAddress){
+      sendCalls.sendCalls({
+      calls: [
+        {
+          to: sendFormState.values.sendRecipient as Address.Address,
+          value: Value.from(sendFormState.values.sendAmount, 18)
+        },
+      ],
+    })
+    }else{
     sendCalls.sendCalls({
       calls: [
         {
@@ -822,7 +833,7 @@ function AssetRow({
           to: address,
         },
       ],
-    })
+    })}
   }
 
   const ref = React.useRef<HTMLTableCellElement | null>(null)


### PR DESCRIPTION
### Description
This PR adds support to send ETH using Porto ID and also updates the history to include ETH transfers as well

### Note
Since BlockScout API does not provide API catered to fetch ETH transfers for an address, the following implementation fetches all the internal calls and checks if the addresses involved aren't contracts and value is greater then 0.
The logic can be polished further to prevent any fetching of unwanted `call` or `delegatecall`

### Screen-recording

https://github.com/user-attachments/assets/e40bd984-5519-4a0d-a2da-ba3263a294ef


Fixes #384 