### PR TITLE
Update key schema reference to Porto documentation

### DIFF
--- a/src/core/internal/rpcServer/typebox/key.ts
+++ b/src/core/internal/rpcServer/typebox/key.ts
@@ -1,7 +1,7 @@
 /**
  * RPC account key.
  *
- * @see https://github.com/ithacaxyz/relay/blob/main/src/types/key.rs
+ * @see https://github.com/ithacaxyz/porto/blob/main/apps/docs/pages/contracts/account.md#keys
  */
 
 import * as Primitive from '../../typebox/primitive.js'


### PR DESCRIPTION
Replaced the outdated link to key.rs in the relay repository with a reference to the current Porto documentation (account.md#keys). This ensures the comment points to an up-to-date and accessible description of the key structure.