### PR TITLE
fix: prevent ability to revoke primary WebAuthn key

### DIFF
--- a/src/core/internal/modes/contract.ts
+++ b/src/core/internal/modes/contract.ts
@@ -415,9 +415,7 @@ export function contract(parameters: contract.Parameters = {}) {
         const { account, id, internal } = parameters
         const { client } = internal
 
-        const key = account.keys?.find(
-          (key) => key.id.toLowerCase() === id.toLowerCase(),
-        )
+        const key = account.keys?.find((key) => key.id === id)
         if (!key) return
 
         // Cannot revoke the only WebAuthn key left

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -503,9 +503,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
         if (request.method !== 'wallet_revokeAdmin')
           throw new Error('Cannot revoke admin for method: ' + request.method)
 
-        const key = account.keys?.find(
-          (key) => key.id.toLowerCase() === id.toLowerCase(),
-        )
+        const key = account.keys?.find((key) => key.id === id)
         if (!key) return
 
         // Cannot revoke the only WebAuthn key left

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -456,9 +456,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
         const { account, id, internal } = parameters
         const { client } = internal
 
-        const key = account.keys?.find(
-          (key) => key.id.toLowerCase() === id.toLowerCase(),
-        )
+        const key = account.keys?.find((key) => key.id === id)
         if (!key) return
 
         // Cannot revoke the only WebAuthn key left

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -515,22 +515,6 @@ export function from<
             : state.accounts[0]
           if (!account) throw new ox_Provider.UnauthorizedError()
 
-          // Find the key to be revoked
-          const keyToRevoke = account.keys?.find(
-            (key) => key.id.toLowerCase() === id.toLowerCase(),
-          )
-
-          // Prevent revoking the only webauthn-p256 key left in the array of keys
-          if (
-            keyToRevoke &&
-            account.keys?.filter((key) => key.type === 'webauthn-p256')
-              .length === 1
-          ) {
-            throw new RpcResponse.InvalidParamsError({
-              message: 'Cannot revoke the only webauthn-p256 key left.',
-            })
-          }
-
           const client = getClient()
 
           await getMode().actions.revokeAdmin({


### PR DESCRIPTION
Adds a check to prevent revoking the only WebAuthn key left in user keys.