### PR TITLE
feat: enhance Claude GitHub workflow with permission checks and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/claude_action_request.yml
+++ b/.github/ISSUE_TEMPLATE/claude_action_request.yml
@@ -1,0 +1,65 @@
+name: 🤖 Claude Action Request
+description: Request Claude AI to perform a specific action on the repository
+title: "[Claude] "
+labels: ["claude-action"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for requesting Claude to help with the Porto repository! 
+        
+        **⚠️ Important:** Only repository maintainers (users with write/admin permissions) can trigger Claude actions.
+        
+        Claude will automatically respond to this issue and perform the requested action if you have the required permissions.
+        
+        **Note:** This will trigger Claude to:
+        - Analyze your request
+        - Perform the requested changes
+        - Provide feedback on what was done
+        
+        Please be specific about what you want Claude to do.
+
+  - type: textarea
+    id: action-request
+    attributes:
+      label: "Action Request"
+      description: "Describe what you want Claude to do. Be specific about the task, files to modify, or features to implement."
+      value: "@claude "
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: What priority should this action have?
+      options:
+        - Low
+        - Medium
+        - High
+        - Critical
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Additional Context"
+      description: "Provide any additional context, requirements, or constraints for the action."
+      placeholder: |
+        - Related files or directories
+        - Specific requirements or constraints
+        - Expected behavior or outcomes
+        - Dependencies or prerequisites
+
+  - type: markdown
+    attributes:
+      value: |
+        ## How this works
+        
+        1. **Automatic Response**: Claude will automatically respond to this issue within a few minutes
+        2. **Action Execution**: Claude will analyze your request and perform the necessary changes
+        3. **Feedback**: Claude will provide detailed feedback about what was done
+        4. **Review**: You can review the changes and request modifications if needed
+        
+        **Tip**: You can also mention `@claude` in any comment on this issue to request additional actions or clarifications.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,17 +6,47 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
   pull_request_review:
     types: [submitted]
 
 jobs:
+  check-permissions:
+    runs-on: ubuntu-latest
+    outputs:
+      has-permission: ${{ steps.check.outputs.has-permission }}
+    steps:
+      - name: Check if user has write permissions
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.actor
+              });
+              
+              const hasWritePermission = ['admin', 'maintain', 'write'].includes(permission.permission);
+              console.log(`User ${context.actor} has permission: ${permission.permission}`);
+              core.setOutput('has-permission', hasWritePermission);
+              return hasWritePermission;
+            } catch (error) {
+              console.log(`Error checking permissions for ${context.actor}: ${error.message}`);
+              core.setOutput('has-permission', false);
+              return false;
+            }
+
   claude-code-action:
+    needs: check-permissions
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      needs.check-permissions.outputs.has-permission == 'true' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.labels.*.name, 'claude-action')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Enhanced the Claude GitHub workflow with proper permission validation
- Added support for label-based triggering via `claude-action` label
- Created comprehensive issue template for structured Claude action requests

## Changes Made
- **Permission Validation**: Added a `check-permissions` job that validates users have write/admin permissions before allowing Claude actions
- **Label Support**: Extended trigger conditions to support `claude-action` label on issues
- **Issue Template**: Created `.github/ISSUE_TEMPLATE/claude_action_request.yml` with structured form for:
  - Action requests with clear descriptions
  - Priority levels (Low, Medium, High, Critical)  
  - Additional context section
  - Usage instructions and workflow explanation

## Security Improvements
- Only users with `admin`, `maintain`, or `write` permissions can trigger Claude actions
- Graceful handling of permission check errors
- Clear user feedback about permission requirements

## Test Plan
- [ ] Verify permission validation works for authorized users
- [ ] Verify permission validation blocks unauthorized users
- [ ] Test issue template functionality
- [ ] Confirm label-based triggering works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)