### PR TITLE
feat: add balance checking to permission revocation

### DIFF
--- a/apps/dialog/src/routes/dialog/wallet_revokePermissions.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_revokePermissions.tsx
@@ -1,9 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Actions } from 'porto/remote'
+import { Key } from 'porto'
+import { Actions, Hooks } from 'porto/remote'
 
+import { CheckBalance } from '~/components/CheckBalance'
 import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
+import * as RpcServer from '~/lib/RpcServer'
 import { RevokePermissions } from '../-components/RevokePermissions'
 
 export const Route = createFileRoute('/dialog/wallet_revokePermissions')({
@@ -19,6 +22,16 @@ function RouteComponent() {
   const request = Route.useSearch()
   const parameters = request.params[0]
 
+  const { data } = Hooks.usePermissions()
+  const permissions = data?.find((x) => x.id === parameters.id)?.permissions
+  const revokeKey = permissions?.keys?.find((key) => key.id === parameters.id)
+
+  const prepareCallsQuery = RpcServer.usePrepareCalls({
+    enabled: !!revokeKey,
+    feeToken: parameters.capabilities?.feeToken,
+    revokeKeys: revokeKey ? [Key.from(revokeKey)] : [],
+  })
+
   const respond = useMutation({
     mutationFn() {
       return Actions.respond(porto, request)
@@ -26,11 +39,18 @@ function RouteComponent() {
   })
 
   return (
-    <RevokePermissions
-      {...parameters}
-      loading={respond.isPending}
-      onApprove={() => respond.mutate()}
+    <CheckBalance
+      address={parameters.address}
+      feeToken={parameters.capabilities?.feeToken}
       onReject={() => Actions.reject(porto, request)}
-    />
+      query={prepareCallsQuery}
+    >
+      <RevokePermissions
+        {...parameters}
+        loading={respond.isPending}
+        onApprove={() => respond.mutate()}
+        onReject={() => Actions.reject(porto, request)}
+      />
+    </CheckBalance>
   )
 }


### PR DESCRIPTION
Wrap RevokePermissions component with CheckBalance to prompt users  to add funds when trying to revoke permissions with insufficient balance.

Follows the same pattern as RevokeAdmin component:
- Use usePrepareCalls with revokeKeys parameter for fee estimation
- Wrap with CheckBalance component for balance validation
- Support "Add Funds" flow when PaymentError is detected

Fixes #427