### PR TITLE
chore: wrap claude pr comment in <details>

### DIFF
--- a/.github/workflows/wrap-user-comments.yml
+++ b/.github/workflows/wrap-user-comments.yml
@@ -1,0 +1,62 @@
+name: Update Bot PR Comments
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  TARGET_USERNAMES: 'claude'
+
+jobs:
+  wrap-comment:
+    # Only run on pull request comments
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    
+    permissions:
+      pull-requests: write
+      issues: write
+    
+    steps:
+      - name: Check if comment is from specific user
+        id: check-user
+        env:
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          TARGET_USER: ${{ env.TARGET_USERNAMES }}
+        run: |
+          if [ "$COMMENT_USER" = "$TARGET_USER" ]; then
+            echo "should_wrap=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_wrap=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Wrap comment in details
+        if: steps.check-user.outputs.should_wrap == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = context.payload.comment;
+            const body = comment.body;
+            
+            // Check if comment is already wrapped in details
+            if (body.trim().startsWith('<details>') && body.trim().endsWith('</details>')) {
+              console.log('Comment is already wrapped in details tag')
+              return
+            }
+            
+            // Wrap the comment
+            const wrappedBody = `<details>
+            <summary>Comment from ${comment.user.login}</summary>
+            
+            ${body}
+            </details>`
+            
+            // Update the comment
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+              body: wrappedBody
+            })
+            
+            console.log('Comment wrapped successfully')


### PR DESCRIPTION
claude PR reviews are great but they can be too much in a PR that has multiple commits. It currently creates a new comment for every review. This action wraps its comments in `<details>` so that it doesn't take too much space

![CleanShot 2025-06-10 at 11 47 57](https://github.com/user-attachments/assets/c1b1d1bf-dbd2-4e73-9375-0bb72179e9cd)
