### PR TITLE
feat(ci): split into 2 steps and add disallowed_tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,8 +45,8 @@ jobs:
               return false;
             }
 
-  claude-code-action:
-    name: Claude PR Assistant
+  claude-assistant:
+    name: Claude Assistant
     needs: check-permissions
     if: |
       needs.check-permissions.outputs.has-permission == 'true' && (
@@ -70,7 +70,23 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Run Claude PR Action
+      - name: Check if PR review is needed
+        id: check_pr_review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check if this is a PR-related event and not authored by Claude
+            const isPR = context.payload.issue?.pull_request || context.payload.pull_request;
+            const isNotClaude = context.payload.pull_request?.user?.login !== 'claude-bot' && 
+                                context.payload.issue?.user?.login !== 'claude-bot';
+            const shouldReview = isPR && isNotClaude;
+            
+            console.log(`Is PR: ${isPR}, Is not Claude: ${isNotClaude}, Should review: ${shouldReview}`);
+            core.setOutput('should_review', shouldReview);
+            return shouldReview;
+
+      - name: Run Claude Code Action
+        if: steps.check_pr_review.outputs.should_review != 'true'
         uses: anthropics/claude-code-action@beta
         env: 
           NODE_VERSION: 23.9.0
@@ -86,32 +102,8 @@ jobs:
             You MUST create a pull request after completing your task.
             You can create pull requests using the `mcp__github__create_pull_request` tool.
 
-  claude-pr-review:
-    name: Claude PR Review
-    needs: check-permissions
-    if: |
-      needs.check-permissions.outputs.has-permission == 'true' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.labels.*.name, 'claude-action')))
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Install dependencies
-        uses: ./.github/actions/install-dependencies
-
-      - name: Run Claude PR Action
+      - name: Run Claude PR Review
+        if: steps.check_pr_review.outputs.should_review == 'true'
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
             }
 
   claude-code-action:
-    name: Run Claude
+    name: Claude PR Assistant
     needs: check-permissions
     if: |
       needs.check-permissions.outputs.has-permission == 'true' && (
@@ -78,9 +78,63 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: "60"
+          disallowed_tools: "npm,yarn"
           allowed_tools: "mcp__github__create_pull_request,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
           custom_instructions: |
             You MUST follow the development workflow described in .ai/CLAUDE.md.
             You MUST open a draft pull request after creating a branch.
             You MUST create a pull request after completing your task.
             You can create pull requests using the `mcp__github__create_pull_request` tool.
+
+  claude-pr-review:
+    name: Claude PR Review
+    needs: check-permissions
+    if: |
+      needs.check-permissions.outputs.has-permission == 'true' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.labels.*.name, 'claude-action')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          timeout_minutes: "60"
+          disallowed_tools: "npm,yarn"
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
+          direct_prompt: |-
+            Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:
+
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+
+            Focus your review on:
+            - Code quality and best practices
+            - Potential bugs or security issues
+            - Performance considerations
+            - Maintainability and readability
+            - Architecture and design decisions
+
+            Provide specific, actionable feedback. Use inline comments for line-specific issues and include an overall summary when submitting the review.
+            **Important**:
+            - Submit as "COMMENT" type so the review doesn't block the PR.
+            - Wrap your PR review in <details> tags.


### PR DESCRIPTION
- split jobs into steps, one for PR creation one for PR review,
- added `disallowed_tools`,
- added `direct_prompt` to PR review job