### PR TITLE
feat: add EOA upgrade support in dialog with email integration

### DIFF
--- a/apps/dialog/src/routeTree.gen.ts
+++ b/apps/dialog/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DialogWalletupdateAccountImport } from './routes/dialog/wallet
 import { Route as DialogWalletsendCallsImport } from './routes/dialog/wallet_sendCalls'
 import { Route as DialogWalletrevokePermissionsImport } from './routes/dialog/wallet_revokePermissions'
 import { Route as DialogWalletrevokeAdminImport } from './routes/dialog/wallet_revokeAdmin'
+import { Route as DialogWalletprepareUpgradeAccountImport } from './routes/dialog/wallet_prepareUpgradeAccount'
 import { Route as DialogWalletgrantPermissionsImport } from './routes/dialog/wallet_grantPermissions'
 import { Route as DialogWalletgrantAdminImport } from './routes/dialog/wallet_grantAdmin'
 import { Route as DialogWalletconnectImport } from './routes/dialog/wallet_connect'
@@ -66,6 +67,13 @@ const DialogWalletrevokeAdminRoute = DialogWalletrevokeAdminImport.update({
   path: '/dialog/wallet_revokeAdmin',
   getParentRoute: () => rootRoute,
 } as any)
+
+const DialogWalletprepareUpgradeAccountRoute =
+  DialogWalletprepareUpgradeAccountImport.update({
+    id: '/dialog/wallet_prepareUpgradeAccount',
+    path: '/dialog/wallet_prepareUpgradeAccount',
+    getParentRoute: () => rootRoute,
+  } as any)
 
 const DialogWalletgrantPermissionsRoute =
   DialogWalletgrantPermissionsImport.update({
@@ -209,6 +217,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DialogWalletgrantPermissionsImport
       parentRoute: typeof rootRoute
     }
+    '/dialog/wallet_prepareUpgradeAccount': {
+      id: '/dialog/wallet_prepareUpgradeAccount'
+      path: '/dialog/wallet_prepareUpgradeAccount'
+      fullPath: '/dialog/wallet_prepareUpgradeAccount'
+      preLoaderRoute: typeof DialogWalletprepareUpgradeAccountImport
+      parentRoute: typeof rootRoute
+    }
     '/dialog/wallet_revokeAdmin': {
       id: '/dialog/wallet_revokeAdmin'
       path: '/dialog/wallet_revokeAdmin'
@@ -261,6 +276,7 @@ export interface FileRoutesByFullPath {
   '/dialog/wallet_connect': typeof DialogWalletconnectRoute
   '/dialog/wallet_grantAdmin': typeof DialogWalletgrantAdminRoute
   '/dialog/wallet_grantPermissions': typeof DialogWalletgrantPermissionsRoute
+  '/dialog/wallet_prepareUpgradeAccount': typeof DialogWalletprepareUpgradeAccountRoute
   '/dialog/wallet_revokeAdmin': typeof DialogWalletrevokeAdminRoute
   '/dialog/wallet_revokePermissions': typeof DialogWalletrevokePermissionsRoute
   '/dialog/wallet_sendCalls': typeof DialogWalletsendCallsRoute
@@ -280,6 +296,7 @@ export interface FileRoutesByTo {
   '/dialog/wallet_connect': typeof DialogWalletconnectRoute
   '/dialog/wallet_grantAdmin': typeof DialogWalletgrantAdminRoute
   '/dialog/wallet_grantPermissions': typeof DialogWalletgrantPermissionsRoute
+  '/dialog/wallet_prepareUpgradeAccount': typeof DialogWalletprepareUpgradeAccountRoute
   '/dialog/wallet_revokeAdmin': typeof DialogWalletrevokeAdminRoute
   '/dialog/wallet_revokePermissions': typeof DialogWalletrevokePermissionsRoute
   '/dialog/wallet_sendCalls': typeof DialogWalletsendCallsRoute
@@ -300,6 +317,7 @@ export interface FileRoutesById {
   '/dialog/wallet_connect': typeof DialogWalletconnectRoute
   '/dialog/wallet_grantAdmin': typeof DialogWalletgrantAdminRoute
   '/dialog/wallet_grantPermissions': typeof DialogWalletgrantPermissionsRoute
+  '/dialog/wallet_prepareUpgradeAccount': typeof DialogWalletprepareUpgradeAccountRoute
   '/dialog/wallet_revokeAdmin': typeof DialogWalletrevokeAdminRoute
   '/dialog/wallet_revokePermissions': typeof DialogWalletrevokePermissionsRoute
   '/dialog/wallet_sendCalls': typeof DialogWalletsendCallsRoute
@@ -321,6 +339,7 @@ export interface FileRouteTypes {
     | '/dialog/wallet_connect'
     | '/dialog/wallet_grantAdmin'
     | '/dialog/wallet_grantPermissions'
+    | '/dialog/wallet_prepareUpgradeAccount'
     | '/dialog/wallet_revokeAdmin'
     | '/dialog/wallet_revokePermissions'
     | '/dialog/wallet_sendCalls'
@@ -339,6 +358,7 @@ export interface FileRouteTypes {
     | '/dialog/wallet_connect'
     | '/dialog/wallet_grantAdmin'
     | '/dialog/wallet_grantPermissions'
+    | '/dialog/wallet_prepareUpgradeAccount'
     | '/dialog/wallet_revokeAdmin'
     | '/dialog/wallet_revokePermissions'
     | '/dialog/wallet_sendCalls'
@@ -357,6 +377,7 @@ export interface FileRouteTypes {
     | '/dialog/wallet_connect'
     | '/dialog/wallet_grantAdmin'
     | '/dialog/wallet_grantPermissions'
+    | '/dialog/wallet_prepareUpgradeAccount'
     | '/dialog/wallet_revokeAdmin'
     | '/dialog/wallet_revokePermissions'
     | '/dialog/wallet_sendCalls'
@@ -377,6 +398,7 @@ export interface RootRouteChildren {
   DialogWalletconnectRoute: typeof DialogWalletconnectRoute
   DialogWalletgrantAdminRoute: typeof DialogWalletgrantAdminRoute
   DialogWalletgrantPermissionsRoute: typeof DialogWalletgrantPermissionsRoute
+  DialogWalletprepareUpgradeAccountRoute: typeof DialogWalletprepareUpgradeAccountRoute
   DialogWalletrevokeAdminRoute: typeof DialogWalletrevokeAdminRoute
   DialogWalletrevokePermissionsRoute: typeof DialogWalletrevokePermissionsRoute
   DialogWalletsendCallsRoute: typeof DialogWalletsendCallsRoute
@@ -396,6 +418,8 @@ const rootRouteChildren: RootRouteChildren = {
   DialogWalletconnectRoute: DialogWalletconnectRoute,
   DialogWalletgrantAdminRoute: DialogWalletgrantAdminRoute,
   DialogWalletgrantPermissionsRoute: DialogWalletgrantPermissionsRoute,
+  DialogWalletprepareUpgradeAccountRoute:
+    DialogWalletprepareUpgradeAccountRoute,
   DialogWalletrevokeAdminRoute: DialogWalletrevokeAdminRoute,
   DialogWalletrevokePermissionsRoute: DialogWalletrevokePermissionsRoute,
   DialogWalletsendCallsRoute: DialogWalletsendCallsRoute,
@@ -424,6 +448,7 @@ export const routeTree = rootRoute
         "/dialog/wallet_connect",
         "/dialog/wallet_grantAdmin",
         "/dialog/wallet_grantPermissions",
+        "/dialog/wallet_prepareUpgradeAccount",
         "/dialog/wallet_revokeAdmin",
         "/dialog/wallet_revokePermissions",
         "/dialog/wallet_sendCalls",
@@ -463,6 +488,9 @@ export const routeTree = rootRoute
     },
     "/dialog/wallet_grantPermissions": {
       "filePath": "dialog/wallet_grantPermissions.tsx"
+    },
+    "/dialog/wallet_prepareUpgradeAccount": {
+      "filePath": "dialog/wallet_prepareUpgradeAccount.tsx"
     },
     "/dialog/wallet_revokeAdmin": {
       "filePath": "dialog/wallet_revokeAdmin.tsx"

--- a/apps/dialog/src/routes/-components/Email.tsx
+++ b/apps/dialog/src/routes/-components/Email.tsx
@@ -7,7 +7,7 @@ import LucideLogIn from '~icons/lucide/log-in'
 import IconScanFace from '~icons/porto/scan-face'
 
 export function Email(props: Email.Props) {
-  const { loading, onApprove, permissions } = props
+  const { loading, onApprove, permissions, variant = 'sign-in' } = props
 
   const hostname = Dialog.useStore((state) => state.referrer?.url?.hostname)
 
@@ -44,25 +44,29 @@ export function Email(props: Email.Props) {
       <Permissions title="Permissions requested" {...permissions} />
 
       <div className="group flex min-h-[48px] w-full flex-col items-center justify-center space-y-3 px-3 pb-3">
-        <Button
-          className="flex w-full gap-2"
-          data-testid="sign-in"
-          onClick={() => onApprove({ signIn: true })}
-          type="button"
-          variant="accent"
-        >
-          <IconScanFace className="size-5.25" />
-          Sign in
-        </Button>
+        {variant === 'sign-in' && (
+          <Button
+            className="flex w-full gap-2"
+            data-testid="sign-in"
+            onClick={() => onApprove({ signIn: true })}
+            type="button"
+            variant="accent"
+          >
+            <IconScanFace className="size-5.25" />
+            Sign in
+          </Button>
+        )}
 
         <form
           className="flex w-full flex-grow flex-col gap-2"
           onSubmit={onSubmit}
         >
-          <div className="-tracking-[2.8%] flex items-center whitespace-nowrap text-[12px] text-gray9 leading-[17px]">
-            First time?
-            <div className="ms-2 h-px w-full bg-gray4" />
-          </div>
+          {variant === 'sign-in' && (
+            <div className="-tracking-[2.8%] flex items-center whitespace-nowrap text-[12px] text-gray9 leading-[17px]">
+              First time?
+              <div className="ms-2 h-px w-full bg-gray4" />
+            </div>
+          )}
           <div className="relative flex items-center">
             <label className="sr-only" htmlFor="email">
               Email
@@ -81,7 +85,7 @@ export function Email(props: Email.Props) {
             className="w-full gap-2 group-has-[:user-invalid]:cursor-not-allowed group-has-[:user-invalid]:text-gray10"
             data-testid="sign-up"
             type="submit"
-            variant="default"
+            variant={variant === 'sign-in' ? 'default' : 'accent'}
           >
             <span className="hidden group-has-[:user-invalid]:block">
               Invalid email
@@ -101,5 +105,6 @@ export namespace Email {
     loading: boolean
     onApprove: (p: { email?: string; signIn?: boolean }) => void
     permissions?: Permissions.Props
+    variant?: 'sign-in' | 'upgrade'
   }
 }

--- a/apps/dialog/src/routes/dialog/wallet_prepareUpgradeAccount.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_prepareUpgradeAccount.tsx
@@ -1,0 +1,70 @@
+import { useMutation } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { Actions } from 'porto/remote'
+
+import { porto } from '~/lib/Porto'
+import * as Router from '~/lib/Router'
+import { Email } from '../-components/Email'
+import { SignUp } from '../-components/SignUp'
+
+export const Route = createFileRoute('/dialog/wallet_prepareUpgradeAccount')({
+  component: RouteComponent,
+  validateSearch: (search) => {
+    const request = Router.parseSearchRequest(search, {
+      method: 'wallet_prepareUpgradeAccount',
+    })
+    return request
+  },
+})
+
+function RouteComponent() {
+  const request = Route.useSearch()
+  const { params = [] } = request
+  const { capabilities } = params[0] ?? {}
+
+  const respond = useMutation({
+    async mutationFn({ email }: { email?: string | undefined } = {}) {
+      if (!request) throw new Error('no request found.')
+      if (request.method !== 'wallet_prepareUpgradeAccount')
+        throw new Error(
+          'request is not a wallet_prepareUpgradeAccount request.',
+        )
+
+      const params = request.params ?? []
+
+      return Actions.respond(porto, {
+        ...request,
+        params: [
+          {
+            ...params[0],
+            capabilities: {
+              ...params[0]?.capabilities,
+              email: Boolean(email),
+              label: email,
+            },
+          },
+        ],
+      } as typeof request)
+    },
+  })
+
+  if (capabilities?.email ?? true)
+    return (
+      <Email
+        loading={respond.isPending}
+        onApprove={(options) => respond.mutate(options)}
+        permissions={capabilities?.grantPermissions?.permissions}
+        variant="upgrade"
+      />
+    )
+
+  return (
+    <SignUp
+      enableSignIn={false}
+      loading={respond.isPending}
+      onApprove={() => respond.mutate({})}
+      onReject={() => Actions.reject(porto, request)}
+      permissions={capabilities?.grantPermissions?.permissions}
+    />
+  )
+}

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -173,6 +173,8 @@ export type Mode = {
     prepareUpgradeAccount: (parameters: {
       /** Address of the account to import. */
       address: Address.Address
+      /** Whether to link `label` to account address as email. */
+      email?: boolean | undefined
       /** Label to associate with the account. */
       label?: string | undefined
       /** Internal properties. */

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -47,6 +47,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
   } = config
 
   let address_internal: Hex.Hex | undefined
+  let email_internal: string | undefined
 
   const keystoreHost = (() => {
     if (config.keystoreHost === 'self') return undefined
@@ -426,7 +427,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
 
       async prepareUpgradeAccount(parameters) {
-        const { address, label, internal, permissions } = parameters
+        const { address, email, label, internal, permissions } = parameters
         const { client } = internal
 
         const adminKey = !mock
@@ -452,6 +453,8 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
             permissionsFeeLimit: feeToken.permissionsFeeLimit,
           },
         )
+
+        if (email) email_internal = label
 
         return {
           context,
@@ -666,6 +669,12 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           context: context as any,
           signatures,
         })
+
+        if (email_internal)
+          await ServerActions.setEmail(client, {
+            email: email_internal,
+            walletAddress: account.address,
+          })
 
         return { account }
       },

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -413,16 +413,21 @@ export function from<
         }
 
         case 'wallet_prepareUpgradeAccount': {
-          const [{ address, capabilities, chainId, label }] = request._decoded
+          const [{ address, capabilities, chainId }] = request._decoded
             .params ?? [{}]
 
-          const { grantPermissions: permissions } = capabilities ?? {}
+          const {
+            email,
+            label,
+            grantPermissions: permissions,
+          } = capabilities ?? {}
 
           const client = getClient(chainId)
 
           const { context, digests } =
             await getMode().actions.prepareUpgradeAccount({
               address,
+              email,
               internal: {
                 client,
                 config,
@@ -687,6 +692,7 @@ export function from<
             signatures,
           })
 
+          const admins = getAdmins(account.keys ?? [])
           const permissions = getActivePermissions(account.keys ?? [], {
             address: account.address,
           })
@@ -699,6 +705,7 @@ export function from<
           return {
             address: account.address,
             capabilities: {
+              admins,
               ...(permissions.length > 0 ? { permissions } : {}),
             },
           } satisfies Typebox.Static<typeof Rpc.wallet_upgradeAccount.Response>

--- a/src/core/internal/typebox/rpc.ts
+++ b/src/core/internal/typebox/rpc.ts
@@ -260,37 +260,6 @@ export namespace wallet_getPermissions {
   export type Response = Typebox.StaticDecode<typeof Response>
 }
 
-export namespace wallet_prepareUpgradeAccount {
-  export const Capabilities = Type.Object({
-    feeToken: Typebox.Optional(C.feeToken.Request),
-    grantPermissions: Typebox.Optional(C.grantPermissions.Request),
-  })
-  export type Capabilities = Typebox.StaticDecode<typeof Capabilities>
-
-  export const Parameters = Type.Object({
-    address: Primitive.Address,
-    capabilities: Typebox.Optional(Capabilities),
-    chainId: Typebox.Optional(Primitive.Number),
-    label: Typebox.Optional(Type.String()),
-  })
-  export type Parameters = Typebox.StaticDecode<typeof Parameters>
-
-  export const Request = Type.Object({
-    method: Type.Literal('wallet_prepareUpgradeAccount'),
-    params: Type.Tuple([Parameters]),
-  })
-  export type Request = Typebox.StaticDecode<typeof Request>
-
-  export const Response = Type.Object({
-    context: Type.Unknown(),
-    digests: Type.Object({
-      auth: Primitive.Hex,
-      exec: Primitive.Hex,
-    }),
-  })
-  export type Response = Typebox.StaticDecode<typeof Response>
-}
-
 export namespace wallet_revokeAdmin {
   export const Capabilities = Type.Object({
     feeToken: Typebox.Optional(C.feeToken.Request),
@@ -371,6 +340,7 @@ export namespace wallet_upgradeAccount {
   export type Request = Typebox.StaticDecode<typeof Request>
 
   export const ResponseCapabilities = Type.Object({
+    admins: Typebox.Optional(wallet_getAdmins.Response.properties.keys),
     permissions: Typebox.Optional(C.permissions.Response),
   })
   export type ResponseCapabilities = Typebox.StaticDecode<
@@ -597,6 +567,38 @@ export namespace wallet_prepareCalls {
     }),
     digest: Primitive.Hex,
     key: Parameters.properties.key,
+  })
+  export type Response = Typebox.StaticDecode<typeof Response>
+}
+
+export namespace wallet_prepareUpgradeAccount {
+  export const Capabilities = Type.Intersect([
+    wallet_connect.Capabilities,
+    Type.Object({
+      label: Typebox.Optional(Type.String()),
+    }),
+  ])
+  export type Capabilities = Typebox.StaticDecode<typeof Capabilities>
+
+  export const Parameters = Type.Object({
+    address: Primitive.Address,
+    capabilities: Typebox.Optional(Capabilities),
+    chainId: Typebox.Optional(Primitive.Number),
+  })
+  export type Parameters = Typebox.StaticDecode<typeof Parameters>
+
+  export const Request = Type.Object({
+    method: Type.Literal('wallet_prepareUpgradeAccount'),
+    params: Type.Tuple([Parameters]),
+  })
+  export type Request = Typebox.StaticDecode<typeof Request>
+
+  export const Response = Type.Object({
+    context: Type.Unknown(),
+    digests: Type.Object({
+      auth: Primitive.Hex,
+      exec: Primitive.Hex,
+    }),
   })
   export type Response = Typebox.StaticDecode<typeof Response>
 }


### PR DESCRIPTION
## Summary
- Add comprehensive support for upgrading Externally Owned Accounts (EOAs) through the dialog interface with integrated email functionality
- Implement new dialog route, enhanced email component variants, and updated RPC schema to support the upgrade flow

🤖 Generated with [Claude Code](https://claude.ai/code)