### PR TITLE
docs: move CLAUDE.md to root and improve formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,31 +188,48 @@ forge test --config-path ./contracts/demo/foundry.toml
 - Bundle size limits must be respected (`pnpm check:size`)
 - No unused dependencies (`pnpm check:knip`)
 
-## AI Assistant Guidelines
+### PR Template
 
-When working with this repository, AI assistants should follow these additional guidelines:
+AI Assistants must follow the PR template:
 
-### Documentation Writing Style
+```markdown
+### Summary
+
+<!-- Brief summary of the PR. -->
+
+### Details
+
+<!-- Detailed list of changes in bullet point format. -->
+
+### Checklist
+
+- [ ] All tests pass
+- [ ] Code is properly formatted
+- [ ] Types are valid
+- [ ] Build succeeds
+```
+
+## Documentation Writing Style
 
 When writing or editing documentation files, follow these style guidelines:
 
-#### Voice and Perspective
+### Voice and Perspective
 
-##### Use Third Person for Technical Documentation
+#### Use Third Person for Technical Documentation
 
 - ✅ "The Porto SDK is a TypeScript library designed for Applications and Wallets"
 - ✅ "Porto can be used in conjunction with Wagmi"
 - ✅ "This will internally inject a Porto instance"
 - ❌ "We designed Porto to..." or "Our SDK allows you to..."
 
-##### Use Second Person for Instructions
+#### Use Second Person for Instructions
 
 When giving direct instructions to developers, use second person:
 
 - ✅ "You can get started with Porto by creating a new instance"
 - ✅ "After you have set up Wagmi, you can set up Porto"
 
-##### Avoid First Person
+#### Avoid First Person
 
 Never use "we," "our," or "I" in technical documentation:
 
@@ -223,7 +240,7 @@ Never use "we," "our," or "I" in technical documentation:
 - ❌ "We do not really care about..."
 - ✅ "The provable resource-lock capabilities are not prioritized..."
 
-#### Examples
+### Examples
 
 **Before (First Person):**
 
@@ -255,7 +272,7 @@ When writing changelog entries, follow these guidelines:
 - Include relevant file paths and line numbers when applicable
 - Use passive voice when appropriate to maintain objectivity
 
-### PR Review Comments
+## PR Review Comments
 
 - @claude should **Always wrap PR review comments in `<details>` tags**
 - Use descriptive summary text in the `<summary>` tag


### PR DESCRIPTION
### Summary

Move CLAUDE.md from `.ai/` directory to project root and improve its formatting and structure for better accessibility.

### Details

- Move `.ai/CLAUDE.md` to root directory (`CLAUDE.md`)
- Improve document structure and formatting
- Add PR template section for AI assistants
- Reorganize sections for better readability
- Maintain all existing content and guidelines

### Checklist

- [x] All tests pass
- [x] Code is properly formatted  
- [x] Types are valid
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)