### PR TITLE
ci: separate Claude workflows into focused actions

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,10 +1,8 @@
-name: Claude PR Assistant
+name: Claude Assistant
 
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [ready_for_review]
   pull_request_review_comment:
     types: [created]
   issues:
@@ -72,23 +70,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Check if PR review is needed
-        id: check_pr_review
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Check if this is a PR-related event and not authored by Claude
-            const isPR = context.payload.issue?.pull_request || context.payload.pull_request;
-            const isNotClaude = context.payload.pull_request?.user?.login !== 'claude-bot' && 
-                                context.payload.issue?.user?.login !== 'claude-bot';
-            const shouldReview = isPR && isNotClaude;
-            
-            console.log(`Is PR: ${isPR}, Is not Claude: ${isNotClaude}, Should review: ${shouldReview}`);
-            core.setOutput('should_review', shouldReview);
-            return shouldReview;
-
       - name: Run Claude Code Action
-        if: steps.check_pr_review.outputs.should_review != 'true'
         uses: anthropics/claude-code-action@beta
         env: 
           NODE_VERSION: 23.9.0
@@ -99,36 +81,7 @@ jobs:
           disallowed_tools: "npm,yarn"
           allowed_tools: "mcp__github__create_pull_request,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
           custom_instructions: |
-            You MUST follow the development workflow described in .ai/CLAUDE.md.
+            You MUST follow the development workflow described in CLAUDE.md.
             You MUST open a draft pull request after creating a branch.
             You MUST create a pull request after completing your task.
             You can create pull requests using the `mcp__github__create_pull_request` tool.
-
-      - name: Run Claude PR Review
-        if: steps.check_pr_review.outputs.should_review == 'true'
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          timeout_minutes: "60"
-          disallowed_tools: "npm,yarn"
-          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
-          direct_prompt: |-
-            Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:
-
-            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
-            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
-            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
-
-            Focus your review on:
-            - Code quality and best practices
-            - Potential bugs or security issues
-            - Performance considerations
-            - Maintainability and readability
-            - Architecture and design decisions
-
-            Provide specific, actionable feedback. Use inline comments for line-specific issues and include an overall summary when submitting the review.
-            **Important**:
-            - Submit as "COMMENT" type so the review doesn't block the PR.
-            - Wrap your PR review in <details> tags.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,61 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  claude-review:
+    name: Claude Review
+    needs: check-permissions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check
+        id: check_pr_review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check if this is a PR-related event and not authored by Claude
+            const isNotClaude = context.payload.pull_request?.user?.login !== 'claude-bot' && 
+                                context.payload.issue?.user?.login !== 'claude-bot';
+            core.setOutput('should_review', isNotClaude);
+            return isNotClaude;
+
+      - name: Run Claude PR Review
+        if: steps.check_pr_review.outputs.should_review == 'true'
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          timeout_minutes: "60"
+          disallowed_tools: "npm,yarn"
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
+          direct_prompt: |-
+            Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:
+
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+
+            Focus your review on:
+            - Code quality and best practices
+            - Potential bugs or security issues
+            - Performance considerations
+            - Maintainability and readability
+            - Architecture and design decisions
+
+            Provide specific, actionable feedback. Use inline comments for line-specific issues and include an overall summary when submitting the review.
+            **Important**:
+            - Submit as "COMMENT" type so the review doesn't block the PR.
+            - Wrap your PR review in <details> tags.


### PR DESCRIPTION
### Summary

Separate the Claude GitHub Actions workflow into two focused workflows: one for general assistance and one dedicated to PR reviews.

### Details

- Renamed `claude.yml` to `claude-code.yml` for general Claude assistance
- Created new `claude-review.yml` workflow dedicated to PR reviews
- Removed complex PR review logic from the main Claude workflow
- Simplified `claude-code.yml` to focus on issue comments and general tasks
- Added proper permissions and check logic to `claude-review.yml`
- Updated custom instructions to reference correct CLAUDE.md path

### Areas Touched

- GitHub Actions Workflows (`.github/workflows/`)

🤖 Generated with [Claude Code](https://claude.ai/code)