### PR TITLE
feat: wallet_connect signInWithEthereum capability

### DIFF
--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -1,6 +1,7 @@
 import * as AbiItem from 'ox/AbiItem'
 import type * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
+import * as Siwe from 'ox/Siwe'
 
 import type * as Account from '../../viem/Account.js'
 import type * as Key from '../../viem/Key.js'
@@ -13,7 +14,7 @@ import * as PreCalls from './preCalls.js'
 import * as FeeToken from './typebox/feeToken.js'
 import type * as RpcRequest from './typebox/request.js'
 import * as Typebox from './typebox/typebox.js'
-import type { PartialBy } from './types.js'
+import type { Compute, PartialBy } from './types.js'
 
 type Request = RpcRequest.parseRequest.ReturnType
 
@@ -52,9 +53,18 @@ export type Mode = {
       label?: string | undefined
       /** Permissions to grant. */
       permissions?: PermissionsRequest.PermissionsRequest | undefined
+      /** Adds support for offchain authentication using ERC-4361. */
+      signInWithEthereum?: Compute<Omit<Siwe.Message, 'address'>> | undefined
     }) => Promise<{
       /** Account. */
       account: Account.Account
+      /** Formatted SIWE message and signature. */
+      signInWithEthereum?:
+        | {
+            message: string
+            signature: Hex.Hex
+          }
+        | undefined
     }>
 
     getAccountVersion: (parameters: {
@@ -133,11 +143,20 @@ export type Mode = {
       internal: ActionsInternal
       /** Permissions to grant. */
       permissions?: PermissionsRequest.PermissionsRequest | undefined
+      /** Adds support for offchain authentication using ERC-4361. */
+      signInWithEthereum?: Compute<Omit<Siwe.Message, 'address'>> | undefined
     }) => Promise<{
       /** Accounts. */
       accounts: readonly Account.Account[]
       /** Pre-calls to be executed (e.g. key authorization). */
       preCalls?: PreCalls.PreCalls | undefined
+      /** Formatted SIWE message and signature. */
+      signInWithEthereum?:
+        | {
+            message: string
+            signature: Hex.Hex
+          }
+        | undefined
     }>
 
     prepareCalls: (parameters: {

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -7,6 +7,7 @@ import * as PersonalMessage from 'ox/PersonalMessage'
 import * as Provider from 'ox/Provider'
 import * as PublicKey from 'ox/PublicKey'
 import * as Secp256k1 from 'ox/Secp256k1'
+import * as Siwe from 'ox/Siwe'
 import * as TypedData from 'ox/TypedData'
 import * as Value from 'ox/Value'
 import * as WebAuthnP256 from 'ox/WebAuthnP256'
@@ -65,7 +66,8 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
 
       async createAccount(parameters) {
-        const { email, label, permissions, internal } = parameters
+        const { email, label, permissions, internal, signInWithEthereum } =
+          parameters
         const { client } = internal
 
         const eoa = Account.fromPrivateKey(Secp256k1.randomPrivateKey())
@@ -100,7 +102,29 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
             walletAddress: account.address,
           })
 
-        return { account }
+        const { message, signature } = await (async () => {
+          if (!signInWithEthereum) return {}
+          const key = account.keys?.find(
+            (key) => key.role === 'admin' && key.privateKey,
+          )
+          if (!key) throw new Error('cannot find admin key to sign with.')
+          const message = Siwe.createMessage({
+            ...signInWithEthereum,
+            address: account.address,
+          })
+          return {
+            message,
+            signature: await Account.sign(account, {
+              key,
+              payload: PersonalMessage.getSignPayload(Hex.fromString(message)),
+            }),
+          }
+        })()
+
+        return {
+          account,
+          signInWithEthereum: signature ? { message, signature } : undefined,
+        }
       },
 
       async getAccountVersion(parameters) {
@@ -260,7 +284,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
 
       async loadAccounts(parameters) {
-        const { internal, permissions } = parameters
+        const { internal, permissions, signInWithEthereum } = parameters
         const {
           client,
           config: { storage },
@@ -375,9 +399,29 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
             storage,
           })
 
+        const siweResult = await (async () => {
+          if (!signInWithEthereum) return {}
+          const key = account.keys?.find(
+            (key) => key.role === 'admin' && key.privateKey,
+          )
+          if (!key) throw new Error('cannot find admin key to sign with.')
+          const message = Siwe.createMessage({
+            ...signInWithEthereum,
+            address: account.address,
+          })
+          return {
+            message,
+            signature: await Account.sign(account, {
+              key,
+              payload: PersonalMessage.getSignPayload(Hex.fromString(message)),
+            }),
+          }
+        })()
+
         return {
           accounts: [account],
           preCalls,
+          signInWithEthereum: siweResult.signature ? siweResult : undefined,
         }
       },
 

--- a/src/core/internal/typebox/capabilities.ts
+++ b/src/core/internal/typebox/capabilities.ts
@@ -27,6 +27,30 @@ export namespace createAccount {
   export type Request = Typebox.StaticDecode<typeof Request>
 }
 
+export namespace signInWithEthereum {
+  export const Request = Type.Object({
+    chainId: Primitive.Number,
+    domain: Type.String(),
+    expirationTime: Typebox.Optional(Type.Date()),
+    issuedAt: Typebox.Optional(Type.Date()),
+    nonce: Type.String(),
+    notBefore: Typebox.Optional(Type.Date()),
+    requestId: Typebox.Optional(Type.String()),
+    resources: Typebox.Optional(Type.Array(Type.String())),
+    scheme: Typebox.Optional(Type.String()),
+    statement: Typebox.Optional(Type.String()),
+    uri: Type.String(),
+    version: Typebox.Optional(Type.Literal('1')),
+  })
+  export type Request = Typebox.StaticDecode<typeof Request>
+
+  export const Response = Type.Object({
+    message: Type.String(),
+    signature: Primitive.Hex,
+  })
+  export type Response = Typebox.StaticDecode<typeof Response>
+}
+
 export namespace feeToken {
   export const GetCapabilitiesResponse = Type.Object({
     supported: Type.Boolean(),

--- a/src/core/internal/typebox/rpc.ts
+++ b/src/core/internal/typebox/rpc.ts
@@ -413,6 +413,7 @@ export namespace wallet_connect {
     grantPermissions: Typebox.Optional(C.grantPermissions.Request),
     preCalls: Typebox.Optional(C.preCalls.Request),
     selectAccount: Typebox.Optional(Type.Boolean()),
+    signInWithEthereum: Typebox.Optional(C.signInWithEthereum.Request),
   })
   export type Capabilities = Typebox.StaticDecode<typeof Capabilities>
 
@@ -432,6 +433,7 @@ export namespace wallet_connect {
     admins: Typebox.Optional(wallet_getAdmins.Response.properties.keys),
     permissions: Typebox.Optional(C.permissions.Response),
     preCalls: Typebox.Optional(C.preCalls.Response),
+    signInWithEthereum: Typebox.Optional(C.signInWithEthereum.Response),
   })
   export type ResponseCapabilities = Typebox.StaticDecode<
     typeof ResponseCapabilities


### PR DESCRIPTION
Adds `signInWithEthereum` [capability](https://github.com/ethereum/ERCs/blob/abd1c9f4eda2d6ad06ade0e3af314637a27d1ee7/ERCS/erc-7846.md#example) to `'wallet_connect'`.