### PR TITLE
feat: dialog errors

### DIFF
--- a/apps/dialog/src/lib/Dialog.ts
+++ b/apps/dialog/src/lib/Dialog.ts
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/shallow'
 import { createStore } from 'zustand/vanilla'
 
 export const store = createStore<store.State>(() => ({
+  error: null,
   mode: 'popup-standalone',
   referrer: undefined,
 }))
@@ -16,6 +17,13 @@ export declare namespace store {
           url?: URL | undefined
         })
       | undefined
+    error: {
+      action: 'close' | 'retry-in-popup'
+      message: string
+      name: string
+      secondaryMessage?: string
+      title: string
+    } | null
   }
 }
 type Payload = Extract<Messenger.Payload<'__internal'>, { type: 'init' }>

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -119,21 +119,23 @@ function RouteComponent() {
             className="flex flex-grow *:w-full"
             key={request?.id ? request.id.toString() : '-1'} // rehydrate on id changes
           >
-            <CheckUnsupportedBrowser>
-              <CheckReferrer>
-                {status === 'connecting' || status === 'reconnecting' ? (
-                  <Layout loading loadingTitle="Loading...">
-                    <div />
-                  </Layout>
-                ) : search.requireUpdatedAccount ? (
-                  <UpdateAccount.CheckUpdate>
+            <CheckError>
+              <CheckUnsupportedBrowser>
+                <CheckReferrer>
+                  {status === 'connecting' || status === 'reconnecting' ? (
+                    <Layout loading loadingTitle="Loading…">
+                      <div />
+                    </Layout>
+                  ) : search.requireUpdatedAccount ? (
+                    <UpdateAccount.CheckUpdate>
+                      <Outlet />
+                    </UpdateAccount.CheckUpdate>
+                  ) : (
                     <Outlet />
-                  </UpdateAccount.CheckUpdate>
-                ) : (
-                  <Outlet />
-                )}
-              </CheckReferrer>
-            </CheckUnsupportedBrowser>
+                  )}
+                </CheckReferrer>
+              </CheckUnsupportedBrowser>
+            </CheckError>
           </div>
         </div>
       </div>
@@ -148,6 +150,92 @@ function RouteComponent() {
       </React.Suspense>
     </>
   )
+}
+
+function CheckError(props: CheckError.Props) {
+  const { children } = props
+
+  const error = Dialog.useStore((state) => state.error)
+
+  if (!error) return children
+
+  const closeAndClearError = () => {
+    Actions.rejectAll(porto)
+    setTimeout(() => {
+      Dialog.store.setState({ error: null })
+    }, 100)
+  }
+
+  const mainAction =
+    error.action === 'retry-in-popup'
+      ? {
+          label: 'Try in popup',
+          onClick: () => {
+            // clear error state and switch to popup mode
+            Dialog.store.setState({ error: null })
+            porto.messenger.send('__internal', {
+              mode: 'popup',
+              type: 'switch',
+            })
+          },
+        }
+      : {
+          label: 'Close',
+          onClick: closeAndClearError,
+        }
+
+  const secondaryAction = error.action !== 'close' && {
+    label: 'Cancel',
+    onClick: closeAndClearError,
+  }
+
+  return (
+    <Layout>
+      <Layout.Header className="flex-grow">
+        <Layout.Header.Default
+          content={
+            <div className="space-y-2">
+              <div>{error.message}</div>
+              {error.secondaryMessage && (
+                <div className="text-secondary">{error.secondaryMessage}</div>
+              )}
+            </div>
+          }
+          icon={LucideCircleAlert}
+          title={error.title}
+          variant="warning"
+        />
+      </Layout.Header>
+      <Layout.Footer>
+        <Layout.Footer.Actions>
+          {secondaryAction && (
+            <Button
+              data-testid="secondary-action"
+              onClick={secondaryAction.onClick}
+              type="button"
+            >
+              {secondaryAction.label}
+            </Button>
+          )}
+          <Button
+            className="flex-grow"
+            data-testid="primary-action"
+            onClick={mainAction.onClick}
+            type="button"
+            variant="accent"
+          >
+            {mainAction.label}
+          </Button>
+        </Layout.Footer.Actions>
+      </Layout.Footer>
+    </Layout>
+  )
+}
+
+declare namespace CheckError {
+  type Props = {
+    children: React.ReactNode
+  }
 }
 
 function CheckReferrer(props: CheckReferrer.Props) {

--- a/apps/dialog/src/routes/dialog/wallet_connect.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_connect.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Actions, Hooks } from 'porto/remote'
 
+import * as Dialog from '~/lib/Dialog'
 import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
 import { Email } from '../-components/Email'
@@ -48,28 +49,52 @@ function RouteComponent() {
 
       const params = request.params ?? []
 
-      return Actions.respond(porto, {
-        ...request,
-        params: [
-          {
-            ...params[0],
-            capabilities: {
-              ...params[0]?.capabilities,
-              createAccount: email
-                ? {
-                    ...(typeof params[0]?.capabilities?.createAccount ===
-                    'object'
-                      ? params[0]?.capabilities?.createAccount
-                      : {}),
-                    label: email,
-                  }
-                : params[0]?.capabilities?.createAccount || !signIn,
-              email: Boolean(email),
-              selectAccount,
+      return Actions.respond(
+        porto,
+        {
+          ...request,
+          params: [
+            {
+              ...params[0],
+              capabilities: {
+                ...params[0]?.capabilities,
+                createAccount: email
+                  ? {
+                      ...(typeof params[0]?.capabilities?.createAccount ===
+                      'object'
+                        ? params[0]?.capabilities?.createAccount
+                        : {}),
+                      label: email,
+                    }
+                  : params[0]?.capabilities?.createAccount || !signIn,
+                email: Boolean(email),
+                selectAccount,
+              },
             },
+          ],
+        },
+        {
+          onError: (e) => {
+            if (
+              e?.message?.includes("Invalid 'sameOriginWithAncestors' value")
+            ) {
+              Dialog.store.setState({
+                error: {
+                  action: 'retry-in-popup',
+                  message:
+                    'Your browser doesn’t support passkey creation in the current context.',
+                  name: 'CREDENTIAL_CREATION_FAILED',
+                  secondaryMessage:
+                    'Please try again in a popup window for better compatibility.',
+                  title: 'Passkey Creation Not Supported',
+                },
+              })
+              // Prevent the response from being sent since the error is handled by the dialog
+              return { cancelResponse: true }
+            }
           },
-        ],
-      } as typeof request)
+        },
+      )
     },
   })
 

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -54,7 +54,7 @@ export function iframe(options: iframe.Options = {}) {
       const { host, internal } = parameters
       const { store } = internal
 
-      const fallback = popup()?.setup(parameters)
+      const fallback = popup().setup(parameters)
 
       let open = false
 
@@ -177,6 +177,11 @@ export function iframe(options: iframe.Options = {}) {
           iframe.style.height = `${payload.height}px`
           if (!isMobile()) iframe.style.width = `${payload.width}px`
         }
+
+        if (payload.type === 'switch' && payload.mode === 'popup') {
+          fallback.open()
+          fallback.syncRequests(store.getState().requestQueue)
+        }
       })
 
       function onEscape(event: KeyboardEvent) {
@@ -200,7 +205,7 @@ export function iframe(options: iframe.Options = {}) {
 
       return {
         close() {
-          fallback?.close()
+          fallback.close()
           open = false
           root.close()
           Object.assign(document.body.style, bodyStyle ?? '')
@@ -221,7 +226,7 @@ export function iframe(options: iframe.Options = {}) {
           }
         },
         destroy() {
-          fallback?.destroy()
+          fallback.destroy()
           this.close()
           document.removeEventListener('keydown', onEscape)
           messenger.destroy()

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -71,6 +71,10 @@ export type Schema = [
           }
         }
       | {
+          type: 'switch'
+          mode: 'inline-iframe' | 'iframe' | 'popup' | 'popup-standalone'
+        }
+      | {
           type: 'resize'
           height?: number | undefined
           width?: number | undefined

--- a/src/remote/Actions.ts
+++ b/src/remote/Actions.ts
@@ -61,9 +61,14 @@ export async function respond<result>(
   porto: Pick<Remote.Porto<any>, 'messenger' | 'provider'>,
   request: Porto.QueuedRequest['request'],
   options?: {
-    selector?: (result: result) => unknown
     error?: RpcResponse.ErrorObject | undefined
+    onError?: (error: RpcResponse.BaseError) =>
+      | undefined
+      | {
+          cancelResponse: boolean
+        }
     result?: result | undefined
+    selector?: (result: result) => unknown
   },
 ) {
   const { messenger, provider } = porto
@@ -94,6 +99,11 @@ export async function respond<result>(
     )
   } catch (e) {
     const error = e as RpcResponse.BaseError
+    if (options?.onError?.(error)?.cancelResponse === true) {
+      // If the onError callback sets cancelResponse to true,
+      // we do not send a response.
+      return
+    }
     messenger.send(
       'rpc-response',
       Object.assign(RpcResponse.from({ ...shared, error, status: 'error' }), {


### PR DESCRIPTION
This PR adds errors occuring at the dialog level.

This is also used to get around the Firefox + Bitwarden error [when calling WebAuthnP256.createCredential() from inside an iframe](https://github.com/bitwarden/clients/issues/12590).

Notes:

- A new error object has been added to the Dialog store.
- In the main dialog route, the `<CheckError />` component detects if an
  error is present in the store and displays the corresponding screen.
- Actions.respond has been extended to accept a `onError()` callback, that
  allows to cancel the response (by returning `{ cancelResponse: true }`).
- In the messenger, a new `switch` payload type has been added,
  which allows to request switching to another mode.