### PR TITLE
feat(id): add SKIP_MKCERT support for development

### DIFF
--- a/apps/id/vite.config.ts
+++ b/apps/id/vite.config.ts
@@ -17,6 +17,7 @@ const commitSha =
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  const skipMkcert = env.SKIP_MKCERT === 'true' || mode === 'test'
 
   // don't index id.porto.sh except in production
   if (env.NODE_ENV === 'production' && env.VITE_VERCEL_ENV === 'production') {
@@ -35,15 +36,17 @@ export default defineConfig(({ mode }) => {
       'process.env': {},
     },
     plugins: [
-      Mkcert({
-        hosts: [
-          'localhost',
-          'prod.localhost',
-          'stg.localhost',
-          'dev.localhost',
-          'anvil.localhost',
-        ],
-      }),
+      skipMkcert
+        ? null
+        : Mkcert({
+            hosts: [
+              'localhost',
+              'prod.localhost',
+              'stg.localhost',
+              'dev.localhost',
+              'anvil.localhost',
+            ],
+          }),
       Tailwindcss(),
       React(),
       Icons({

--- a/apps/id/vite.config.ts
+++ b/apps/id/vite.config.ts
@@ -17,7 +17,7 @@ const commitSha =
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  const skipMkcert = env.SKIP_MKCERT === 'true' || mode === 'test'
+  const skipMkcert = env.SKIP_MKCERT === 'true'
 
   // don't index id.porto.sh except in production
   if (env.NODE_ENV === 'production' && env.VITE_VERCEL_ENV === 'production') {


### PR DESCRIPTION
Matches https://github.com/ithacaxyz/porto/blob/main/apps/playground/vite.config.ts and https://github.com/ithacaxyz/porto/blob/main/apps/dialog/vite.config.ts so now can all run locally when user runs `SKIP_MKCERT=true pnpm dev`