### PR TITLE
feat(cli): add `Dialog.cli()`; refactor CLI account creation

### DIFF
--- a/.changeset/fuzzy-rules-exist.md
+++ b/.changeset/fuzzy-rules-exist.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+**CLI:** Refactored account onboarding.

--- a/apps/dialog/src/lib/Dialog.ts
+++ b/apps/dialog/src/lib/Dialog.ts
@@ -3,11 +3,26 @@ import * as Zustand from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import { createStore } from 'zustand/vanilla'
 
-export const store = createStore<store.State>(() => ({
-  error: null,
-  mode: 'popup-standalone',
-  referrer: undefined,
-}))
+export const store = createStore<store.State>(() => {
+  const referrer = (() => {
+    const referrer = new URLSearchParams(window.location.search).get('referrer')
+    if (!referrer) return undefined
+    try {
+      const parsed = JSON.parse(referrer)
+      return {
+        ...parsed,
+        url: parsed.url ? new URL(parsed.url) : undefined,
+      }
+    } catch {}
+    return undefined
+  })()
+
+  return {
+    error: null,
+    mode: 'popup-standalone',
+    referrer,
+  }
+})
 
 export declare namespace store {
   type State = {

--- a/apps/dialog/src/lib/Router.ts
+++ b/apps/dialog/src/lib/Router.ts
@@ -19,6 +19,10 @@ export function parseSearchRequest<
 ): parseSearchRequest.ReturnType<method> {
   const { method } = parameters
   try {
+    // Avoid re-parsing already decoded requests to prevent double-processing
+    if ('_decoded' in search && search._decoded) return search as never
+    if (search._decoded) return search as never
+
     const request = RpcRequest.parseRequest(search)
     if (request.method === method)
       return {

--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -64,12 +64,26 @@ const offDialogRequest = Events.onDialogRequest(
       })
 
     Router.router.navigate({
-      search: (search) =>
-        ({ ...search, ...request, account, requireUpdatedAccount }) as never,
+      search: (search) => {
+        return {
+          ...search,
+          _decoded: undefined,
+          ...request,
+          account,
+          requireUpdatedAccount,
+        } as never
+      },
       to: '/dialog/' + (request?.method ?? ''),
     })
   },
 )
+
+porto.messenger.on('success', (payload) => {
+  Router.router.navigate({
+    search: (search) => ({ ...search, ...payload }) as never,
+    to: '/dialog/success',
+  })
+})
 
 porto.ready()
 

--- a/apps/dialog/src/routeTree.gen.ts
+++ b/apps/dialog/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as DialogWalletgrantPermissionsImport } from './routes/dialog/wal
 import { Route as DialogWalletgrantAdminImport } from './routes/dialog/wallet_grantAdmin'
 import { Route as DialogWalletconnectImport } from './routes/dialog/wallet_connect'
 import { Route as DialogWalletaddFundsImport } from './routes/dialog/wallet_addFunds'
+import { Route as DialogSuccessImport } from './routes/dialog/success'
 import { Route as DialogPlaygroundImport } from './routes/dialog/playground'
 import { Route as DialogPersonalsignImport } from './routes/dialog/personal_sign'
 import { Route as DialogEthsendTransactionImport } from './routes/dialog/eth_sendTransaction'
@@ -97,6 +98,12 @@ const DialogWalletconnectRoute = DialogWalletconnectImport.update({
 const DialogWalletaddFundsRoute = DialogWalletaddFundsImport.update({
   id: '/dialog/wallet_addFunds',
   path: '/dialog/wallet_addFunds',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const DialogSuccessRoute = DialogSuccessImport.update({
+  id: '/dialog/success',
+  path: '/dialog/success',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -189,6 +196,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DialogPlaygroundImport
       parentRoute: typeof rootRoute
     }
+    '/dialog/success': {
+      id: '/dialog/success'
+      path: '/dialog/success'
+      fullPath: '/dialog/success'
+      preLoaderRoute: typeof DialogSuccessImport
+      parentRoute: typeof rootRoute
+    }
     '/dialog/wallet_addFunds': {
       id: '/dialog/wallet_addFunds'
       path: '/dialog/wallet_addFunds'
@@ -272,6 +286,7 @@ export interface FileRoutesByFullPath {
   '/dialog/eth_sendTransaction': typeof DialogEthsendTransactionRoute
   '/dialog/personal_sign': typeof DialogPersonalsignRoute
   '/dialog/playground': typeof DialogPlaygroundRoute
+  '/dialog/success': typeof DialogSuccessRoute
   '/dialog/wallet_addFunds': typeof DialogWalletaddFundsRoute
   '/dialog/wallet_connect': typeof DialogWalletconnectRoute
   '/dialog/wallet_grantAdmin': typeof DialogWalletgrantAdminRoute
@@ -292,6 +307,7 @@ export interface FileRoutesByTo {
   '/dialog/eth_sendTransaction': typeof DialogEthsendTransactionRoute
   '/dialog/personal_sign': typeof DialogPersonalsignRoute
   '/dialog/playground': typeof DialogPlaygroundRoute
+  '/dialog/success': typeof DialogSuccessRoute
   '/dialog/wallet_addFunds': typeof DialogWalletaddFundsRoute
   '/dialog/wallet_connect': typeof DialogWalletconnectRoute
   '/dialog/wallet_grantAdmin': typeof DialogWalletgrantAdminRoute
@@ -313,6 +329,7 @@ export interface FileRoutesById {
   '/dialog/eth_sendTransaction': typeof DialogEthsendTransactionRoute
   '/dialog/personal_sign': typeof DialogPersonalsignRoute
   '/dialog/playground': typeof DialogPlaygroundRoute
+  '/dialog/success': typeof DialogSuccessRoute
   '/dialog/wallet_addFunds': typeof DialogWalletaddFundsRoute
   '/dialog/wallet_connect': typeof DialogWalletconnectRoute
   '/dialog/wallet_grantAdmin': typeof DialogWalletgrantAdminRoute
@@ -335,6 +352,7 @@ export interface FileRouteTypes {
     | '/dialog/eth_sendTransaction'
     | '/dialog/personal_sign'
     | '/dialog/playground'
+    | '/dialog/success'
     | '/dialog/wallet_addFunds'
     | '/dialog/wallet_connect'
     | '/dialog/wallet_grantAdmin'
@@ -354,6 +372,7 @@ export interface FileRouteTypes {
     | '/dialog/eth_sendTransaction'
     | '/dialog/personal_sign'
     | '/dialog/playground'
+    | '/dialog/success'
     | '/dialog/wallet_addFunds'
     | '/dialog/wallet_connect'
     | '/dialog/wallet_grantAdmin'
@@ -373,6 +392,7 @@ export interface FileRouteTypes {
     | '/dialog/eth_sendTransaction'
     | '/dialog/personal_sign'
     | '/dialog/playground'
+    | '/dialog/success'
     | '/dialog/wallet_addFunds'
     | '/dialog/wallet_connect'
     | '/dialog/wallet_grantAdmin'
@@ -394,6 +414,7 @@ export interface RootRouteChildren {
   DialogEthsendTransactionRoute: typeof DialogEthsendTransactionRoute
   DialogPersonalsignRoute: typeof DialogPersonalsignRoute
   DialogPlaygroundRoute: typeof DialogPlaygroundRoute
+  DialogSuccessRoute: typeof DialogSuccessRoute
   DialogWalletaddFundsRoute: typeof DialogWalletaddFundsRoute
   DialogWalletconnectRoute: typeof DialogWalletconnectRoute
   DialogWalletgrantAdminRoute: typeof DialogWalletgrantAdminRoute
@@ -414,6 +435,7 @@ const rootRouteChildren: RootRouteChildren = {
   DialogEthsendTransactionRoute: DialogEthsendTransactionRoute,
   DialogPersonalsignRoute: DialogPersonalsignRoute,
   DialogPlaygroundRoute: DialogPlaygroundRoute,
+  DialogSuccessRoute: DialogSuccessRoute,
   DialogWalletaddFundsRoute: DialogWalletaddFundsRoute,
   DialogWalletconnectRoute: DialogWalletconnectRoute,
   DialogWalletgrantAdminRoute: DialogWalletgrantAdminRoute,
@@ -444,6 +466,7 @@ export const routeTree = rootRoute
         "/dialog/eth_sendTransaction",
         "/dialog/personal_sign",
         "/dialog/playground",
+        "/dialog/success",
         "/dialog/wallet_addFunds",
         "/dialog/wallet_connect",
         "/dialog/wallet_grantAdmin",
@@ -476,6 +499,9 @@ export const routeTree = rootRoute
     },
     "/dialog/playground": {
       "filePath": "dialog/playground.tsx"
+    },
+    "/dialog/success": {
+      "filePath": "dialog/success.tsx"
     },
     "/dialog/wallet_addFunds": {
       "filePath": "dialog/wallet_addFunds.tsx"

--- a/apps/dialog/src/routes/-components/AddFunds.tsx
+++ b/apps/dialog/src/routes/-components/AddFunds.tsx
@@ -75,6 +75,8 @@ export function AddFunds(props: AddFunds.Props) {
     'default',
   )
 
+  if (deposit.isSuccess) return
+
   if (view === 'default')
     return (
       <Layout loading={loading} loadingTitle="Adding funds...">
@@ -322,7 +324,7 @@ export declare namespace AddFunds {
     address?: Address.Address | undefined
     onApprove: (result: { id: Hex.Hex }) => void
     onReject?: () => void
-    tokenAddress: Address.Address
+    tokenAddress?: Address.Address | undefined
     value?: bigint | undefined
   }
 }

--- a/apps/dialog/src/routes/-components/Email.tsx
+++ b/apps/dialog/src/routes/-components/Email.tsx
@@ -15,6 +15,9 @@ export function Email(props: Email.Props) {
     variant = 'sign-in',
   } = props
 
+  const cli = Dialog.useStore((state) =>
+    state.referrer?.url?.toString().startsWith('cli'),
+  )
   const hostname = Dialog.useStore((state) => state.referrer?.url?.hostname)
 
   const onSubmit = React.useCallback<React.FormEventHandler<HTMLFormElement>>(
@@ -27,21 +30,23 @@ export function Email(props: Email.Props) {
     [onApprove],
   )
 
+  const content = cli ? undefined : (
+    <>
+      Authenticate with your Porto account to start using{' '}
+      {hostname ? (
+        <span className="font-medium">{hostname}</span>
+      ) : (
+        'this website'
+      )}
+      .
+    </>
+  )
+
   return (
     <Layout loading={loading} loadingTitle="Signing up...">
       <Layout.Header className="flex-grow">
         <Layout.Header.Default
-          content={
-            <>
-              Authenticate with your Porto account to start using{' '}
-              {hostname ? (
-                <span className="font-medium">{hostname}</span>
-              ) : (
-                'this website'
-              )}
-              .
-            </>
-          }
+          content={content}
           icon={LucideLogIn}
           title="Get started"
         />
@@ -113,6 +118,6 @@ export namespace Email {
     loading: boolean
     onApprove: (p: { email?: string; signIn?: boolean }) => void
     permissions?: Permissions.Props
-    variant?: 'sign-in' | 'upgrade'
+    variant?: 'sign-in' | 'sign-up' | 'upgrade'
   }
 }

--- a/apps/dialog/src/routes/-components/Layout.tsx
+++ b/apps/dialog/src/routes/-components/Layout.tsx
@@ -51,9 +51,9 @@ export namespace Layout {
     }
 
     export function Default(props: Default.Props) {
-      const { icon: Icon, title, content, variant } = props
+      const { icon: Icon, title, content, subContent, variant } = props
       return (
-        <div>
+        <div className="flex flex-col gap-3 pb-1">
           <div className="flex items-center gap-2">
             {Icon && (
               <div className={Default.className({ variant })}>
@@ -62,9 +62,18 @@ export namespace Layout {
             )}
             <div className="font-medium text-[18px] text-primary">{title}</div>
           </div>
-          {content && (
-            <div className="mt-2 mb-1 text-[15px] text-primary leading-[22px]">
-              {content}
+          {(content || subContent) && (
+            <div className="flex flex-col gap-0.5">
+              {content && (
+                <div className="text-[15px] text-primary leading-[22px]">
+                  {content}
+                </div>
+              )}
+              {subContent && (
+                <div className="text-[15px] text-secondary leading-[20px]">
+                  {subContent}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -76,6 +85,7 @@ export namespace Layout {
       export interface Props extends VariantProps<typeof className> {
         content?: React.ReactNode
         icon?: React.FC<React.SVGProps<SVGSVGElement>> | undefined
+        subContent?: React.ReactNode
         title: string
       }
 

--- a/apps/dialog/src/routes/-components/TitleBar.tsx
+++ b/apps/dialog/src/routes/-components/TitleBar.tsx
@@ -6,6 +6,7 @@ import { porto } from '~/lib/Porto'
 import type { useVerify } from '~/lib/Referrer'
 import LucideBadgeCheck from '~icons/lucide/badge-check'
 import LucideGlobe from '~icons/lucide/globe'
+import LucideTerminal from '~icons/lucide/terminal'
 import LucideX from '~icons/lucide/x'
 
 const env = (
@@ -38,7 +39,9 @@ export function TitleBar(props: TitleBar.Props) {
       ref={ref}
     >
       <div className="flex size-5 min-w-5 items-center justify-center rounded-[5px] bg-gray6">
-        {icon && url ? (
+        {url?.startsWith('cli') ? (
+          <LucideTerminal className="size-3.5 text-primary" />
+        ) : icon && url?.startsWith('http') ? (
           <div className="p-[3px]">
             {typeof icon === 'string' ? (
               <img
@@ -70,7 +73,9 @@ export function TitleBar(props: TitleBar.Props) {
       </div>
 
       <div className="mr-auto flex shrink items-center gap-1 overflow-hidden whitespace-nowrap font-normal text-[14px] text-secondary leading-[22px]">
-        {url ? (
+        {url?.startsWith('cli') ? (
+          referrer?.title
+        ) : url ? (
           <div className="flex overflow-hidden" title={url}>
             {subdomain && (
               <>
@@ -97,7 +102,7 @@ export function TitleBar(props: TitleBar.Props) {
         )}
       </div>
 
-      {mode !== 'inline-iframe' && (
+      {mode !== 'inline-iframe' && mode !== 'popup-standalone' && (
         <button
           onClick={() => Actions.rejectAll(porto)}
           title="Close Dialog"

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -102,7 +102,7 @@ function RouteComponent() {
       <div
         data-dialog
         {...{ [`data-${mode === 'inline-iframe' ? 'iframe' : mode}`]: '' }} // for conditional styling based on dialog mode ("in-data-iframe:..." or "in-data-popup:...")
-        className="border-primary contain-content data-iframe:rounded-[14px] data-iframe:border"
+        className="border-primary contain-content data-popup-standalone:mx-auto data-popup-standalone:h-fit data-popup-standalone:max-w-[360px] data-iframe:rounded-[14px] data-popup-standalone:rounded-[14px] data-iframe:border data-popup-standalone:border data-popup-standalone:[@media(min-height:400px)]:mt-8"
       >
         <TitleBar
           mode={mode}
@@ -112,7 +112,7 @@ function RouteComponent() {
         />
 
         <div
-          className="flex not-in-data-popup-standalone:h-fit in-data-popup-standalone:min-h-dvh flex-col overflow-hidden bg-primary pt-titlebar"
+          className="flex h-fit flex-col overflow-hidden bg-primary pt-titlebar"
           ref={contentRef}
         >
           <div

--- a/apps/dialog/src/routes/dialog/success.tsx
+++ b/apps/dialog/src/routes/dialog/success.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import * as Dialog from '~/lib/Dialog'
+import CheckIcon from '~icons/lucide/check'
+import { Layout } from '../-components/Layout'
+
+export const Route = createFileRoute('/dialog/success')({
+  component: RouteComponent,
+  validateSearch: (search) => {
+    return {
+      content: search.content as string | undefined,
+      title: search.title as string,
+    }
+  },
+})
+
+function RouteComponent() {
+  const {
+    content = 'This action was performed successfully.',
+    title = 'Success',
+  } = Route.useSearch()
+  const url = Dialog.useStore((state) => state.referrer?.url)
+
+  return (
+    <Layout>
+      <Layout.Header>
+        <Layout.Header.Default
+          content={content}
+          icon={CheckIcon}
+          subContent={
+            'You may now close this window' +
+            (url?.toString().startsWith('cli')
+              ? ' and return to the command line'
+              : '') +
+            '.'
+          }
+          title={title}
+          variant="success"
+        />
+      </Layout.Header>
+    </Layout>
+  )
+}

--- a/apps/dialog/src/routes/dialog/wallet_connect.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_connect.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
+import * as Provider from 'ox/Provider'
 import { Actions, Hooks } from 'porto/remote'
 
 import * as Dialog from '~/lib/Dialog'
@@ -48,6 +49,26 @@ function RouteComponent() {
         throw new Error('request is not a wallet_connect request.')
 
       const params = request.params ?? []
+
+      const relayUrl = new URLSearchParams(window.location.search).get(
+        'relayUrl',
+      )
+      const capabilities = params[0]?.capabilities
+      const grantAdmins = capabilities?.grantAdmins
+
+      if (grantAdmins && grantAdmins.length > 0) {
+        if (!relayUrl || new URL(relayUrl).hostname !== 'localhost')
+          return Actions.respond(porto, request, {
+            error: new Provider.UnauthorizedError(),
+          }).catch(() => {})
+
+        const publicKeys = grantAdmins.map((admin) => admin.publicKey)
+        const isValid = await verifyKeys(relayUrl, publicKeys)
+        if (!isValid)
+          return Actions.respond(porto, request, {
+            error: new Provider.UnauthorizedError(),
+          }).catch(() => {})
+      }
 
       return Actions.respond(
         porto,
@@ -103,6 +124,8 @@ function RouteComponent() {
     },
   })
 
+  if (respond.isSuccess) return
+
   if (capabilities?.email ?? true)
     return (
       <Email
@@ -114,6 +137,7 @@ function RouteComponent() {
         loading={respond.isPending}
         onApprove={(options) => respond.mutate(options)}
         permissions={capabilities?.grantPermissions?.permissions}
+        variant={capabilities?.createAccount ? 'sign-up' : 'sign-in'}
       />
     )
 
@@ -135,4 +159,24 @@ function RouteComponent() {
       permissions={capabilities?.grantPermissions?.permissions}
     />
   )
+}
+
+/** Utility to verify CLI public keys via relay. */
+async function verifyKeys(
+  relayUrl: string,
+  publicKeys: string[],
+): Promise<boolean> {
+  try {
+    const response = await fetch(`${relayUrl}/.well-known/keys`)
+    if (!response.ok) return false
+
+    const data = await response.json()
+    const validKeys = data.keys as string[]
+
+    // Check if all provided public keys are in the valid keys list
+    return publicKeys.every((key) => validKeys.includes(key))
+  } catch (error) {
+    console.error('Failed to verify CLI keys:', error)
+    return false
+  }
 }

--- a/apps/dialog/src/routes/dialog/wallet_connect.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_connect.tsx
@@ -56,12 +56,17 @@ function RouteComponent() {
       const capabilities = params[0]?.capabilities
       const grantAdmins = capabilities?.grantAdmins
 
+      // If any admins need to be authorized, we need to check the
+      // authority & validity of the request.
       if (grantAdmins && grantAdmins.length > 0) {
+        // If the request did not come from a local relay (CLI), do
+        // not allow.
         if (!relayUrl || new URL(relayUrl).hostname !== 'localhost')
           return Actions.respond(porto, request, {
             error: new Provider.UnauthorizedError(),
           }).catch(() => {})
 
+        // If the keys are not trusted by the relay, do not allow.
         const publicKeys = grantAdmins.map((admin) => admin.publicKey)
         const isValid = await verifyKeys(relayUrl, publicKeys)
         if (!isValid)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "deps": "pnpx taze -r",
     "dev": "pnpm preconstruct && pnpm --filter playground --filter dialog --filter id dev",
     "dev:anvil": "pnpm preconstruct && ANVIL=true pnpm --filter playground --filter dialog --filter id dev",
-    "dev:cli": "tsx src/cli/index.ts",
+    "dev:cli": "tsx src/cli/bin/index.ts",
     "dev:wagmi": "pnpm preconstruct && pnpm --filter wagmi-example --filter dialog --filter id dev",
     "docs:build": "pnpm --filter docs build",
     "docs:dev": "pnpm --filter docs --filter dialog --filter id dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -943,6 +943,9 @@ importers:
       mipd:
         specifier: ^0.0.7
         version: 0.0.7(typescript@5.8.3)
+      open:
+        specifier: ^10.1.0
+        version: 10.1.2
       ox:
         specifier: ^0.6.12
         version: 0.6.12(typescript@5.8.3)(zod@3.25.28)

--- a/scripts/utils/exports.ts
+++ b/scripts/utils/exports.ts
@@ -28,8 +28,6 @@ export function getExports({
     .filter((entry) => !exclude.some((x) => matchesGlob(entry.name, x)))
 
   for (const parentEntry of entries) {
-    if (parentEntry.name === 'cli') continue
-
     if (!parentEntry.isDirectory()) {
       if (parentEntry.name.endsWith('test.ts')) continue
       if (

--- a/src/cli/Dialog.ts
+++ b/src/cli/Dialog.ts
@@ -1,0 +1,76 @@
+import open from 'open'
+import { RpcRequest } from 'ox'
+import * as Dialog from '../core/Dialog.js'
+import type * as RpcSchema from '../core/RpcSchema.js'
+import * as Messenger from './Messenger.js'
+
+export const messenger = await Messenger.cliRelay()
+
+/**
+ * Instantiates a CLI dialog.
+ *
+ * @returns CLI dialog.
+ */
+export async function cli() {
+  const store = RpcRequest.createStore<RpcSchema.Schema>()
+
+  let isOpen = false
+
+  return Dialog.from({
+    name: 'cli',
+    setup(parameters) {
+      messenger.on('rpc-response', (response) => {
+        Dialog.handleResponse(parameters.internal.store, response)
+      })
+
+      return {
+        close() {},
+        destroy() {
+          messenger.destroy()
+        },
+        open(p: { request: RpcRequest.RpcRequest }) {
+          const request = store.prepare(p.request)
+
+          const search = new URLSearchParams([
+            ['id', request.id.toString()],
+            ['method', request.method],
+            ['params', JSON.stringify(request.params)],
+            [
+              'referrer',
+              JSON.stringify({
+                title: 'Porto CLI',
+                url: 'cli://porto',
+              }),
+            ],
+            ['relayUrl', messenger.relayUrl],
+          ])
+
+          const host = parameters.host.replace(/\/$/, '')
+          const url = host + '/' + request.method + '?' + search.toString()
+
+          open(url)
+
+          isOpen = true
+        },
+        async syncRequests(requests) {
+          if (requests.length > 1)
+            throw new Error(
+              'renderer (`cli`) does not support multiple requests.',
+            )
+          if (!requests[0]?.request) return
+
+          const request = store.prepare(requests[0]!.request)
+
+          if (!isOpen) this.open({ request })
+          else messenger.send('rpc-requests', requests)
+        },
+      }
+    },
+  })
+}
+
+export declare namespace cli {
+  type Options = {
+    messenger: Messenger.CliRelay
+  }
+}

--- a/src/cli/Messenger.ts
+++ b/src/cli/Messenger.ts
@@ -1,0 +1,135 @@
+import type { ServerResponse } from 'node:http'
+import * as Url from 'node:url'
+import type * as Messenger from '../core/Messenger.js'
+import * as Http from './internal/http.js'
+
+export type CliRelay = Messenger.Messenger & {
+  relayUrl: string
+  registerPublicKey: (publicKey: string) => void
+}
+
+export async function cliRelay(): Promise<CliRelay> {
+  const listenerSets = new Map<
+    string,
+    Set<(payload: any, event: any) => void>
+  >()
+
+  const streams = new Set<ServerResponse>()
+
+  // Store for CLI public keys with expiration
+  const keys = new Set<string>()
+
+  const server = await Http.createServer((req, res) => {
+    const url = Url.parse(req.url!, true)
+
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(200)
+      res.end()
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/') {
+      res.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream',
+      })
+
+      streams.add(res)
+
+      req.on('close', () => streams.delete(res))
+
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/') {
+      let body = ''
+
+      req.on('data', (chunk) => (body += chunk.toString()))
+
+      req.on('end', () => {
+        try {
+          const data = JSON.parse(body)
+
+          // Handle the received data
+          if (data.topic && data.payload !== undefined) {
+            const listeners = listenerSets.get(data.topic)
+            if (listeners) {
+              const event = { data, origin: 'http://localhost' }
+              for (const listener of listeners) listener(data.payload, event)
+            }
+          }
+
+          res.writeHead(200, { 'Content-Type': 'text/plain' })
+          res.end('ok')
+        } catch (error) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' })
+          res.end('Invalid JSON')
+        }
+      })
+    } else if (req.method === 'GET' && url.pathname === '/.well-known/keys') {
+      res.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      })
+      res.end(JSON.stringify({ keys: Array.from(keys) }))
+    } else {
+      res.writeHead(404, { 'Content-Type': 'text/plain' })
+      res.end('not found')
+    }
+  })
+
+  const relayUrl = server.url
+
+  return {
+    destroy() {
+      listenerSets.clear()
+      for (const stream of streams)
+        try {
+          stream.end()
+        } catch {}
+
+      streams.clear()
+      server.close()
+    },
+    on(topic, listener) {
+      if (!listenerSets.has(topic)) listenerSets.set(topic, new Set())
+      listenerSets.get(topic)!.add(listener)
+
+      return () => {
+        const listeners = listenerSets.get(topic)
+        if (!listeners) return
+
+        listeners.delete(listener)
+        if (listeners.size === 0) listenerSets.delete(topic)
+      }
+    },
+    registerPublicKey(publicKey: string) {
+      keys.add(publicKey)
+    },
+    relayUrl,
+    async send(topic, payload) {
+      const id = crypto.randomUUID()
+      const data = { id, payload, topic }
+
+      const eventData = `data: ${JSON.stringify(data)}\n\n`
+      for (const stream of streams) {
+        try {
+          stream.write(eventData)
+        } catch {
+          streams.delete(stream)
+        }
+      }
+
+      return { id, payload, topic } as never
+    },
+    async sendAsync() {
+      throw new Error('Not implemented')
+    },
+  }
+}

--- a/src/cli/bin/index.ts
+++ b/src/cli/bin/index.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { cac } from 'cac'
+
+import pkgJson from '../../package.json' with { type: 'json' }
+import * as Commands from '../internal/commands.js'
+
+const cli = cac('porto')
+
+cli.command('[root]', 'Display usage').action(() => {
+  cli.outputHelp()
+  process.exit(0)
+})
+
+cli
+  .command('onboard [alias: o]', 'Create a Porto Account')
+  .alias('o')
+  .option(
+    '-a, --admin-key',
+    'Create and provision an additional admin key for server access',
+    {
+      default: false,
+    },
+  )
+  .option('-d, --dialog <hostname>', 'Dialog hostname', {
+    default: 'id.porto.sh',
+  })
+  .action(Commands.createAccount)
+
+cli.help()
+cli.version(pkgJson.version)
+
+cli.parse()

--- a/src/cli/bin/tsconfig.json
+++ b/src/cli/bin/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["."],
+  "compilerOptions": {
+    "noEmit": true,
+    "resolveJsonModule": true
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,26 +1,2 @@
-#!/usr/bin/env node
-import { cac } from 'cac'
-
-import pkgJson from '../package.json' with { type: 'json' }
-import * as Commands from './internal/commands.js'
-import * as Utils from './internal/utils.js'
-
-const cli = cac('porto')
-
-cli.command('[root]', 'Display usage').action(cli.outputHelp)
-
-cli
-  .command('create-account [alias: ca]', 'Create a Porto Account')
-  .alias('ca')
-  .option(
-    '-c, --chain <chain>',
-    `Chain name (available: ${Utils.getChainNames().join(', ')})`,
-    { default: 'base-sepolia' },
-  )
-  .option('-r, --rpc <rpc_url>', 'RPC server URL')
-  .action(Commands.createAccount)
-
-cli.help()
-cli.version(pkgJson.version)
-
-cli.parse()
+export * as Dialog from './Dialog.js'
+export * as Messenger from './Messenger.js'

--- a/src/cli/internal/commands.ts
+++ b/src/cli/internal/commands.ts
@@ -15,7 +15,7 @@ export async function createAccount(_: unknown, args: createAccount.Arguments) {
 
   const s = prompts.spinner()
 
-  const adminKey = args.serverKey ? Key.createSecp256k1() : undefined
+  const adminKey = args.adminKey ? Key.createSecp256k1() : undefined
 
   // Register public key for verification.
   if (adminKey) Dialog.messenger.registerPublicKey(adminKey.publicKey)
@@ -85,6 +85,6 @@ export declare namespace createAccount {
     /** Dialog hostname. */
     dialog?: string | undefined
     /** Create a server key with admin privileges. */
-    serverKey?: boolean | undefined
+    adminKey?: boolean | undefined
   }
 }

--- a/src/cli/internal/commands.ts
+++ b/src/cli/internal/commands.ts
@@ -1,50 +1,90 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { setTimeout } from 'node:timers/promises'
 import * as prompts from '@clack/prompts'
 import * as Key from '../../viem/Key.js'
-import * as ServerActions from '../../viem/ServerActions.js'
+import * as WalletActions from '../../viem/WalletActions.js'
+import * as Dialog from '../Dialog.js'
 import * as Context from './context.js'
 
 /** Creates a Porto account. */
 export async function createAccount(_: unknown, args: createAccount.Arguments) {
-  const client = await Context.getClient(args)
+  const client = await Context.getWalletClient(args)
 
-  prompts.intro('Create Account')
-
-  const key = Key.createSecp256k1()
+  prompts.intro('Create a Porto Account')
 
   const s = prompts.spinner()
-  s.start('Creating...')
-  const account = await ServerActions.createAccount(client, {
-    authorizeKeys: [key],
-  }).catch((error) => {
-    s.stop('Failed. ')
-    throw error
+
+  const adminKey = args.serverKey ? Key.createSecp256k1() : undefined
+
+  // Register public key for verification.
+  if (adminKey) Dialog.messenger.registerPublicKey(adminKey.publicKey)
+
+  // Create an account.
+  s.start('Creating account (check browser window)...')
+  const { accounts } = await WalletActions.connect(client, {
+    createAccount: true,
+    grantAdmins: adminKey
+      ? [
+          {
+            publicKey: adminKey.publicKey,
+            type: adminKey.type,
+          },
+        ]
+      : undefined,
   })
-  s.stop('Created. ')
+  s.stop('Account created.')
 
-  prompts.log.info('Address: ' + account.address)
+  // Onramp the account.
+  s.start('Onramping (check browser window)...')
+  await client.request({
+    method: 'wallet_addFunds',
+    params: [
+      {
+        address: accounts[0]!.address,
+      },
+    ],
+  })
+  s.stop('Onramped.')
 
-  const reveal = await prompts.confirm({
-    initialValue: false,
-    message: 'Reveal private key? (This will be visible in terminal history)',
+  // Send success message to the dialog.
+  Dialog.messenger.send('success', {
+    content: 'You have successfully created an account.',
+    title: 'Account created',
   })
 
-  if (reveal) prompts.log.warn('Private key: ' + key.privateKey!()!)
-  else {
-    // Write to secure file
-    const keyFile = path.join(import.meta.dirname, `${account.address}.key`)
-    fs.writeFileSync(keyFile, key.privateKey!()!, { mode: 0o600 })
-    fs.chmodSync(keyFile, 0o600)
-    prompts.log.info(`Private key saved securely to: ${keyFile}`)
+  if (adminKey) {
+    const reveal = await prompts.confirm({
+      initialValue: false,
+      message: 'Reveal admin private key? (This will be visible in terminal)',
+    })
+
+    if (reveal)
+      prompts.log.info('Admin private key: ' + adminKey?.privateKey!()!)
+    else {
+      const keyFile = path.join(
+        import.meta.dirname,
+        `${accounts[0]!.address}.key`,
+      )
+      fs.writeFileSync(keyFile, adminKey?.privateKey!()!, { mode: 0o600 })
+      fs.chmodSync(keyFile, 0o600)
+      prompts.log.info(`Admin key saved securely to: ${keyFile}`)
+    }
   }
+
+  const env = args.dialog?.split(/\.|-/)[0]
+  prompts.log.info('Address: ' + accounts[0]!.address)
+  prompts.log.info(`Manage your account at: https://${env ?? ''}.id.porto.sh`)
+
+  await setTimeout(1_000)
+  process.exit(0)
 }
 
 export declare namespace createAccount {
   type Arguments = {
-    /** Chain name. */
-    chain?: string | undefined
-    /** RPC Server URL. */
-    rpc?: string | undefined
+    /** Dialog hostname. */
+    dialog?: string | undefined
+    /** Create a server key with admin privileges. */
+    serverKey?: boolean | undefined
   }
 }

--- a/src/cli/internal/context.ts
+++ b/src/cli/internal/context.ts
@@ -2,10 +2,34 @@ import { createClient, http } from 'viem'
 import { getChainId } from 'viem/actions'
 
 import * as Chains from '../../core/Chains.js'
+import * as Mode from '../../core/Mode.js'
+import * as Porto from '../../core/Porto.js'
+import * as WalletClient from '../../viem/WalletClient.js'
+import * as Dialog from '../Dialog.js'
 import * as Utils from './utils.js'
 
+/** Gets a Viem client for Porto Dialog. */
+export async function getWalletClient(options: getWalletClient.Options = {}) {
+  const { dialog: host } = options
+  const porto = Porto.create({
+    announceProvider: false,
+    mode: Mode.dialog({
+      host: host ? new URL('/dialog', 'https://' + host).toString() : undefined,
+      renderer: await Dialog.cli(),
+    }),
+  })
+  return WalletClient.fromPorto(porto)
+}
+
+export declare namespace getWalletClient {
+  type Options = {
+    /** Dialog hostname. */
+    dialog?: string | undefined
+  }
+}
+
 /** Gets a Viem client for RPC Server. */
-export async function getClient(options: getClient.Options = {}) {
+export async function getServerClient(options: getServerClient.Options = {}) {
   const chain = Utils.kebabToCamel(options.chain!) as keyof typeof Chains
   const client = createClient({
     // biome-ignore lint/performance/noDynamicNamespaceImportAccess: _
@@ -19,7 +43,7 @@ export async function getClient(options: getClient.Options = {}) {
   return client
 }
 
-export declare namespace getClient {
+export declare namespace getServerClient {
   type Options = {
     /** Chain name. */
     chain?: string | undefined

--- a/src/cli/internal/http.ts
+++ b/src/cli/internal/http.ts
@@ -1,0 +1,28 @@
+import * as Http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+export type Server = Http.Server & {
+  closeAsync: () => Promise<unknown>
+  url: string
+}
+
+export function createServer(handler: Http.RequestListener): Promise<Server> {
+  const server = Http.createServer(handler)
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject)
+    server.listen(() => {
+      const { port } = server.address() as AddressInfo
+      resolve(
+        Object.assign(server, {
+          closeAsync() {
+            return new Promise((resolve, reject) =>
+              server.close((err) => (err ? reject(err) : resolve(undefined))),
+            )
+          },
+          url: `http://localhost:${port}`,
+        }),
+      )
+    })
+  })
+}

--- a/src/cli/tsconfig.json
+++ b/src/cli/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["."],
-  "compilerOptions": {
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "types": ["node"]
-  }
-}

--- a/src/cli/tsdown.config.ts
+++ b/src/cli/tsdown.config.ts
@@ -5,11 +5,11 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
   clean: true,
   dts: false,
-  entry: [resolve(import.meta.dirname, 'index.ts')],
+  entry: [resolve(import.meta.dirname, 'bin/index.ts')],
   external: getExternals(),
   format: ['esm'],
   minify: true,
-  outDir: resolve(import.meta.dirname, '../_dist/cli'),
+  outDir: resolve(import.meta.dirname, '../_dist/cli/bin'),
   target: 'node20',
 })
 
@@ -25,6 +25,8 @@ function getExternals() {
   const dependencies = pkgJson.dependencies || {}
 
   for (const [depName] of Object.entries(dependencies)) {
+    if (depName === 'ox') continue
+
     // Add a regex pattern for the package and all its subpaths
     externals.push(
       new RegExp(`^${depName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\/.*)?$`),

--- a/src/cli/tsdown.config.ts
+++ b/src/cli/tsdown.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  clean: true,
+  clean: false,
   dts: false,
   entry: [resolve(import.meta.dirname, 'bin/index.ts')],
   external: getExternals(),

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -12,7 +12,7 @@ export type Dialog = {
   setup: (parameters: { host: string; internal: Internal }) => {
     close: () => void
     destroy: () => void
-    open: () => void
+    open: (parameters: any) => void
     syncRequests: (requests: readonly QueuedRequest[]) => Promise<void>
   }
 }

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -221,7 +221,7 @@ export type QueuedRequest<result = unknown> = {
         credentialId?: string | undefined
       }
     | undefined
-  request: RpcRequest.RpcRequest
+  request: RpcRequest.RpcRequest & { _internal?: unknown }
 } & OneOf<
   | {
       status: 'pending'

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -38,12 +38,14 @@ export type Mode = {
       /** Internal properties. */
       internal: ActionsInternal
       /** Token to add funds to. */
-      token: Address.Address
+      token?: Address.Address | undefined
       /** Amount to add. */
       value?: bigint | undefined
     }) => Promise<{ id: Hex.Hex }>
 
     createAccount: (parameters: {
+      /** Admins to grant. */
+      admins?: readonly Pick<Key.Key, 'publicKey' | 'type'>[] | undefined
       /** Whether to link `label` to account address as email. */
       email?: boolean | undefined
       /** Internal properties. */

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -66,7 +66,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
 
       async createAccount(parameters) {
-        const { email, label, permissions, internal } = parameters
+        const { admins, email, label, permissions, internal } = parameters
         const { client } = internal
 
         const eoa = Account.fromPrivateKey(Secp256k1.randomPrivateKey())
@@ -82,13 +82,19 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           : Key.createHeadlessWebAuthnP256()
         const sessionKey = await PermissionsRequest.toKey(permissions)
 
+        const adminKeys = admins?.map((admin) => Key.from(admin))
+
         const feeToken = await resolveFeeToken(internal, {
           permissionsFeeLimit,
         })
 
         const account = await ServerActions.upgradeAccount(client, {
           account: eoa,
-          authorizeKeys: [adminKey, ...(sessionKey ? [sessionKey] : [])],
+          authorizeKeys: [
+            adminKey,
+            ...(adminKeys ?? []),
+            ...(sessionKey ? [sessionKey] : []),
+          ],
           feeToken: feeToken.address,
           permissionsFeeLimit: feeToken.permissionsFeeLimit,
         })

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -752,6 +752,7 @@ export function from<
           const {
             createAccount,
             email,
+            grantAdmins: admins,
             grantPermissions: permissions,
             selectAccount,
           } = capabilities ?? {}
@@ -768,6 +769,7 @@ export function from<
               const { label = undefined } =
                 typeof createAccount === 'object' ? createAccount : {}
               const { account } = await getMode().actions.createAccount({
+                admins,
                 email,
                 internal,
                 label,

--- a/src/core/internal/typebox/rpc.ts
+++ b/src/core/internal/typebox/rpc.ts
@@ -48,7 +48,7 @@ export namespace account_verifyEmail {
 export namespace wallet_addFunds {
   export const Parameters = Type.Object({
     address: Typebox.Optional(Primitive.Address),
-    token: Primitive.Address,
+    token: Typebox.Optional(Primitive.Address),
     value: Typebox.Optional(Primitive.BigInt),
   })
 
@@ -380,6 +380,9 @@ export namespace wallet_connect {
     createAccount: Typebox.Optional(C.createAccount.Request),
     credentialId: Typebox.Optional(Type.String()),
     email: Typebox.Optional(Type.Boolean()),
+    grantAdmins: Typebox.Optional(
+      Type.Array(wallet_grantAdmin.Parameters.properties.key),
+    ),
     grantPermissions: Typebox.Optional(C.grantPermissions.Request),
     preCalls: Typebox.Optional(C.preCalls.Request),
     selectAccount: Typebox.Optional(Type.Boolean()),

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.30",
   "type": "module",
   "bin": {
-    "porto": "./_dist/cli/index.js"
+    "porto": "./_dist/cli/bin/index.js"
   },
   "main": "./_dist/index.js",
   "types": "./_dist/index.d.ts",
@@ -21,6 +21,7 @@
     "@sinclair/typebox": "~0.34",
     "idb-keyval": "^6.2.1",
     "mipd": "^0.0.7",
+    "open": "^10.1.0",
     "ox": "^0.6.12",
     "zustand": "^5.0.1"
   },

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../tsconfig.base.json",
   "include": ["."],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "cli/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/bin/**",
+    "**/tsdown.config.ts"
+  ],
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -38,6 +38,6 @@
     // Skip type checking for node modules
     "skipLibCheck": true,
 
-    "types": ["typed-query-selector/strict"]
+    "types": ["node", "typed-query-selector/strict"]
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,12 +3,13 @@
   "extends": "./tsconfig.base.json",
   "include": ["src"],
   "exclude": [
-    "src/cli/**/*",
+    "**/bin/**",
     "src/**/*.bench.ts",
     "src/**/*.bench-d.ts",
     "src/**/*.snap-d.ts",
     "src/**/*.test.ts",
-    "src/**/*.test-d.ts"
+    "src/**/*.test-d.ts",
+    "src/**/tsdown.config.ts"
   ],
   "compilerOptions": {
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     { "path": "./docker/proxy/tsconfig.json" },
     { "path": "./scripts/tsconfig.json" },
     { "path": "./src/tsconfig.json" },
+    { "path": "./src/cli/bin/tsconfig.json" },
     { "path": "./test/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
## Summary

- Added CLI renderer that opens the dialog in the browser and communicates via Server-Sent Events (SSE) for real-time communication.
- Refactored CLI create account command to use the new dialog-based approach instead of direct RPC server calls – this enables users to create passkey accounts with improved security.
- Updated account provisioning flow from generating only a server-side admin key to now provisioning a passkey as the primary authentication method, with the ability to optionally provision an additional server admin key.

```bash
pnpx https://pkg.pr.new/porto@ed49cc9 onboard -d dialogporto-git-jxom-cli-create-account-ithacaxyz.vercel.app
```

## Details

- **SSE Communication**: Implemented Server-Sent Events for real-time communication between CLI and browser dialog
- **CLI Renderer**: Added `src/cli/Dialog.ts` with a new `cli()` renderer that opens browser dialogs and handles SSE-based communication via a local relay server
- **Local Relay Messenger**: Added `src/cli/Messenger.ts` for handling SSE-based communication between CLI and browser dialog
- **HTTP Server**: Added `src/cli/internal/server.ts` for creating local callback servers with SSE endpoints
- **Enhanced Account Provisioning**: 
  - Updated flow from server-side admin key generation to passkey-first approach
  - Added support for optional additional server admin key provisioning
  - Improved security by prioritizing passkey authentication
- **Command Refactor**: Updated `src/cli/internal/commands.ts` to use wallet client with dialog mode instead of direct server actions
- **Context Updates**: Added `getWalletClient()` function alongside existing `getServerClient()` 
- **Dialog Enhancements**: 
  - Added CLI detection and styling in dialog components
  - Added success page (`/dialog/success`) for CLI workflows
  - Enhanced referrer parsing and UI handling for CLI context
  - Added terminal icon and CLI-specific messaging
  - Updated account creation flow to support new passkey-first provisioning
- **Build Configuration**: Updated CLI build to output to `bin/` directory and adjusted npm scripts

## Areas Touched

- CLI (`src/cli/`)
- Dialog (`apps/dialog/`)
- Core Library (`src/core/`)
- Viem Integration (`src/viem/`)

🤖 Generated with [Claude Code](https://claude.ai/code)