### PR TITLE
refactor: simplify dialog mode handling

### DIFF
--- a/apps/dialog/src/lib/Dialog.ts
+++ b/apps/dialog/src/lib/Dialog.ts
@@ -19,7 +19,7 @@ export const store = createStore<store.State>(() => {
 
   return {
     error: null,
-    mode: 'popup-standalone',
+    mode: 'standalone',
     referrer,
   }
 })

--- a/apps/dialog/src/routes/__root.tsx
+++ b/apps/dialog/src/routes/__root.tsx
@@ -66,14 +66,14 @@ function RouteComponent() {
           if (height === lastHeight) return
 
           const titlebarHeight = titlebarRef.current?.clientHeight ?? 0
-          const modeHeight =
-            mode === 'popup'
-              ? UserAgent.isSafari()
-                ? 28 // safari: 27px title bar, 1px in borders
-                : UserAgent.isFirefox()
-                  ? 63 // firefox: 27px title bar, 34px address bar, 2px in borders
-                  : 63 // chrome: 27px title bar, 34px address bar, 2px in borders
-              : 2
+          const modeHeight = (() => {
+            if (mode === 'popup' && !UserAgent.isMobile()) {
+              if (UserAgent.isSafari()) return 27 + 1 // safari: 27px title bar, 1px in borders
+              return 27 + 34 + 2 // others: 27px title bar, 34px address bar, 2px in borders
+            }
+            return 2 // standalone: 2px in borders
+          })()
+
           const totalHeight = height + titlebarHeight + modeHeight
           lastHeight = height
 
@@ -95,14 +95,20 @@ function RouteComponent() {
     }
   }, [mode])
 
+  const styleMode = React.useMemo(() => {
+    if (mode === 'inline-iframe') return 'iframe' // condense to "iframe" for style simplicity
+    if (mode === 'popup' && UserAgent.isMobile()) return 'standalone' // popups on mobile look "standalone"
+    return mode
+  }, [mode])
+
   return (
     <>
       <HeadContent />
 
       <div
         data-dialog
-        {...{ [`data-${mode === 'inline-iframe' ? 'iframe' : mode}`]: '' }} // for conditional styling based on dialog mode ("in-data-iframe:..." or "in-data-popup:...")
-        className="border-primary contain-content data-popup-standalone:mx-auto data-popup-standalone:h-fit data-popup-standalone:max-w-[360px] data-iframe:rounded-[14px] data-popup-standalone:rounded-[14px] data-iframe:border data-popup-standalone:border data-popup-standalone:[@media(min-height:400px)]:mt-8"
+        {...{ [`data-${styleMode}`]: '' }} // for conditional styling based on dialog mode ("in-data-iframe:..." or "in-data-popup:...")
+        className="border-primary contain-content data-standalone:mx-auto data-standalone:h-fit data-standalone:max-w-[360px] data-iframe:rounded-[14px] data-standalone:rounded-[14px] data-iframe:border data-standalone:border data-standalone:[@media(min-height:400px)]:mt-8"
       >
         <TitleBar
           mode={mode}

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -364,7 +364,7 @@ export function popup() {
           })
 
           messenger.send('__internal', {
-            mode: isMobile() ? 'popup-standalone' : 'popup',
+            mode: 'popup',
             referrer: getReferrer(),
             type: 'init',
           })

--- a/src/core/Messenger.ts
+++ b/src/core/Messenger.ts
@@ -73,7 +73,7 @@ export type Schema = [
     payload:
       | {
           type: 'init'
-          mode: 'inline-iframe' | 'iframe' | 'popup' | 'popup-standalone'
+          mode: 'inline-iframe' | 'iframe' | 'popup' | 'standalone'
           referrer: {
             icon?: string | { light: string; dark: string } | undefined
             title: string
@@ -81,7 +81,7 @@ export type Schema = [
         }
       | {
           type: 'switch'
-          mode: 'inline-iframe' | 'iframe' | 'popup' | 'popup-standalone'
+          mode: 'inline-iframe' | 'iframe' | 'popup' | 'standalone'
         }
       | {
           type: 'resize'


### PR DESCRIPTION
### Summary

Simplified the dialog mode system by consolidating `popup-standalone` into `standalone` mode and improving mobile popup handling.

### Details

- Removed `popup-standalone` mode type from Dialog and Messenger schemas
- Changed default dialog mode from `popup-standalone` to `standalone`
- Refactored height calculation logic to be clearer and more maintainable
- Introduced `styleMode` computed value that treats mobile popups as `standalone` for styling consistency
- Updated CSS classes to use `data-standalone` instead of `data-popup-standalone`

### Areas Touched

- Dialog (`apps/dialog`)
- `porto` Library (`src/`)