### PR TITLE
feat: improve sign-in UX for existing accounts

### DIFF
--- a/apps/dialog/src/routes/-components/Email.tsx
+++ b/apps/dialog/src/routes/-components/Email.tsx
@@ -8,12 +8,14 @@ import IconScanFace from '~icons/porto/scan-face'
 
 export function Email(props: Email.Props) {
   const {
+    actions = ['sign-in', 'sign-up'],
     defaultValue = '',
     loading,
     onApprove,
     permissions,
-    variant = 'sign-in',
   } = props
+
+  const [loadingTitle, setLoadingTitle] = React.useState('Signing up...')
 
   const cli = Dialog.useStore((state) =>
     state.referrer?.url?.toString().startsWith('cli'),
@@ -25,6 +27,7 @@ export function Email(props: Email.Props) {
       event.preventDefault()
       const formData = new FormData(event.target as HTMLFormElement)
       const email = formData.get('email')?.toString()
+      setLoadingTitle('Signing up...')
       onApprove({ email, signIn: false })
     },
     [onApprove],
@@ -43,23 +46,26 @@ export function Email(props: Email.Props) {
   )
 
   return (
-    <Layout loading={loading} loadingTitle="Signing up...">
+    <Layout loading={loading} loadingTitle={loadingTitle}>
       <Layout.Header className="flex-grow">
         <Layout.Header.Default
           content={content}
           icon={LucideLogIn}
-          title="Get started"
+          title={actions.includes('sign-up') ? 'Get started' : 'Sign in'}
         />
       </Layout.Header>
 
       <Permissions title="Permissions requested" {...permissions} />
 
       <div className="group flex min-h-[48px] w-full flex-col items-center justify-center space-y-3 px-3 pb-3">
-        {variant === 'sign-in' && (
+        {actions.includes('sign-in') && (
           <Button
             className="flex w-full gap-2"
             data-testid="sign-in"
-            onClick={() => onApprove({ signIn: true })}
+            onClick={() => {
+              setLoadingTitle('Signing in...')
+              onApprove({ signIn: true })
+            }}
             type="button"
             variant="accent"
           >
@@ -68,45 +74,63 @@ export function Email(props: Email.Props) {
           </Button>
         )}
 
-        <form
-          className="flex w-full flex-grow flex-col gap-2"
-          onSubmit={onSubmit}
-        >
-          {variant === 'sign-in' && (
-            <div className="-tracking-[2.8%] flex items-center whitespace-nowrap text-[12px] text-gray9 leading-[17px]">
-              First time?
-              <div className="ms-2 h-px w-full bg-gray4" />
-            </div>
-          )}
-          <div className="relative flex items-center">
-            <label className="sr-only" htmlFor="email">
-              Email
-            </label>
-            <Input
-              className="w-full user-invalid:bg-gray3 user-invalid:ring-red9"
-              defaultValue={defaultValue}
-              name="email"
-              placeholder="example@ithaca.xyz"
-              type="email"
-            />
-            <div className="-tracking-[2.8%] absolute end-3 text-[12px] text-gray9 leading-normal">
-              Optional
-            </div>
-          </div>
-          <Button
-            className="w-full gap-2 group-has-[:user-invalid]:cursor-not-allowed group-has-[:user-invalid]:text-gray10"
-            data-testid="sign-up"
-            type="submit"
-            variant={variant === 'sign-in' ? 'default' : 'accent'}
+        {actions.includes('sign-up') ? (
+          <form
+            className="flex w-full flex-grow flex-col gap-2"
+            onSubmit={onSubmit}
           >
-            <span className="hidden group-has-[:user-invalid]:block">
-              Invalid email
-            </span>
-            <span className="block group-has-[:user-invalid]:hidden">
-              Create account
-            </span>
+            {/* If "Sign in" button is present, show the "First time?" text for sign up. */}
+            {actions.includes('sign-in') && (
+              <div className="-tracking-[2.8%] flex items-center whitespace-nowrap text-[12px] text-gray9 leading-[17px]">
+                First time?
+                <div className="ms-2 h-px w-full bg-gray4" />
+              </div>
+            )}
+            <div className="relative flex items-center">
+              <label className="sr-only" htmlFor="email">
+                Email
+              </label>
+              <Input
+                className="w-full user-invalid:bg-gray3 user-invalid:ring-red9"
+                defaultValue={defaultValue}
+                name="email"
+                placeholder="example@ithaca.xyz"
+                type="email"
+              />
+              <div className="-tracking-[2.8%] absolute end-3 text-[12px] text-gray9 leading-normal">
+                Optional
+              </div>
+            </div>
+            <Button
+              className="w-full gap-2 group-has-[:user-invalid]:cursor-not-allowed group-has-[:user-invalid]:text-gray10"
+              data-testid="sign-up"
+              type="submit"
+              variant={actions.includes('sign-in') ? 'default' : 'accent'}
+            >
+              <span className="hidden group-has-[:user-invalid]:block">
+                Invalid email
+              </span>
+              <span className="block group-has-[:user-invalid]:hidden">
+                Create account
+              </span>
+            </Button>
+          </form>
+        ) : (
+          // If no sign up button, this means the user is already logged in, however
+          // the user may want to sign in with a different passkey.
+          <Button
+            className="flex w-full gap-2"
+            data-testid="sign-in"
+            onClick={() => {
+              setLoadingTitle('Signing in...')
+              onApprove({ selectAccount: true, signIn: true })
+            }}
+            type="button"
+            variant="default"
+          >
+            Sign in using a different passkey
           </Button>
-        </form>
+        )}
       </div>
     </Layout>
   )
@@ -114,10 +138,14 @@ export function Email(props: Email.Props) {
 
 export namespace Email {
   export type Props = {
+    actions?: readonly ('sign-in' | 'sign-up')[]
     defaultValue?: string | undefined
     loading: boolean
-    onApprove: (p: { email?: string; signIn?: boolean }) => void
+    onApprove: (p: {
+      email?: string
+      selectAccount?: boolean
+      signIn?: boolean
+    }) => void
     permissions?: Permissions.Props
-    variant?: 'sign-in' | 'sign-up' | 'upgrade'
   }
 }

--- a/apps/dialog/src/routes/dialog/wallet_connect.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_connect.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import * as Provider from 'ox/Provider'
 import { Actions, Hooks } from 'porto/remote'
+import * as React from 'react'
 
 import * as Dialog from '~/lib/Dialog'
 import { porto } from '~/lib/Porto'
@@ -30,9 +31,11 @@ function RouteComponent() {
     (state) => state.accounts[0]?.address,
   )
 
-  const signIn =
-    (address && !capabilities?.createAccount) ||
-    capabilities?.createAccount === false
+  const actions = React.useMemo<readonly ('sign-in' | 'sign-up')[]>(() => {
+    if (capabilities?.createAccount) return ['sign-up']
+    if (address) return ['sign-in']
+    return ['sign-in', 'sign-up']
+  }, [capabilities?.createAccount, address])
 
   const respond = useMutation({
     async mutationFn({
@@ -134,6 +137,7 @@ function RouteComponent() {
   if (capabilities?.email ?? true)
     return (
       <Email
+        actions={actions}
         defaultValue={
           typeof capabilities?.createAccount === 'object'
             ? capabilities?.createAccount?.label || ''
@@ -142,25 +146,24 @@ function RouteComponent() {
         loading={respond.isPending}
         onApprove={(options) => respond.mutate(options)}
         permissions={capabilities?.grantPermissions?.permissions}
-        variant={capabilities?.createAccount ? 'sign-up' : 'sign-in'}
       />
     )
 
-  if (signIn)
+  if (actions.includes('sign-up'))
     return (
-      <SignIn
+      <SignUp
+        enableSignIn={actions.includes('sign-in')}
         loading={respond.isPending}
         onApprove={(options) => respond.mutate(options)}
+        onReject={() => Actions.reject(porto, request)}
         permissions={capabilities?.grantPermissions?.permissions}
       />
     )
 
   return (
-    <SignUp
-      enableSignIn={!capabilities?.createAccount}
+    <SignIn
       loading={respond.isPending}
       onApprove={(options) => respond.mutate(options)}
-      onReject={() => Actions.reject(porto, request)}
       permissions={capabilities?.grantPermissions?.permissions}
     />
   )

--- a/apps/dialog/src/routes/dialog/wallet_prepareUpgradeAccount.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_prepareUpgradeAccount.tsx
@@ -51,10 +51,10 @@ function RouteComponent() {
   if (capabilities?.email ?? true)
     return (
       <Email
+        actions={['sign-up']}
         loading={respond.isPending}
         onApprove={(options) => respond.mutate(options)}
         permissions={capabilities?.grantPermissions?.permissions}
-        variant="upgrade"
       />
     )
 

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -188,6 +188,7 @@ function Events() {
 }
 
 function Connect() {
+  const [email, setEmail] = React.useState<boolean>(true)
   const [grantPermissions, setGrantPermissions] = React.useState<boolean>(false)
   const [result, setResult] = React.useState<unknown | null>(null)
   const [error, setError] = React.useState<string | null>(null)
@@ -195,6 +196,14 @@ function Connect() {
   return (
     <div>
       <h3>wallet_connect</h3>
+      <label>
+        <input
+          checked={email}
+          onChange={() => setEmail((x) => !x)}
+          type="checkbox"
+        />
+        Email
+      </label>
       <label>
         <input
           checked={grantPermissions}
@@ -209,6 +218,7 @@ function Connect() {
             const payload = {
               capabilities: {
                 createAccount: false,
+                email,
                 grantPermissions: grantPermissions ? permissions() : undefined,
               },
             } as const
@@ -235,6 +245,7 @@ function Connect() {
             const payload = {
               capabilities: {
                 createAccount: true,
+                email,
                 grantPermissions: grantPermissions ? permissions() : undefined,
               },
             } as const


### PR DESCRIPTION
### Summary

Improved the sign-in user experience for existing accounts by refactoring the Email component to use an actions array instead of a variant prop, providing better flexibility in determining available authentication options.

### Details

- Refactored `Email` component to accept `actions` array instead of `variant` prop
- Added dynamic loading title that updates based on the action being performed ("Signing in..." vs "Signing up...")
- Implemented "Sign in using a different passkey" option for existing account holders
- Updated wallet connect flow to dynamically determine available actions based on account state and capabilities
- Enhanced playground with email capability toggle for testing different scenarios

### Areas Touched

- Dialog (`apps/dialog`)
- Playground (`apps/playground`)

### Test plan

- [ ] Test sign-in flow for existing accounts
- [ ] Test sign-up flow for new accounts  
- [ ] Test "Sign in using a different passkey" functionality
- [ ] Verify loading states display correct messages
- [ ] Test playground email capability toggle