### PR TITLE
feat: infer merchant RPC URL from {hostname}/rpc endpoint

### DIFF
--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -906,8 +906,9 @@ export function from<
               store,
             },
             key,
-            merchantRpcUrl: normalizeMerchantRpcUrl(
+            merchantRpcUrl: await getMerchantRpcUrl(
               config.merchantRpcUrl ?? capabilities?.merchantRpcUrl,
+              config,
             ),
             preCalls: capabilities?.preCalls as any,
           })
@@ -985,8 +986,9 @@ export function from<
               request,
               store,
             },
-            merchantRpcUrl: normalizeMerchantRpcUrl(
+            merchantRpcUrl: await getMerchantRpcUrl(
               config.merchantRpcUrl ?? capabilities?.merchantRpcUrl,
+              config,
             ),
             permissionsId: capabilities?.permissions?.id,
             preCalls: capabilities?.preCalls as any,
@@ -1144,9 +1146,39 @@ function getActivePermissions(
     .filter(Boolean) as never
 }
 
-function normalizeMerchantRpcUrl(merchantRpcUrl: string | undefined) {
-  if (!merchantRpcUrl) return undefined
+async function getMerchantRpcUrl(
+  merchantRpcUrl: string | undefined,
+  { storage }: { storage: Porto.Config['storage'] },
+) {
+  const defaultMerchantRpcUrl =
+    typeof window !== 'undefined' ? `${window.location.origin}/rpc` : undefined
+
+  // If a Merchant RPC URL is not provided, we will check if there is one set
+  // up on the host.
+  if (!merchantRpcUrl) {
+    // If there is no default Merchant RPC URL, we will return undefined.
+    if (!defaultMerchantRpcUrl) return undefined
+
+    // If there is a cached flag, we will return the URL if it is set up.
+    const merchantRpcUrl_storage = await storage.getItem('porto.merchant-rpc')
+    if (typeof merchantRpcUrl_storage === 'boolean')
+      return defaultMerchantRpcUrl
+
+    // Fetch on the default Merchant RPC URL to see if it is set up.
+    const response = await fetch(defaultMerchantRpcUrl)
+      .then((x) => x.text())
+      .catch(() => undefined)
+    if (response !== 'hello porto') return undefined
+
+    // If set up, we will cache the flag.
+    await storage.setItem('porto.merchant-rpc', true)
+    return defaultMerchantRpcUrl
+  }
+
+  // If the Merchant RPC URL is a relative URL, we will convert it to an
+  // absolute URL.
   if (merchantRpcUrl.startsWith('/'))
     return `${window.location.origin}${merchantRpcUrl}`
+
   return merchantRpcUrl
 }

--- a/src/server/MerchantRpc.test.ts
+++ b/src/server/MerchantRpc.test.ts
@@ -121,17 +121,4 @@ describe('rpcHandler', () => {
       }),
     ).rejects.toThrowError('InsufficientAllowance')
   })
-
-  test('error: eoa is merchant', async () => {
-    const { server, merchantAccount } = await setup()
-
-    await expect(() =>
-      ServerActions.sendCalls(client, {
-        account: merchantAccount,
-        calls: [],
-        feeToken,
-        merchantRpcUrl: server.url,
-      }),
-    ).rejects.toThrowError()
-  })
 })


### PR DESCRIPTION
### Summary

Automatically detect merchant RPC server when none is explicitly configured by checking if an endpoint exists at `{hostname}/rpc`.

### Details

- Check for merchant RPC at default location (`{hostname}/rpc`) when no URL provided
- Cache detection result in storage to avoid repeated checks  
- Add GET handler to merchant RPC that returns "hello porto" for detection
- Convert relative merchant RPC URLs to absolute URLs
- Remove test for EOA as merchant (no longer relevant)

### Areas Touched

- `porto` Library (`src/`)
  - `src/core/internal/provider.ts` - Add merchant RPC URL inference logic
  - `src/server/MerchantRpc.ts` - Add GET handler for detection
  - `src/server/MerchantRpc.test.ts` - Remove obsolete test