### PR TITLE
feat: conditional sponsoring

### DIFF
--- a/.changeset/afraid-carpets-fetch.md
+++ b/.changeset/afraid-carpets-fetch.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added conditional sponsoring to `MerchantRpc` via a `sponsor` option.

--- a/examples/sponsoring-next.js/src/app/rpc/route.ts
+++ b/examples/sponsoring-next.js/src/app/rpc/route.ts
@@ -1,4 +1,5 @@
 import { MerchantRpc } from 'porto/server'
+import * as Contracts from '../../contracts.ts'
 
 export const GET = MerchantRpc.GET
 
@@ -7,4 +8,7 @@ export const OPTIONS = MerchantRpc.OPTIONS
 export const POST = MerchantRpc.POST({
   address: process.env.NEXT_PUBLIC_MERCHANT_ADDRESS,
   key: process.env.NEXT_PUBLIC_MERCHANT_PRIVATE_KEY,
+  sponsor(request) {
+    return request.calls.every((call) => call.to === Contracts.exp1Address)
+  },
 })

--- a/examples/sponsoring-vite/package.json
+++ b/examples/sponsoring-vite/package.json
@@ -1,7 +1,6 @@
 {
   "name": "sponsoring-vite-example",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "build": "tsc -b && vite build",

--- a/examples/sponsoring-vite/worker/index.ts
+++ b/examples/sponsoring-vite/worker/index.ts
@@ -1,10 +1,14 @@
 import { env } from 'cloudflare:workers'
 import { MerchantRpc } from 'porto/server'
+import * as Contracts from '../src/contracts.ts'
 
 export default {
   fetch: MerchantRpc.requestHandler({
     address: env.MERCHANT_ADDRESS as `0x${string}`,
     base: '/rpc',
     key: env.MERCHANT_PRIVATE_KEY as `0x${string}`,
+    sponsor(request) {
+      return request.calls.every((call) => call.to === Contracts.exp1Address)
+    },
   }),
 } satisfies ExportedHandler<Env>

--- a/src/server/MerchantRpc.test.ts
+++ b/src/server/MerchantRpc.test.ts
@@ -7,14 +7,23 @@ import { describe, expect, test } from 'vitest'
 
 import * as TestActions from '../../test/src/actions.js'
 import * as Http from '../../test/src/http.js'
-import { exp1Abi, exp1Address, getPorto } from '../../test/src/porto.js'
+import {
+  exp1Abi,
+  exp1Address,
+  exp2Abi,
+  exp2Address,
+  getPorto,
+} from '../../test/src/porto.js'
+import type { ExactPartial } from '../core/internal/types.js'
 
 const { client, porto } = getPorto()
 
 const feeToken = exp1Address
 
 let server: Http.Server | undefined
-async function setup() {
+async function setup(
+  options: ExactPartial<MerchantRpc.requestHandler.Options> = {},
+) {
   const merchantKey = Key.createSecp256k1()
   const merchantAccount = await TestActions.createAccount(client, {
     deploy: true,
@@ -23,6 +32,7 @@ async function setup() {
 
   const handler = MerchantRpc.requestHandler({
     ...porto.config,
+    ...options,
     address: merchantAccount.address,
     key: merchantKey.privateKey!(),
   })
@@ -91,6 +101,125 @@ describe('rpcHandler', () => {
 
     // Check if merchant was debited the fee payment.
     expect(merchantBalance_post).toBeLessThan(merchantBalance_pre)
+  })
+
+  test('behavior: conditional sponsoring', async () => {
+    const { server, merchantAccount } = await setup({
+      sponsor: (request) =>
+        // Only sponsor calls targeting the exp1Address
+        request.calls.every((call) => call.to === exp1Address),
+    })
+
+    const userKey = Key.createHeadlessWebAuthnP256()
+    const userAccount = await TestActions.createAccount(client, {
+      keys: [userKey],
+    })
+
+    {
+      // Test 1: Calls satisfy the sponsor condition.
+      const userBalance_pre = await readContract(client, {
+        abi: exp1Abi,
+        address: exp1Address,
+        args: [userAccount.address],
+        functionName: 'balanceOf',
+      })
+      const merchantBalance_pre = await readContract(client, {
+        abi: exp1Abi,
+        address: exp1Address,
+        args: [merchantAccount.address],
+        functionName: 'balanceOf',
+      })
+
+      const result = await ServerActions.sendCalls(client, {
+        account: userAccount,
+        calls: [
+          {
+            abi: exp1Abi,
+            args: [userAccount.address, Value.fromEther('1')],
+            functionName: 'mint',
+            to: exp1Address,
+          },
+        ],
+        feeToken,
+        merchantRpcUrl: server.url,
+      })
+
+      await waitForCallsStatus(client, {
+        id: result.id,
+      })
+
+      const userBalance_post = await readContract(client, {
+        abi: exp1Abi,
+        address: exp1Address,
+        args: [userAccount.address],
+        functionName: 'balanceOf',
+      })
+      const merchantBalance_post = await readContract(client, {
+        abi: exp1Abi,
+        address: exp1Address,
+        args: [merchantAccount.address],
+        functionName: 'balanceOf',
+      })
+
+      // Check if user was credited with 1 EXP.
+      expect(userBalance_post).toBe(userBalance_pre + Value.fromEther('1'))
+
+      // Check if merchant was debited the fee payment.
+      expect(merchantBalance_post).toBeLessThan(merchantBalance_pre)
+    }
+
+    {
+      // Test 2: Calls do not satisfy the sponsor condition.
+      const userBalance_pre = await readContract(client, {
+        abi: exp2Abi,
+        address: exp2Address,
+        args: [userAccount.address],
+        functionName: 'balanceOf',
+      })
+      const merchantBalance_pre = await readContract(client, {
+        abi: exp1Abi,
+        address: exp1Address,
+        args: [merchantAccount.address],
+        functionName: 'balanceOf',
+      })
+
+      const result = await ServerActions.sendCalls(client, {
+        account: userAccount,
+        calls: [
+          {
+            abi: exp2Abi,
+            args: [userAccount.address, Value.fromEther('1')],
+            functionName: 'mint',
+            to: exp2Address,
+          },
+        ],
+        feeToken,
+        merchantRpcUrl: server.url,
+      })
+
+      await waitForCallsStatus(client, {
+        id: result.id,
+      })
+
+      const userBalance_post = await readContract(client, {
+        abi: exp2Abi,
+        address: exp2Address,
+        args: [userAccount.address],
+        functionName: 'balanceOf',
+      })
+      const merchantBalance_post = await readContract(client, {
+        abi: exp1Abi,
+        address: exp1Address,
+        args: [merchantAccount.address],
+        functionName: 'balanceOf',
+      })
+
+      // Check if user was credited with 1 EXP.
+      expect(userBalance_post).toBe(userBalance_pre + Value.fromEther('1'))
+
+      // Check if merchant was NOT debited the fee payment.
+      expect(merchantBalance_post).toEqual(merchantBalance_pre)
+    }
   })
 
   test('error: contract error', async () => {


### PR DESCRIPTION
### Summary

Added conditional sponsoring functionality to `MerchantRpc` via a `sponsor` option that allows merchants to selectively sponsor calls based on custom logic.

### Details

- Added `sponsor` option to `MerchantRpc.requestHandler` that accepts:
  - `boolean` - Unconditionally sponsor or not sponsor calls  
  - `function` - Custom function that receives request parameters and returns boolean
  - `undefined` - Defaults to `true` (sponsor all calls)
- When `sponsor` returns `false`, the merchant account is not set as fee payer and no fee signature is provided
- Updated examples in `sponsoring-next.js` and `sponsoring-vite` to demonstrate conditional sponsoring based on contract address
- Added comprehensive tests covering both sponsored and non-sponsored scenarios
- Added changeset documenting the new feature

### Areas Touched

- `porto` Library (`src/`)
  - `src/server/MerchantRpc.ts` - Core implementation
  - `src/server/MerchantRpc.test.ts` - Test coverage
- Examples
  - `examples/sponsoring-next.js` - Updated to show conditional sponsoring
  - `examples/sponsoring-vite` - Updated to show conditional sponsoring