### PR TITLE
feat: condense Connect + SIWE into single passkey digest

### DIFF
--- a/src/viem/Account.ts
+++ b/src/viem/Account.ts
@@ -222,6 +222,10 @@ export declare namespace sign {
      */
     payload: Hex.Hex
     /**
+     * Role to extract the key from the `account` for signing.
+     */
+    role?: Key.Key['role'] | undefined
+    /**
      * Storage to use for keytype-specific caching (e.g. WebAuthn user verification).
      */
     storage?: Storage.Storage | undefined


### PR DESCRIPTION
### Summary

Consolidates wallet connection and SIWE (Sign-In With Ethereum) into a single passkey operation, improving UX by reducing the number of authentication prompts.

### Details

- Added `digestType` discriminator to track whether a session key authorization ('precall') or SIWE message ('siwe') was signed
- Modified `loadAccounts` to prepare either session key or SIWE digest based on parameters
- Implemented signature reuse - when SIWE is signed during WebAuthn discovery, the same signature is reused instead of prompting again
- Added `role` parameter to `Account.sign()` for automatic key selection based on role ('admin', 'session')
- Fixed SIWE signing in `createAccount` to correctly use the EOA private key instead of admin key
- Updated signature verification logic to handle both digest types appropriately

### Areas Touched

- `porto` Library (`src/`)
  - `src/core/internal/modes/rpcServer.ts` - Core connection and SIWE flow changes
  - `src/viem/Account.ts` - Added role-based signing support
  - `src/viem/Account.test.ts` - Tests for role-based signing