### PR TITLE
feat: update wagmi connect to return wallet_connect response format

### DIFF
--- a/.changeset/petite-files-create.md
+++ b/.changeset/petite-files-create.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+**Breaking(`porto/wagmi`):** Tweaked return type of `Hooks.useConnect` & `Actions.connect` to match the return type of `wallet_connect`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,58 @@ importers:
         specifier: latest
         version: 1.2.17
 
+  examples/authentication:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5
+        version: 5.77.1(react@19.1.0)
+      hono:
+        specifier: ^4
+        version: 4.7.10
+      porto:
+        specifier: workspace:*
+        version: link:../../src
+      react:
+        specifier: ^19
+        version: 19.1.0
+      react-dom:
+        specifier: ^19
+        version: 19.1.0(react@19.1.0)
+      viem:
+        specifier: ^2
+        version: 2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
+      wagmi:
+        specifier: ^2
+        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.7.5
+        version: 1.7.5(bufferutil@4.0.9)(rollup@4.41.1)(utf-8-validate@5.0.10)(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0))(workerd@1.20250617.0)(wrangler@4.21.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.1.5
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.1.5(@types/react@19.1.5)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.6.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0))
+      globals:
+        specifier: ^16.0.0
+        version: 16.2.0
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.30.1
+        version: 8.35.0(typescript@5.8.3)
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.0)
+      wrangler:
+        specifier: ^4.21.2
+        version: 4.21.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
   examples/next.js:
     dependencies:
       '@tanstack/react-query':

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -3,7 +3,6 @@ import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
 import * as ox_Provider from 'ox/Provider'
 import * as RpcResponse from 'ox/RpcResponse'
-import { verifyHash } from 'viem/actions'
 import * as Account from '../../viem/Account.js'
 import * as Actions from '../../viem/internal/serverActions.js'
 import type * as Key from '../../viem/Key.js'
@@ -839,6 +838,18 @@ export function from<
             chainId: Hex.fromNumber(client.chain.id),
           })
 
+          const currentChainId = client.chain.id
+          const chainIds = [
+            Hex.fromNumber(currentChainId),
+            ...(config.chains
+              .map((chain) =>
+                chain.id === currentChainId
+                  ? undefined
+                  : Hex.fromNumber(chain.id),
+              )
+              .filter(Boolean) as `0x${string}`[]),
+          ]
+
           return {
             accounts: accounts.map((account) => ({
               address: account.address,
@@ -855,6 +866,7 @@ export function from<
                 }),
               },
             })),
+            chainIds,
           } satisfies Typebox.Static<typeof Rpc.wallet_connect.Response>
         }
 
@@ -1026,16 +1038,6 @@ export function from<
             address,
             digest,
             signature,
-          }).catch(async () => {
-            const valid = await verifyHash(client, {
-              address,
-              hash: digest,
-              signature,
-            })
-            return {
-              proof: null,
-              valid,
-            }
           })
 
           return {

--- a/src/core/internal/typebox/rpc.ts
+++ b/src/core/internal/typebox/rpc.ts
@@ -419,6 +419,7 @@ export namespace wallet_connect {
         capabilities: Typebox.Optional(ResponseCapabilities),
       }),
     ),
+    chainIds: Type.Array(Primitive.Number),
   })
   export type Response = Typebox.StaticDecode<typeof Response>
 }


### PR DESCRIPTION
### Summary

Updated the return type of `Hooks.useConnect` & `Actions.connect` to match the return type of `wallet_connect` RPC method, providing access to chainIds and other response data.

### Details

- **Breaking Change:** Modified `Hooks.useConnect` & `Actions.connect` return type to match `wallet_connect` response
- Added `chainIds` array to the response format alongside `accounts`
- Updated internal provider to return chainIds in wallet_connect response
- Modified wagmi playground to use Porto's `useConnect` hook instead of wagmi's
- Added SIWE (Sign In With Ethereum) support in playground example

### Areas Touched

- `porto` Library (`src/`)
  - `src/core/internal/provider.ts` - Added chainIds to wallet_connect response
  - `src/core/internal/typebox/rpc.ts` - Updated RPC schema with chainIds
  - `src/wagmi/internal/core.ts` - Modified connect function return type
- Wagmi Playground (`apps/wagmi`)
  - Updated App.tsx to demonstrate new connect functionality with SIWE