### PR TITLE
feat: implement quote signing in dialog transaction flows

### DIFF
--- a/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
@@ -1,9 +1,11 @@
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Actions } from 'porto/remote'
+import { Signature } from 'ox'
+import { Actions, Hooks } from 'porto/remote'
 
 import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
+import * as RpcServer from '~/lib/RpcServer'
 import { ActionRequest } from '../-components/ActionRequest'
 
 export const Route = createFileRoute('/dialog/wallet_sendCalls')({
@@ -20,10 +22,50 @@ function RouteComponent() {
 
   const { feeToken, merchantRpcUrl } = capabilities ?? {}
 
+  const account = Hooks.useAccount(porto, { address: from })
+
+  const prepareCallsQuery = RpcServer.usePrepareCalls({
+    address: from,
+    calls,
+    chainId,
+    feeToken,
+    merchantRpcUrl,
+    authorizeKeys: [],
+    revokeKeys: [],
+  })
+
   const respond = useMutation({
-    mutationFn() {
-      // TODO: sign quote.
-      return Actions.respond(porto, request!)
+    async mutationFn() {
+      if (!account) throw new Error('Account not found')
+      if (!prepareCallsQuery.data) throw new Error('Prepare calls data not available')
+
+      const { digest, capabilities } = prepareCallsQuery.data
+      const { quote } = capabilities
+
+      if (!quote) {
+        // If no quote available, respond without signing
+        return Actions.respond(porto, request!)
+      }
+
+      // Sign the digest
+      const signature = await account.sign({ hash: digest })
+      const parsedSignature = Signature.from(signature)
+
+      // Create signed quote by adding signature fields
+      const signedQuote = {
+        ...quote,
+        hash: digest,
+        r: parsedSignature.r,
+        s: parsedSignature.s,
+        yParity: parsedSignature.yParity,
+      }
+
+      // Respond with signed quote
+      return Actions.respond(porto, request!, {
+        result: {
+          quote: signedQuote,
+        },
+      })
     },
   })
 


### PR DESCRIPTION
## Summary
Implements quote signing functionality for transaction requests by replacing TODO comments with actual signature logic.

## Changes
- **eth_sendTransaction.tsx**: Added quote signing with digest verification
- **wallet_sendCalls.tsx**: Added quote signing with digest verification

## Implementation Details
- Integrate account hooks to access signing capabilities
- Use `usePrepareCalls` to obtain transaction quote and digest
- Sign digest using account's signing method
- Create signed quote with signature fields (`hash`, `r`, `s`, `yParity`)
- Pass signed quote in response payload