### PR TITLE
feat: simulate asset diff without merchant RPC

### DIFF
--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -41,6 +41,8 @@ export function ActionRequest(props: ActionRequest.Props) {
 
   const account = Hooks.useAccount(porto, { address })
 
+  // This "prepare calls" query is used as the "source of truth" query that will
+  // ultimately be used to execute the calls.
   const prepareCallsQuery = RpcServer.usePrepareCalls({
     address,
     calls,
@@ -49,7 +51,21 @@ export function ActionRequest(props: ActionRequest.Props) {
     merchantRpcUrl,
   })
 
-  const assetDiff = prepareCallsQuery.data?.capabilities.assetDiff
+  // However, to prevent a malicious RPC server from providing a mutated asset
+  // diff to display to the end-user, we also simulate the prepare calls query
+  // without the merchant RPC URL.
+  const prepareCallsQuery_assetDiff = RpcServer.usePrepareCalls({
+    address,
+    calls,
+    chainId,
+    enabled: !!merchantRpcUrl,
+    feeToken,
+  })
+  const query_assetDiff = merchantRpcUrl
+    ? prepareCallsQuery_assetDiff
+    : prepareCallsQuery
+
+  const assetDiff = query_assetDiff.data?.capabilities.assetDiff
   const quote = prepareCallsQuery.data?.capabilities.quote
 
   return (


### PR DESCRIPTION
### Summary

This PR adds protection against malicious merchant RPC servers by simulating asset diffs without the merchant RPC URL when a merchant is present.

### Details

- Added a secondary `prepareCallsQuery_assetDiff` query that simulates prepare calls without the merchant RPC URL
- This prevents malicious RPC servers from providing mutated asset diffs to display to end-users
- The original prepare calls query with merchant RPC remains the source of truth for execution
- Only the asset diff display uses the simulated query when a merchant RPC is present

### Areas Touched

- Dialog (`apps/dialog`)