### PR TITLE
fix: disable auto-deployment of octopus

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -3,6 +3,10 @@ name: Deploy Workers
 on:
   push:
     branches: [main]
+    paths:
+      - 'apps/faucet/**'
+      - 'apps/verify/**'
+      # - 'apps/octopus/**'
   workflow_dispatch:
 
 concurrency:
@@ -22,7 +26,10 @@ jobs:
     runs-on: ['ubuntu-latest']
     strategy:
       matrix:
-        worker: [faucet, verify, octopus]
+        worker:
+          - faucet
+          - verify
+          # - octopus
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
for a reason I'm currently investigating, whenever https://github.com/ithacaxyz/porto/tree/main/apps/octopus is deployed through the github action, the worker link goes bust and shows 1104 error.

also added a paths filter so that workers are deployed when their files are changed vs. on every push to `main`