### PR TITLE
fix: use git submodule update in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Checkout contracts submodule at specific ref
         if: inputs.contracts-ref != ''
         run: |
+          git submodule update --init --recursive contracts/account
           cd contracts/account
           git fetch origin ${{ inputs.contracts-ref }}
           git checkout ${{ inputs.contracts-ref }}


### PR DESCRIPTION
Without it test fail, see e.g. https://github.com/ithacaxyz/porto/actions/runs/16122735880 