### PR TITLE
fix: resolve submodule checkout failures for arbitrary ref

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,13 +72,17 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
+
+      - name: Initialize submodules
+        run: |
+          git submodule update --init --recursive
+          # Configure submodules to fetch all refs
+          git submodule foreach 'git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"'
+          git submodule foreach 'git fetch --tags'
 
       - name: Checkout contracts submodule at specific ref
         if: inputs.contracts-ref != ''
         run: |
-          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
           cd contracts/account
           git fetch origin ${{ inputs.contracts-ref }}
           git checkout ${{ inputs.contracts-ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ on:
   workflow_call:
   workflow_dispatch:
     inputs:
+      porto-ref:
+        type: string
+        description: 'Porto ref'
+        default: ''
       contracts-ref:
         type: string
         description: 'Contracts ref'
@@ -72,6 +76,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.porto-ref }}
 
       - name: Initialize submodules
         run: |


### PR DESCRIPTION
another attempt to fix the submodule init issue, plus also adds porto-ref as input since when triggering via repository dispatch we can't specify porto ref like we do when triggering workflows via gh cli / ui