### PR TITLE
feat: close dialog on escape

### DIFF
--- a/apps/dialog/src/routes/-components/TitleBar.tsx
+++ b/apps/dialog/src/routes/-components/TitleBar.tsx
@@ -39,12 +39,10 @@ export function TitleBar(props: TitleBar.Props) {
     if (!selfClose) return
 
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') 
-        Actions.rejectAll(porto)
+      if (event.key === 'Escape') Actions.rejectAll(porto)
     }
     window.addEventListener('keydown', onKeyDown)
-    return () => 
-      window.removeEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [selfClose])
 
   return (


### PR DESCRIPTION
This allows to close the dialog using the escape key when the focus has moved inside of the iframe or popup.