### PR TITLE
feat: add URL parameter support for playground mode and headless fallback for dialog

### DIFF
--- a/.changeset/shaky-breads-jump.md
+++ b/.changeset/shaky-breads-jump.md
@@ -1,0 +1,6 @@
+---
+"porto": patch
+---
+
+Fixed an issue where headless methods on the `Dialog.popup` renderer would invoke
+a popup, instead of calling the method in the background.

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -31,7 +31,11 @@ import {
 } from './config'
 
 export function App() {
-  const [mode, setMode] = React.useState<ModeType>('iframe-dialog')
+  const [mode, setMode] = React.useState<ModeType>(() => {
+    const url = new URL(window.location.href)
+    const mode = url.searchParams.get('mode') as ModeType | null
+    return mode ?? 'iframe-dialog'
+  })
   React.useEffect(() => porto._internal.setMode(modes[mode]), [mode])
 
   return (

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -2,6 +2,7 @@ import type * as Address from 'ox/Address'
 import * as Provider from 'ox/Provider'
 import * as RpcRequest from 'ox/RpcRequest'
 import * as RpcSchema from 'ox/RpcSchema'
+import * as Porto_remote from '../../../remote/Porto.js'
 import * as Account from '../../../viem/Account.js'
 import * as Key from '../../../viem/Key.js'
 import * as ServerClient from '../../../viem/ServerClient.js'
@@ -19,9 +20,11 @@ import type * as FeeToken from '../schema/feeToken.js'
 import * as Schema from '../schema/schema.js'
 import * as Siwe from '../siwe.js'
 import * as U from '../utils.js'
+import { rpcServer } from './rpcServer.js'
 
 export function dialog(parameters: dialog.Parameters = {}) {
   const {
+    fallback = rpcServer(),
     host = 'https://stg.id.porto.sh/dialog',
     renderer = Dialog.iframe(),
   } = parameters
@@ -263,6 +266,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
         if (request.method !== 'wallet_getAccountVersion')
           throw new Error('Cannot get version for method: ' + request.method)
 
+        const supported = supportsHeadless(renderer, 'wallet_getAccountVersion')
+        if (!supported) return fallback.actions.getAccountVersion(parameters)
+
         const provider = getProvider(store)
         const result = await provider.request(request)
         return result
@@ -274,6 +280,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
 
         if (request.method !== 'wallet_getCallsStatus')
           throw new Error('Cannot get status for method: ' + request.method)
+
+        const supported = supportsHeadless(renderer, 'wallet_getCallsStatus')
+        if (!supported) return fallback.actions.getCallsStatus(parameters)
 
         const provider = getProvider(store)
         const result = await provider.request(request)
@@ -289,6 +298,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
             'Cannot get capabilities for method: ' + request.method,
           )
 
+        const supported = supportsHeadless(renderer, 'wallet_getCapabilities')
+        if (!supported) return fallback.actions.getCapabilities(parameters)
+
         const provider = getProvider(store)
         const result = await provider.request(request)
         return result
@@ -298,19 +310,25 @@ export function dialog(parameters: dialog.Parameters = {}) {
         const { account, internal } = parameters
         const { store } = internal
 
-        const provider = getProvider(store)
-        const result = await provider.request({
-          method: 'wallet_getKeys',
-          params: [
-            {
-              address: account.address,
-            },
-          ],
-        })
+        const supported = supportsHeadless(renderer, 'wallet_getKeys')
 
-        const keys = Schema.decodeSync(RpcSchema_porto.wallet_getKeys.Response)(
-          result,
-        )
+        const keys = await (async () => {
+          if (!supported) return fallback.actions.getKeys(parameters)
+
+          const provider = getProvider(store)
+          const result = await provider.request({
+            method: 'wallet_getKeys',
+            params: [
+              {
+                address: account.address,
+              },
+            ],
+          })
+
+          return Schema.decodeSync(RpcSchema_porto.wallet_getKeys.Response)(
+            result,
+          )
+        })()
 
         return U.uniqBy(
           [...(account.keys ?? []), ...keys],
@@ -522,6 +540,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
         if (request.method !== 'wallet_prepareCalls')
           throw new Error('Cannot prepare calls for method: ' + request.method)
 
+        const supported = supportsHeadless(renderer, 'wallet_prepareCalls')
+        if (!supported) return fallback.actions.prepareCalls(parameters)
+
         const feeToken = await resolveFeeToken(internal, parameters)
 
         const preCalls = await PreCalls.get({
@@ -562,6 +583,13 @@ export function dialog(parameters: dialog.Parameters = {}) {
           throw new Error(
             'Cannot prepare upgrade for method: ' + request.method,
           )
+
+        const supported = supportsHeadless(
+          renderer,
+          'wallet_prepareUpgradeAccount',
+        )
+        if (!supported)
+          return fallback.actions.prepareUpgradeAccount(parameters)
 
         // Extract the capabilities from the request.
         const [{ capabilities }] = request._decoded.params ?? [{}]
@@ -694,6 +722,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
         // without sending a request to the dialog. If the key does not
         // have permission to execute the calls, fall back to the dialog.
         if (key && key.role === 'session') {
+          const supported = supportsHeadless(renderer, 'wallet_prepareCalls')
+          if (!supported) return fallback.actions.sendCalls(parameters)
+
           try {
             // TODO: use eventual Viem Action.
             const req = await provider.request(
@@ -810,6 +841,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
           throw new Error(
             'Cannot send prepared calls for method: ' + request.method,
           )
+
+        const supported = supportsHeadless(renderer, 'wallet_sendPreparedCalls')
+        if (!supported) return fallback.actions.sendPreparedCalls(parameters)
 
         const provider = getProvider(store)
         const result = await provider.request(request)
@@ -948,6 +982,13 @@ export function dialog(parameters: dialog.Parameters = {}) {
 export declare namespace dialog {
   type Parameters = {
     /**
+     * Mode to fall back to if the renderer does not support background
+     * operations.
+     *
+     * @default `Mode.rpcServer()`
+     */
+    fallback?: Mode.Mode | undefined
+    /**
      * URL of the dialog embed.
      * @default 'http://stg.id.porto.sh/dialog'
      */
@@ -971,6 +1012,31 @@ export async function resolveFeeToken(
   } = internal
   const { feeToken: overrideFeeToken } = parameters ?? {}
   return overrideFeeToken ?? feeToken
+}
+
+/**
+ * Checks if the method is supported in headless mode by the renderer.
+ *
+ * @param method - The method to check.
+ * @returns Whether the method is supported in headless mode.
+ */
+function supportsHeadless(renderer: Dialog.Dialog, method: string) {
+  const policy = Porto_remote.defaultConfig.methodPolicies.find(
+    (x) => x.method === method,
+  ) as Porto_remote.MethodPolicy
+
+  if (renderer.name === 'popup') {
+    if (typeof policy?.modes?.headless === 'boolean')
+      return !policy?.modes?.headless
+  }
+
+  return true
+}
+
+declare namespace supportsHeadless {
+  type Options = {
+    renderer: Dialog.Dialog
+  }
 }
 
 function getAuthUrl(


### PR DESCRIPTION
## Summary

Added URL parameter support for setting the initial mode in the playground app and implemented headless fallback functionality for dialog mode operations.

## Details

- Added URL parameter support (`?mode=`) to set the initial mode in the playground app, allowing direct navigation to specific modes
- Implemented fallback mechanism in dialog mode that defaults to `rpcServer()` mode when the renderer doesn't support headless operations
- Added `supportsHeadless` check for various wallet methods (`wallet_getAccountVersion`, `wallet_getCallsStatus`, `wallet_getCapabilities`, `wallet_getKeys`, `wallet_prepareCalls`, `wallet_prepareUpgradeAccount`, `wallet_sendPreparedCalls`) to determine when to use the fallback
- The fallback ensures operations continue to work even when the dialog renderer (e.g., popup) doesn't support background/headless execution

## Areas Touched

- Playground (`apps/playground`)
- `porto` Library (`src/`)