### PR TITLE
fix: return transaction hash instead of bundle id for eth_sendTransaction

### DIFF
--- a/.changeset/proud-kids-yell.md
+++ b/.changeset/proud-kids-yell.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Fixed issue where `eth_sendTransaction` response would be the bundle identifier, instead of the transaction hash.

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -249,6 +249,8 @@ export type Mode = {
     sendCalls: (parameters: {
       /** Account to execute the calls with. */
       account: Account.Account
+      /** Whether the returned bundle identifier is the transaction hash. */
+      asTxHash?: boolean | undefined
       /** Calls to execute. */
       calls: readonly Call.Call[]
       /** Fee token to use for execution. If not provided, the native token (e.g. ETH) will be used. */

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -251,6 +251,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
         })
         await waitForCallsStatus(client, {
           id,
+          pollingInterval: 500,
         })
 
         return { key: authorizeKey }
@@ -637,7 +638,8 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
       },
 
       async sendCalls(parameters) {
-        const { account, calls, internal, merchantRpcUrl } = parameters
+        const { account, asTxHash, calls, internal, merchantRpcUrl } =
+          parameters
         const {
           client,
           config: { storage },
@@ -679,6 +681,17 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
           address: account.address,
           storage,
         })
+
+        if (asTxHash) {
+          const { receipts } = await waitForCallsStatus(client, {
+            id: result.id,
+            pollingInterval: 500,
+          })
+          if (!receipts?.[0]) throw new Provider.UnknownBundleIdError()
+          return {
+            id: receipts[0].transactionHash,
+          }
+        }
 
         return result
       },

--- a/src/core/internal/provider.test.ts
+++ b/src/core/internal/provider.test.ts
@@ -17,6 +17,7 @@ import {
   setCode,
   signTypedData,
   waitForCallsStatus,
+  waitForTransactionReceipt,
 } from 'viem/actions'
 import { verifySiweMessage } from 'viem/siwe'
 import { describe, expect, test, vi } from 'vitest'
@@ -137,9 +138,8 @@ describe.each([
 
       expect(hash).toBeDefined()
 
-      await waitForCallsStatus(WalletClient.fromPorto(porto), {
-        id: hash,
-      })
+      const receipt = await waitForTransactionReceipt(client, { hash })
+      expect(receipt).toBeDefined()
 
       expect(
         await readContract(client, {

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -191,6 +191,7 @@ export function from<
 
           const { id } = await getMode().actions.sendCalls({
             account,
+            asTxHash: true,
             calls: [
               {
                 data,


### PR DESCRIPTION
### Summary

Resolves https://github.com/ithacaxyz/porto/issues/445.

Fixed an issue where `eth_sendTransaction` was returning a bundle identifier instead of the expected transaction hash.

### Details

- Added `asTxHash` parameter to `sendCalls` method in mode interface
- Modified dialog and rpcServer modes to wait for transaction receipt when `asTxHash` is true
- Updated provider to pass `asTxHash: true` for `eth_sendTransaction` calls
- Added proper polling interval (500ms) for `waitForCallsStatus`
- Updated tests to use `waitForTransactionReceipt` instead of `waitForCallsStatus`

### Areas Touched

- `porto` Library (`src/`)
  - Core internal modules (`src/core/internal/`)