### PR TITLE
fix: CSP fallback for extension dialog

### DIFF
--- a/.changeset/little-clocks-carry.md
+++ b/.changeset/little-clocks-carry.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Tweaked extension to fall back to popup if host site blocks iframe due to CSP.

--- a/src/core/Chains.ts
+++ b/src/core/Chains.ts
@@ -38,7 +38,10 @@ export const base = /*#__PURE__*/ define({
   },
   rpcUrls: {
     default: {
-      http: ['https://base-mainnet.rpc.ithaca.xyz'],
+      http: [
+        'https://base-mainnet.rpc.ithaca.xyz',
+        ...chains.base.rpcUrls.default.http,
+      ],
     },
   },
 })
@@ -53,7 +56,10 @@ export const baseSepolia = /*#__PURE__*/ define({
   },
   rpcUrls: {
     default: {
-      http: ['https://base-sepolia.rpc.ithaca.xyz'],
+      http: [
+        'https://base-sepolia.rpc.ithaca.xyz',
+        ...chains.baseSepolia.rpcUrls.default.http,
+      ],
     },
   },
 })

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -180,6 +180,7 @@ export function unstable_create(
           host: 'https://id.porto.sh/dialog',
         })
       : rpcServer(),
+    storageKey: 'prod.porto.store',
     transports: {
       [Chains.base.id]: http(),
     },

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -14,7 +14,7 @@ import type * as PreCalls from './preCalls.js'
 import type * as Capabilities from './schema/capabilities.js'
 import type * as FeeToken from './schema/feeToken.js'
 import type * as RpcRequest from './schema/request.js'
-import type { PartialBy } from './types.js'
+import type { Assign, PartialBy } from './types.js'
 
 type Request = RpcRequest.parseRequest.ReturnType
 
@@ -335,6 +335,7 @@ export type Mode = {
       internal: ActionsInternal
     }) => Promise<null>
   }
+  config?: unknown | undefined
   name: string
   setup: (parameters: {
     /** Internal properties. */
@@ -348,13 +349,13 @@ export type Mode = {
  * @param mode - Mode.
  * @returns Mode.
  */
-export function from<const _mode extends from.Parameters>(
-  mode: from.Parameters,
-): Mode {
+export function from<const mode extends from.Parameters>(
+  mode: mode | from.Parameters,
+): Assign<Mode, mode> {
   return {
     ...mode,
     setup: mode.setup ?? (() => () => {}),
-  }
+  } as never
 }
 
 export declare namespace from {

--- a/src/core/internal/modes/contract.ts
+++ b/src/core/internal/modes/contract.ts
@@ -614,6 +614,7 @@ export function contract(parameters: contract.Parameters = {}) {
         throw new Provider.UnsupportedMethodError()
       },
     },
+    config: parameters,
     name: 'contract',
   })
 }

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -930,6 +930,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
         return await provider.request(request)
       },
     },
+    config: parameters,
     name: 'dialog',
     setup(parameters) {
       const { internal } = parameters

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -205,14 +205,17 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
                 return null
               }
             })()
-            if (!capabilities) return {}
             return {
               [chainId]: {
                 ...base,
-                feeToken: {
-                  supported: true,
-                  tokens: capabilities.fees.tokens,
-                },
+                ...(capabilities
+                  ? {
+                      feeToken: {
+                        supported: true,
+                        tokens: capabilities.fees.tokens,
+                      },
+                    }
+                  : {}),
               },
             } as const
           }),
@@ -829,6 +832,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
         })
       },
     },
+    config: parameters,
     name: 'rpc',
   })
 }

--- a/src/viem/ServerClient.ts
+++ b/src/viem/ServerClient.ts
@@ -51,10 +51,12 @@ export function fromPorto<
       ].join('\n'),
     )
 
-  const transport =
-    (config_.transports as Record<number, Transport>)[chain.id] ??
-    fallback(chain.rpcUrls.default.http.map((url) => http(url)))
-  if (!transport) throw new Error('transport not found.')
+  const transport = fallback(
+    [
+      (config_.transports as Record<number, Transport>)[chain.id],
+      ...chain.rpcUrls.default.http.map((url) => http(url)),
+    ].filter(Boolean) as Transport[],
+  )
 
   const key = [id, Json.stringify(chain)].filter(Boolean).join(':')
   if (clientCache.has(key)) return clientCache.get(key)!


### PR DESCRIPTION
## Summary

Adds a CSP (Content Security Policy) fallback mechanism for the Porto extension that automatically switches from iframe to popup mode when sites block iframe embedding.

## Details

- Added event listener in the extension's content script to detect CSP violations
- When a CSP violation blocks Porto's iframe from loading, the extension automatically falls back to popup mode
- Extended dialog mode configuration to preserve the original host configuration during mode switching
- Added fallback RPC URLs to Base and Base Sepolia chains for improved reliability
- Updated Porto's production configuration to use a dedicated storage key

## Areas Touched

- Extension (`apps/extension`)
- `porto` Library (`src/`)
  - Dialog mode configuration (`src/core/internal/modes/dialog.ts`)
  - Chain configurations (`src/core/Chains.ts`)
  - ServerClient transport handling (`src/viem/ServerClient.ts`)