### PR TITLE
Fix: use regular for loop for contract build file iteration

### DIFF
--- a/scripts/postbuild:contracts.ts
+++ b/scripts/postbuild:contracts.ts
@@ -19,7 +19,7 @@ await Fs.mkdir(
 )
 
 async function buildContracts(outPath: string) {
-  for await (const file of await Fs.readdir(outPath)) {
+  for (const file of await Fs.readdir(outPath)) {
     const path = Path.resolve(outPath, file)
     const name = Path.basename(path, '.json')
 


### PR DESCRIPTION
Replaced the use of for await...of with a regular for...of loop in the buildContracts function to correctly iterate over files returned by Fs.readdir. This resolves a logic issue, as Fs.readdir returns an array, not an async iterable. No other logic or structure was changed.