### PR TITLE
refactor: refactor `usePrepareCalls` usage, and do not refetch when there is an error

### DIFF
--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -43,18 +43,22 @@ export function ActionRequest(props: ActionRequest.Props) {
 
   // This "prepare calls" query is used as the "source of truth" query that will
   // ultimately be used to execute the calls.
-  const prepareCallsQuery = RpcServer.usePrepareCalls({
+  const prepareCallsQuery = RpcServer.prepareCalls.useQuery({
     address,
     calls,
     chainId,
     feeToken,
     merchantRpcUrl,
+    refetchInterval(query) {
+      if (query.state.error) return false
+      return 15_000
+    },
   })
 
   // However, to prevent a malicious RPC server from providing a mutated asset
   // diff to display to the end-user, we also simulate the prepare calls query
   // without the merchant RPC URL.
-  const prepareCallsQuery_assetDiff = RpcServer.usePrepareCalls({
+  const prepareCallsQuery_assetDiff = RpcServer.prepareCalls.useQuery({
     address,
     calls,
     chainId,

--- a/apps/dialog/src/routes/-components/GrantAdmin.tsx
+++ b/apps/dialog/src/routes/-components/GrantAdmin.tsx
@@ -19,7 +19,7 @@ export function GrantAdmin(props: GrantAdmin.Props) {
 
   const account = Hooks.useAccount(porto)
 
-  const prepareCallsQuery = RpcServer.usePrepareCalls({
+  const prepareCallsQuery = RpcServer.prepareCalls.useQuery({
     authorizeKeys: [Key.from(authorizeKey)],
     feeToken,
   })

--- a/apps/dialog/src/routes/-components/RevokeAdmin.tsx
+++ b/apps/dialog/src/routes/-components/RevokeAdmin.tsx
@@ -19,7 +19,7 @@ export function RevokeAdmin(props: RevokeAdmin.Props) {
     (admin) => admin.id === revokeKeyId,
   )
 
-  const prepareCallsQuery = RpcServer.usePrepareCalls({
+  const prepareCallsQuery = RpcServer.prepareCalls.useQuery({
     enabled: !!revokeKey,
     feeToken,
     revokeKeys: revokeKey ? [Key.from(revokeKey)] : [],

--- a/apps/dialog/src/routes/-components/RevokePermissions.tsx
+++ b/apps/dialog/src/routes/-components/RevokePermissions.tsx
@@ -15,7 +15,7 @@ export function RevokePermissions(props: RevokePermissions.Props) {
   const permissions = data?.find((x) => x.id === id)?.permissions
   const hostname = Dialog.useStore((state) => state.referrer?.url?.hostname)
 
-  const prepareCallsQuery = RpcServer.usePrepareCalls({
+  const prepareCallsQuery = RpcServer.prepareCalls.useQuery({
     enabled: !!permissions,
     feeToken: capabilities?.feeToken,
   })

--- a/apps/dialog/src/routes/-components/UpdateAccount.tsx
+++ b/apps/dialog/src/routes/-components/UpdateAccount.tsx
@@ -30,7 +30,7 @@ export function UpdateAccount(props: UpdateAccount.Props) {
   const { accountImplementation } = contracts ?? {}
 
   const account = Hooks.useAccount(porto)
-  const prepareCallsQuery = RpcServer.usePrepareCalls({
+  const prepareCallsQuery = RpcServer.prepareCalls.useQuery({
     calls:
       account?.address && accountImplementation
         ? [


### PR DESCRIPTION
## Summary

Refactored the `usePrepareCalls` hook to use React Query's `queryOptions` pattern and added conditional refetch logic to prevent refetching when there is an error.

## Details

- Refactored `usePrepareCalls` to use a namespace pattern with `prepareCalls.queryOptions` and `prepareCalls.useQuery`
- Added conditional `refetchInterval` logic that returns `false` when there's an error, preventing unnecessary refetches
- Moved fee token fetching logic into the query function using `Query.client.ensureQueryData`
- Improved type organization and made the API more consistent with other query patterns in the codebase
- Updated all usages of `RpcServer.usePrepareCalls` to use the new `RpcServer.prepareCalls.useQuery` API

## Areas Touched

- Dialog (`apps/dialog`)