### PR TITLE
feat: sign calls from dialog

### DIFF
--- a/apps/dialog/src/lib/RpcServer.ts
+++ b/apps/dialog/src/lib/RpcServer.ts
@@ -80,9 +80,9 @@ export namespace prepareCalls {
       > &
         Pick<
           UseQueryOptions<
-            ServerActions.prepareCalls.ReturnType,
+            queryOptions.Data,
             Error,
-            ServerActions.prepareCalls.ReturnType,
+            queryOptions.Data,
             (string | undefined)[]
           >,
           'enabled' | 'refetchInterval'
@@ -91,6 +91,8 @@ export namespace prepareCalls {
           feeToken?: FeeToken_schema.Symbol | Address.Address | undefined
           merchantRpcUrl?: string | undefined
         }
+
+    export type Data = ServerActions.prepareCalls.ReturnType
   }
 
   export function useQuery(props: useQuery.Props) {
@@ -107,5 +109,7 @@ export namespace prepareCalls {
       address?: Address.Address | undefined
       chainId?: number | undefined
     }
+
+    export type Data = queryOptions.Data
   }
 }

--- a/apps/dialog/src/routes/-components/ActionRequest.tsx
+++ b/apps/dialog/src/routes/-components/ActionRequest.tsx
@@ -113,7 +113,7 @@ export function ActionRequest(props: ActionRequest.Props) {
                 </Button>
                 <Button
                   className="flex-grow"
-                  onClick={onApprove}
+                  onClick={() => onApprove(prepareCallsQuery.data!)}
                   type="button"
                   variant="accent"
                 >
@@ -135,7 +135,7 @@ export function ActionRequest(props: ActionRequest.Props) {
                   className="flex-grow"
                   data-testid="confirm"
                   disabled={!prepareCallsQuery.isSuccess}
-                  onClick={onApprove}
+                  onClick={() => onApprove(prepareCallsQuery.data!)}
                   type="button"
                   variant="accent"
                 >
@@ -163,7 +163,7 @@ export namespace ActionRequest {
     feeToken?: FeeToken_schema.Symbol | Address.Address | undefined
     loading?: boolean | undefined
     merchantRpcUrl?: string | undefined
-    onApprove: () => void
+    onApprove: (data: RpcServer.prepareCalls.useQuery.Data) => void
     onReject: () => void
     quote?: Quote | undefined
   }

--- a/apps/dialog/src/routes/dialog/eth_sendTransaction.tsx
+++ b/apps/dialog/src/routes/dialog/eth_sendTransaction.tsx
@@ -1,8 +1,13 @@
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Actions } from 'porto/remote'
+import { Provider } from 'ox'
+import { Account, Key } from 'porto'
+import { Actions, Hooks } from 'porto/remote'
+import { ServerActions } from 'porto/viem'
+import { waitForCallsStatus } from 'viem/actions'
 import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
+import type * as RpcServer from '~/lib/RpcServer'
 import { ActionRequest } from '../-components/ActionRequest'
 
 export const Route = createFileRoute('/dialog/eth_sendTransaction')({
@@ -20,10 +25,46 @@ function RouteComponent() {
 
   const calls = [{ data, to: to!, value }] as const
 
+  const account = Hooks.useAccount(porto, { address: from })
+  const client = Hooks.useServerClient(porto, { chainId })
+
   const respond = useMutation({
-    mutationFn() {
-      // TODO: sign quote.
-      return Actions.respond(porto, request)
+    async mutationFn(data: RpcServer.prepareCalls.useQuery.Data) {
+      if (!account) throw new Error('account not found.')
+
+      const key = Account.getKey(account, { role: 'admin' })
+      if (!key) throw new Error('admin key not found.')
+
+      const { capabilities, context, digest } = data
+
+      const signature = await Key.sign(key, {
+        payload: digest,
+        wrap: false,
+      })
+
+      const { id } = await ServerActions.sendPreparedCalls(client, {
+        capabilities: capabilities.feeSignature
+          ? {
+              feeSignature: capabilities.feeSignature,
+            }
+          : undefined,
+        context,
+        key,
+        signature,
+      })
+
+      const { receipts } = await waitForCallsStatus(client, {
+        id,
+      })
+      const hash = receipts?.[0]?.transactionHash
+
+      if (!hash)
+        return Actions.respond(porto, request, {
+          error: new Provider.UnknownBundleIdError(),
+        })
+      return Actions.respond(porto, request!, {
+        result: hash,
+      })
     },
   })
 
@@ -33,7 +74,7 @@ function RouteComponent() {
       calls={calls}
       chainId={chainId}
       loading={respond.isPending}
-      onApprove={() => respond.mutate()}
+      onApprove={(data) => respond.mutate(data)}
       onReject={() => Actions.reject(porto, request)}
     />
   )

--- a/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_sendCalls.tsx
@@ -1,9 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Actions } from 'porto/remote'
+import { Account, Key } from 'porto'
+import { Actions, Hooks } from 'porto/remote'
+import { ServerActions } from 'porto/viem'
 
 import { porto } from '~/lib/Porto'
 import * as Router from '~/lib/Router'
+import type * as RpcServer from '~/lib/RpcServer'
 import { ActionRequest } from '../-components/ActionRequest'
 
 export const Route = createFileRoute('/dialog/wallet_sendCalls')({
@@ -20,10 +23,37 @@ function RouteComponent() {
 
   const { feeToken, merchantRpcUrl } = capabilities ?? {}
 
+  const account = Hooks.useAccount(porto, { address: from })
+  const client = Hooks.useServerClient(porto, { chainId })
+
   const respond = useMutation({
-    mutationFn() {
-      // TODO: sign quote.
-      return Actions.respond(porto, request!)
+    async mutationFn(data: RpcServer.prepareCalls.useQuery.Data) {
+      if (!account) throw new Error('account not found.')
+
+      const key = Account.getKey(account, { role: 'admin' })
+      if (!key) throw new Error('admin key not found.')
+
+      const { capabilities, context, digest } = data
+
+      const signature = await Key.sign(key, {
+        payload: digest,
+        wrap: false,
+      })
+
+      const result = await ServerActions.sendPreparedCalls(client, {
+        capabilities: capabilities.feeSignature
+          ? {
+              feeSignature: capabilities.feeSignature,
+            }
+          : undefined,
+        context,
+        key,
+        signature,
+      })
+
+      return Actions.respond(porto, request!, {
+        result,
+      })
     },
   })
 
@@ -35,7 +65,7 @@ function RouteComponent() {
       feeToken={feeToken}
       loading={respond.isPending}
       merchantRpcUrl={merchantRpcUrl}
-      onApprove={() => respond.mutate()}
+      onApprove={(data) => respond.mutate(data)}
       onReject={() => Actions.reject(porto, request!)}
     />
   )


### PR DESCRIPTION
## Summary

Added sign calls functionality to the dialog for `eth_sendTransaction` and `wallet_sendCalls`, enabling proper quote signing with the admin key before sending prepared calls to the RPC server.

## Details

- Modified `ActionRequest` component to pass `prepareCalls` data to the `onApprove` callback
- Implemented quote signing logic in `eth_sendTransaction` route:
  - Retrieves admin key from account
  - Signs the quote digest with the key
  - Sends prepared calls with signature
  - Returns transaction hash on success
- Implemented quote signing logic in `wallet_sendCalls` route:
  - Similar signing flow as eth_sendTransaction
  - Returns the full sendPreparedCalls result
- Added type exports in RpcServer module for better type safety

## Areas Touched

- Dialog (`apps/dialog`)
  - `src/lib/RpcServer.ts`
  - `src/routes/-components/ActionRequest.tsx`
  - `src/routes/dialog/eth_sendTransaction.tsx`
  - `src/routes/dialog/wallet_sendCalls.tsx`