### PR TITLE
feat: tweak connect loading state

### DIFF
--- a/apps/dialog/src/lib/PermissionsRequest.ts
+++ b/apps/dialog/src/lib/PermissionsRequest.ts
@@ -13,6 +13,12 @@ export function useResolve(
 
   return useQuery({
     enabled: !!request,
+    initialData: request
+      ? {
+          ...Schema.decodeSync(PermissionsRequest.Schema)(request),
+          _encoded: request,
+        }
+      : undefined,
     async queryFn() {
       if (!request) throw new Error('no request found.')
 

--- a/apps/dialog/src/routes/-components/Email.tsx
+++ b/apps/dialog/src/routes/-components/Email.tsx
@@ -13,12 +13,12 @@ export function Email(props: Email.Props) {
   const {
     actions = ['sign-in', 'sign-up'],
     defaultValue = '',
-    loading,
     onApprove,
     permissions,
+    status,
   } = props
 
-  const [loadingTitle, setLoadingTitle] = React.useState('Signing up...')
+  const [respondingTitle, setRespondingTitle] = React.useState('Signing up...')
 
   const account = Hooks.useAccount(porto)
   const email = Dialog.useStore((state) =>
@@ -42,7 +42,7 @@ export function Email(props: Email.Props) {
       event.preventDefault()
       const formData = new FormData(event.target as HTMLFormElement)
       const email = formData.get('email')?.toString()
-      setLoadingTitle('Signing up...')
+      setRespondingTitle('Signing up...')
       onApprove({ email, signIn: false })
     },
     [onApprove],
@@ -67,7 +67,7 @@ export function Email(props: Email.Props) {
   }, [actions, cli, hostname])
 
   return (
-    <Layout loading={loading} loadingTitle={loadingTitle}>
+    <Layout loading={status === 'responding'} loadingTitle={respondingTitle}>
       <Layout.Header className="flex-grow">
         <Layout.Header.Default
           content={content}
@@ -83,8 +83,9 @@ export function Email(props: Email.Props) {
           <Button
             className="flex w-full gap-2"
             data-testid="sign-in"
+            disabled={status === 'loading'}
             onClick={() => {
-              setLoadingTitle('Signing in...')
+              setRespondingTitle('Signing in...')
               onApprove({ signIn: true })
             }}
             type="button"
@@ -116,6 +117,7 @@ export function Email(props: Email.Props) {
               <Input
                 className="w-full user-invalid:bg-gray3 user-invalid:ring-red9"
                 defaultValue={defaultValue}
+                disabled={status === 'loading'}
                 name="email"
                 placeholder="example@ithaca.xyz"
                 type="email"
@@ -127,6 +129,7 @@ export function Email(props: Email.Props) {
             <Button
               className="w-full gap-2 group-has-[:user-invalid]:cursor-not-allowed group-has-[:user-invalid]:text-gray10"
               data-testid="sign-up"
+              disabled={status === 'loading'}
               type="submit"
               variant={actions.includes('sign-in') ? 'default' : 'accent'}
             >
@@ -155,7 +158,7 @@ export function Email(props: Email.Props) {
             <button
               className="text-accent"
               onClick={() => {
-                setLoadingTitle('Signing in...')
+                setRespondingTitle('Signing in...')
                 onApprove({ selectAccount: true, signIn: true })
               }}
               type="button"
@@ -173,12 +176,12 @@ export namespace Email {
   export type Props = {
     actions?: readonly ('sign-in' | 'sign-up')[]
     defaultValue?: string | undefined
-    loading: boolean
     onApprove: (p: {
       email?: string
       selectAccount?: boolean
       signIn?: boolean
     }) => void
     permissions?: Permissions.Props
+    status?: 'loading' | 'responding' | undefined
   }
 }

--- a/apps/dialog/src/routes/-components/SignIn.tsx
+++ b/apps/dialog/src/routes/-components/SignIn.tsx
@@ -8,13 +8,13 @@ import { Permissions } from '~/routes/-components/Permissions'
 import LucideLogIn from '~icons/lucide/log-in'
 
 export function SignIn(props: SignIn.Props) {
-  const { loading, onApprove, permissions } = props
+  const { onApprove, permissions, status } = props
 
   const account = Hooks.useAccount(porto)
   const hostname = Dialog.useStore((state) => state.referrer?.url?.hostname)
 
   return (
-    <Layout loading={loading} loadingTitle="Signing in...">
+    <Layout loading={status === 'responding'} loadingTitle="Signing in...">
       <Layout.Header className="flex-grow">
         <Layout.Header.Default
           content={
@@ -40,6 +40,7 @@ export function SignIn(props: SignIn.Props) {
           <Button
             className="w-full"
             data-testid="sign-up"
+            disabled={status === 'loading'}
             onClick={() => onApprove({ signIn: false })}
             type="button"
           >
@@ -49,6 +50,7 @@ export function SignIn(props: SignIn.Props) {
           <Button
             className="w-full"
             data-testid="sign-in"
+            disabled={status === 'loading'}
             onClick={() => onApprove({ signIn: true })}
             type="button"
             variant="accent"
@@ -70,8 +72,8 @@ export function SignIn(props: SignIn.Props) {
 
 declare namespace SignIn {
   type Props = {
-    loading: boolean
     onApprove: (p: { signIn?: boolean; selectAccount?: boolean }) => void
     permissions?: Permissions.Props
+    status?: 'loading' | 'responding' | undefined
   }
 }

--- a/apps/dialog/src/routes/-components/SignUp.tsx
+++ b/apps/dialog/src/routes/-components/SignUp.tsx
@@ -9,7 +9,7 @@ import LucideLogIn from '~icons/lucide/log-in'
 import Question from '~icons/mingcute/question-line'
 
 export function SignUp(props: SignUp.Props) {
-  const { enableSignIn, loading, onApprove, onReject, permissions } = props
+  const { enableSignIn, onApprove, onReject, permissions, status } = props
 
   const [showLearn, setShowLearn] = useState(false)
 
@@ -17,7 +17,7 @@ export function SignUp(props: SignUp.Props) {
 
   if (showLearn) return <SignUp.Learn onDone={() => setShowLearn(false)} />
   return (
-    <Layout loading={loading} loadingTitle="Signing up...">
+    <Layout loading={status === 'responding'} loadingTitle="Signing up...">
       <Layout.Header className="flex-grow">
         <Layout.Header.Default
           content={
@@ -43,6 +43,7 @@ export function SignUp(props: SignUp.Props) {
           {enableSignIn ? (
             <Button
               data-testid="sign-in"
+              disabled={status === 'loading'}
               onClick={() => onApprove({ selectAccount: true, signIn: true })}
               type="button"
             >
@@ -57,6 +58,7 @@ export function SignUp(props: SignUp.Props) {
           <Button
             className="flex-grow"
             data-testid="sign-up"
+            disabled={status === 'loading'}
             onClick={() => onApprove({ signIn: false })}
             type="button"
             variant="accent"
@@ -86,10 +88,10 @@ export function SignUp(props: SignUp.Props) {
 export namespace SignUp {
   export type Props = {
     enableSignIn?: boolean
-    loading?: boolean
     onApprove: (p: { signIn?: boolean; selectAccount?: boolean }) => void
     onReject: () => void
     permissions?: Permissions.Props
+    status?: 'loading' | 'responding' | undefined
   }
 
   export function Learn({ onDone }: { onDone: () => void }) {

--- a/apps/dialog/src/routes/dialog/wallet_connect.tsx
+++ b/apps/dialog/src/routes/dialog/wallet_connect.tsx
@@ -163,14 +163,14 @@ function RouteComponent() {
     },
   })
 
-  const isLoading = React.useMemo(() => {
-    if (capabilities?.grantPermissions && grantPermissionsQuery.isPending)
-      return true
-    if (respond.isPending) return true
-    return false
+  const status = React.useMemo(() => {
+    if (capabilities?.grantPermissions && grantPermissionsQuery.isFetching)
+      return 'loading'
+    if (respond.isPending) return 'responding'
+    return undefined
   }, [
     capabilities?.grantPermissions,
-    grantPermissionsQuery.isPending,
+    grantPermissionsQuery.isFetching,
     respond.isPending,
   ])
 
@@ -185,9 +185,9 @@ function RouteComponent() {
             ? capabilities?.createAccount?.label || ''
             : undefined
         }
-        loading={isLoading}
         onApprove={(options) => respond.mutate(options)}
         permissions={grantPermissions?.permissions}
+        status={status}
       />
     )
 
@@ -195,18 +195,18 @@ function RouteComponent() {
     return (
       <SignUp
         enableSignIn={actions.includes('sign-in')}
-        loading={isLoading}
         onApprove={(options) => respond.mutate(options)}
         onReject={() => Actions.reject(porto, request)}
         permissions={grantPermissions?.permissions}
+        status={status}
       />
     )
 
   return (
     <SignIn
-      loading={isLoading}
       onApprove={(options) => respond.mutate(options)}
       permissions={grantPermissions?.permissions}
+      status={status}
     />
   )
 }


### PR DESCRIPTION
### Summary

Improves the loading experience in the dialog connect flow by distinguishing between data fetching and response states.

### Details

- Added initial data to `useResolve` query to prevent unnecessary loading states
- Renamed `loading` prop to `status` with more granular states ('loading' | 'responding')
- Changed from `isPending` to `isFetching` for grant permissions query to better reflect actual loading state
- Disabled form inputs and buttons during the 'loading' state to prevent user interaction while data is being fetched
- Separated loading titles for different actions (signing in vs signing up)

### Areas Touched

- Dialog (`apps/dialog`)