### PR TITLE
feat: support `wallet_switchEthereumChain`

### DIFF
--- a/.changeset/free-pets-wash.md
+++ b/.changeset/free-pets-wash.md
@@ -2,4 +2,4 @@
 "porto": patch
 ---
 
-Added \`wallet_switchEthereumChain\`.
+Added `wallet_switchEthereumChain`.

--- a/.changeset/free-pets-wash.md
+++ b/.changeset/free-pets-wash.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added \`wallet_switchEthereumChain\`.

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -77,6 +77,13 @@ export function App() {
           <hr />
           <br />
         </div>
+        <h2>Chain Management</h2>
+        <SwitchChain />
+        <div>
+          <br />
+          <hr />
+          <br />
+        </div>
         <h2>Permissions</h2>
         <GrantPermissions />
         <GetPermissions />
@@ -154,12 +161,14 @@ function State() {
 }
 
 function Events() {
-  const [responses, setResponses] = React.useState<Record<string, unknown>>({})
+  const [responses, setResponses] = React.useState<Record<string, unknown[]>>(
+    {},
+  )
   React.useEffect(() => {
     const handleResponse = (event: string) => (response: unknown) =>
       setResponses((responses) => ({
         ...responses,
-        [event]: response,
+        [event]: [...(responses[event] ?? []), response],
       }))
 
     const handleAccountsChanged = handleResponse('accountsChanged')
@@ -596,6 +605,51 @@ function UpdateAccount() {
         Update Account
       </button>
       {result ? <pre>{JSON.stringify(result, null, 2)}</pre> : null}
+    </div>
+  )
+}
+
+function SwitchChain() {
+  const [chainId, setChainId] = React.useState<`0x${string}` | undefined>(
+    undefined,
+  )
+
+  React.useEffect(() => {
+    porto.provider
+      .request({
+        method: 'eth_chainId',
+      })
+      .then(setChainId)
+
+    const handleChainChanged = (chainId: string) =>
+      setChainId(chainId as `0x${string}`)
+
+    porto.provider.on('chainChanged', handleChainChanged)
+    return () => {
+      porto.provider.removeListener('chainChanged', handleChainChanged)
+    }
+  }, [])
+
+  return (
+    <div>
+      <h3>wallet_switchEthereumChain</h3>
+      <div>
+        {porto.config.chains.map((chain) => (
+          <button
+            disabled={chainId === Hex.fromNumber(chain.id)}
+            key={chain.id}
+            onClick={() =>
+              porto.provider.request({
+                method: 'wallet_switchEthereumChain',
+                params: [{ chainId: Hex.fromNumber(chain.id) }],
+              })
+            }
+            type="button"
+          >
+            {chain.name}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/wagmi/src/App.tsx
+++ b/apps/wagmi/src/App.tsx
@@ -21,6 +21,7 @@ import {
   useDisconnect,
   useReadContract,
   useSendCalls,
+  useSwitchChain,
   useWaitForCallsStatus,
 } from 'wagmi'
 import { exp1Address, exp1Config } from './contracts'
@@ -50,6 +51,7 @@ export function App() {
     <>
       <Account />
       <Connect />
+      <SwitchChain />
       <UpgradeAccount />
       {isConnected && (
         <>
@@ -154,6 +156,30 @@ function Connect() {
       <pre>{connect.data ? stringify(connect.data, null, 2) : ''}</pre>
       <div>{connect.status}</div>
       <div>{connect.error?.message}</div>
+    </div>
+  )
+}
+
+function SwitchChain() {
+  const chainId = useChainId()
+  const { chains, switchChain, error } = useSwitchChain()
+
+  return (
+    <div>
+      <h2>Switch Chain</h2>
+
+      {chains.map((chain) => (
+        <button
+          disabled={chainId === chain.id}
+          key={chain.id}
+          onClick={() => switchChain({ chainId: chain.id })}
+          type="button"
+        >
+          {chain.name}
+        </button>
+      ))}
+
+      {error?.message}
     </div>
   )
 }

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -112,7 +112,6 @@ export function create(
       ),
     ),
   )
-  store.persist.rehydrate()
 
   let mode = config.mode
 

--- a/src/core/RpcSchema.ts
+++ b/src/core/RpcSchema.ts
@@ -20,6 +20,7 @@ export type Schema =
             | 'wallet_sendCalls'
             | 'wallet_prepareCalls'
             | 'wallet_sendPreparedCalls'
+            | 'wallet_switchEthereumChain'
         }
       }
     >
@@ -107,6 +108,10 @@ export type Schema =
       | {
           Request: typeof Rpc.wallet_sendCalls.Request.Encoded
           ReturnType: typeof Rpc.wallet_sendCalls.Response.Encoded
+        }
+      | {
+          Request: typeof Rpc.wallet_switchEthereumChain.Request.Encoded
+          ReturnType: undefined
         }
       | {
           Request: typeof Rpc.wallet_verifySignature.Request.Encoded

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -303,6 +303,15 @@ export type Mode = {
       internal: ActionsInternal
     }) => Promise<Hex.Hex>
 
+    switchChain?:
+      | ((parameters: {
+          /** Chain ID to switch to. */
+          chainId: number
+          /** Internal properties. */
+          internal: ActionsInternal
+        }) => Promise<void>)
+      | undefined
+
     updateAccount: (parameters: {
       /** Account to update. */
       account: Account.Account

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -896,6 +896,17 @@ export function dialog(parameters: dialog.Parameters = {}) {
         return await provider.request(request)
       },
 
+      async switchChain(parameters) {
+        const { internal } = parameters
+        const { store, request } = internal
+
+        if (request.method !== 'wallet_switchEthereumChain')
+          throw new Error('Cannot switch chain for method: ' + request.method)
+
+        const provider = getProvider(store)
+        return await provider.request(request)
+      },
+
       async updateAccount(parameters) {
         const { internal } = parameters
         const { store, request } = internal

--- a/src/core/internal/schema/request.ts
+++ b/src/core/internal/schema/request.ts
@@ -36,6 +36,7 @@ export const Request = Schema.Union(
   RpcRequest.wallet_prepareCalls.Request,
   RpcRequest.wallet_sendCalls.Request,
   RpcRequest.wallet_sendPreparedCalls.Request,
+  RpcRequest.wallet_switchEthereumChain.Request,
   RpcRequest.wallet_verifySignature.Request,
 ).annotations({
   identifier: 'Request.Request',

--- a/src/core/internal/schema/rpc.ts
+++ b/src/core/internal/schema/rpc.ts
@@ -379,6 +379,20 @@ export namespace wallet_revokePermissions {
   export const Response = undefined
 }
 
+export namespace wallet_switchEthereumChain {
+  export const Request = Schema.Struct({
+    method: Schema.Literal('wallet_switchEthereumChain'),
+    params: Schema.Tuple(
+      Schema.Struct({
+        chainId: Primitive.Hex,
+      }),
+    ),
+  }).annotations({
+    identifier: 'Rpc.wallet_switchEthereumChain.Request',
+  })
+  export type Request = typeof Request.Type
+}
+
 export namespace wallet_updateAccount {
   export const Parameters = Schema.Struct({
     address: Schema.optional(Primitive.Address),

--- a/src/core/internal/store.ts
+++ b/src/core/internal/store.ts
@@ -1,0 +1,9 @@
+import type * as Porto from '../Porto.js'
+
+export async function waitForHydration(store: Porto.Store) {
+  if (store.persist.hasHydrated()) return
+  await new Promise((resolve) => {
+    setTimeout(() => resolve(true), 32)
+    store.persist.onFinishHydration(() => resolve(true))
+  })
+}

--- a/src/remote/Porto.ts
+++ b/src/remote/Porto.ts
@@ -85,8 +85,10 @@ export function create(
     messenger,
     methodPolicies,
     mode,
-    ready() {
+    async ready() {
+      await porto._internal.store.persist.rehydrate()
       const { chainId, feeToken } = porto._internal.store.getState()
+
       if (!('ready' in messenger)) return
       return (messenger as Messenger.Bridge).ready({
         chainId,
@@ -106,7 +108,7 @@ export type Porto<
   mode: Mode.Mode
   messenger: OneOf<Messenger.Bridge | Messenger.Messenger>
   methodPolicies?: MethodPolicies.MethodPolicies | undefined
-  ready: () => void
+  ready: () => Promise<void>
   _internal: Porto_.Porto<chains>['_internal'] & {
     remoteStore: StoreApi<RemoteState>
   }

--- a/src/remote/internal/methodPolicies.ts
+++ b/src/remote/internal/methodPolicies.ts
@@ -116,4 +116,10 @@ export const methodPolicies = [
       headless: true,
     },
   },
+  {
+    method: 'wallet_switchEthereumChain',
+    modes: {
+      headless: true,
+    },
+  },
 ] as const satisfies MethodPolicies


### PR DESCRIPTION
### Summary

Added support for the `wallet_switchEthereumChain` JSON-RPC method to allow switching between different Ethereum chains.

### Details

- Added `wallet_switchEthereumChain` method to RPC schema and request handlers
- Implemented chain switching functionality in dialog and wallet actions
- Updated playground and wagmi examples to demonstrate chain switching
- Added chain change event handling and UI components
- Updated chain configurations to support multiple anvil and porto dev chains

### Areas Touched

- Dialog (`apps/dialog`)
- Playground (`apps/playground`) 
- Wagmi App (`apps/wagmi`)
- `porto` Library (`src/`)