### PR TITLE
pass through request origin

### DIFF
--- a/.changeset/brown-donuts-fail.md
+++ b/.changeset/brown-donuts-fail.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added `origin` to `onDialogRequest`.

--- a/src/remote/Events.ts
+++ b/src/remote/Events.ts
@@ -34,13 +34,14 @@ export function onDialogRequest(
       | undefined
     requireUpdatedAccount?: boolean | undefined
     request: Remote.RemoteState['requests'][number]['request'] | null
+    origin: string
   }) => void,
 ) {
   return onRequests(porto, (requests, event) => {
     const { account, request } = requests[0] ?? {}
 
     if (!request) {
-      cb({ request: null })
+      cb({ origin: event.origin, request: null })
       return
     }
 
@@ -92,6 +93,7 @@ export function onDialogRequest(
 
     cb({
       account: requireConnection ? account : undefined,
+      origin: event.origin,
       request,
       requireUpdatedAccount,
     })


### PR DESCRIPTION
I want to use the `MessageEvent.origin` instead of `document.referrer` as a more robust source of truth for the request origin/referrer.

Ideally this would be included in `onInitialized` too but wasn't sure where to put it, especially since there's some overlap in intent with `referrer`.