### PR TITLE
feat: add `token` property to `signInWithEthereum` capability

### DIFF
--- a/.changeset/few-wasps-smell.md
+++ b/.changeset/few-wasps-smell.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added `token` property to `signInWithEthereum` response capability.

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -214,17 +214,23 @@ export function dialog(parameters: dialog.Parameters = {}) {
                 storage,
               })
 
-            const signInWithEthereum_response =
-              account.capabilities?.signInWithEthereum
-            if (authUrl && signInWithEthereum_response) {
-              const { message, signature } = signInWithEthereum_response
-              await Siwe.authenticate({
+            const signInWithEthereum_response = await (async () => {
+              if (!authUrl) return
+              if (!account.capabilities?.signInWithEthereum) return
+              const { message, signature } =
+                account.capabilities.signInWithEthereum
+              const { token } = await Siwe.authenticate({
                 address: account.address,
                 authUrl,
                 message,
                 signature,
               })
-            }
+              return {
+                message,
+                signature,
+                token,
+              }
+            })()
 
             return {
               ...Account.from({
@@ -510,17 +516,23 @@ export function dialog(parameters: dialog.Parameters = {}) {
                 })
                 .filter(Boolean) as readonly Key.Key[]
 
-              const signInWithEthereum_response =
-                account.capabilities?.signInWithEthereum
-              if (authUrl && signInWithEthereum_response) {
-                const { message, signature } = signInWithEthereum_response
-                await Siwe.authenticate({
+              const signInWithEthereum_response = await (async () => {
+                if (!authUrl) return
+                if (!account.capabilities?.signInWithEthereum) return
+                const { message, signature } =
+                  account.capabilities.signInWithEthereum
+                const { token } = await Siwe.authenticate({
                   address: account.address,
                   authUrl,
                   message,
                   signature,
                 })
-              }
+                return {
+                  message,
+                  signature,
+                  token,
+                }
+              })()
 
               return {
                 ...Account.from({

--- a/src/core/internal/schema/capabilities.ts
+++ b/src/core/internal/schema/capabilities.ts
@@ -73,6 +73,7 @@ export namespace signInWithEthereum {
   export const Response = Schema.Struct({
     message: Schema.String,
     signature: Primitive.Hex,
+    token: Schema.optional(Schema.String),
   })
   export type Response = typeof Response.Type
 }

--- a/src/core/internal/siwe.ts
+++ b/src/core/internal/siwe.ts
@@ -14,7 +14,9 @@ export type AuthUrl = {
   verify: string
 }
 
-export async function authenticate(parameters: authenticate.Parameters) {
+export async function authenticate(
+  parameters: authenticate.Parameters,
+): Promise<authenticate.ReturnType> {
   const { address, authUrl, message, signature } = parameters
 
   const { chainId } = Siwe.parseMessage(message)
@@ -32,7 +34,7 @@ export async function authenticate(parameters: authenticate.Parameters) {
       'Content-Type': 'application/json',
     },
     method: 'POST',
-  })
+  }).then((res) => res.json())
 }
 
 export declare namespace authenticate {
@@ -41,6 +43,10 @@ export declare namespace authenticate {
     authUrl: AuthUrl
     message: string
     signature: Hex.Hex
+  }
+
+  type ReturnType = {
+    token?: string | undefined
   }
 }
 


### PR DESCRIPTION
For cases where folks can't use cookies.