### PR TITLE
feat(config): use pnpm runtime for node

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-auto-install-peers=false
-link-workspace-packages=false
-provenance=false
-enable-pre-post-scripts=true
-strict-peer-dependencies=false
-node-options='--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,6 +51,10 @@
     "**/routeTree.gen.ts": true
   },
   "javascript.preferences.autoImportFileExcludePatterns": ["**/index.js"],
+  "markdownlint.config": {
+    "first-line-heading": false,
+    "no-inline-html": false
+  },
   "search.exclude": {
     "**/_/**": true,
     "**/dist/**": true,

--- a/package.json
+++ b/package.json
@@ -70,9 +70,10 @@
     "vitest": "catalog:",
     "wagmi": "catalog:"
   },
-  "packageManager": "pnpm@10.12.2",
+  "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">=22.5"
+    "node": ">=22.5",
+    "pnpm": ">=10.14.0"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm check"
@@ -126,5 +127,24 @@
       "@wagmi/core": "patches/@wagmi__core.patch",
       "@vitest/browser": "patches/@vitest__browser.patch"
     }
+  },
+  "publishConfig": {
+    "provenance": false
+  },
+  "devEngines": {
+    "runtime": [
+      {
+        "name": "node",
+        "version": "^22.5",
+        "onFail": "download"
+      }
+    ],
+    "packageManager": [
+      {
+        "name": "pnpm",
+        "version": "^10.14",
+        "onFail": "download"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
   },
   "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">=22.5",
-    "pnpm": ">=10.14.0"
+    "node": ">=22.5"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm check"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       markdownlint-cli2:
         specifier: ^0.18.1
         version: 0.18.1
+      node:
+        specifier: runtime:^22.5
+        version: runtime:22.18.0
       ox:
         specifier: 'catalog:'
         version: 0.8.4(typescript@5.8.3)(zod@3.25.28)
@@ -7627,6 +7630,115 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node@runtime:22.18.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-e7da8wj8n2PlaJaODvDhYAuxBavi0q+ZIXrHLpok/9A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-LBKRPLpnr3fe2KOZ3z/ZHC5/hijHB52kC7n/M78A38A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-nIqh5f9XgLOMwRNOImPYTi9DCOuEwCUV468zk2ygLNw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-1BXu6pCi/bYMZt04ayWKy/xNH6RyCo313qc2n7283e4=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-V4MJFFgdw2QOjZU3i3bGkQhg9CUxlZ5OiOtEXgzZgrA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-OPlly6pecw29Oxr+iVz9uG2pY3FHSCfQXYR9M4oMnJc=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-81eLDnzfJHBF9u63Zv69dJQpVDUhYRAstgQKTUw7TDw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-oucDcl2Gg76Gu12pZ7+CcvRRi9rxDyE4nissnq6ujIo=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-Ajr7PSXEx9EMtuuKZIZcNHtW1LB+ZpBgbQIRMKkZImM=
+            prefix: node-v22.18.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-yV2KfhyZ5mnMCMnxF24GjB9QhHw3kI/LjDW2JII2ZRE=
+            prefix: node-v22.18.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-8uVGNF9ynY6CyCoIjmFudt8UMwxT08/su6tR94PwjPQ=
+            prefix: node-v22.18.0-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+    version: 22.18.0
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -17865,6 +17977,8 @@ snapshots:
       which: 2.0.2
 
   node-releases@2.0.19: {}
+
+  node@runtime:22.18.0: {}
 
   normalize-path@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,12 @@ packages:
   - "docker/*"
   - "examples/*"
   - "src"
-  - "test/e2e"
+
+autoInstallPeers: false
+enablePrePostScripts: true
+linkWorkspacePackages: false
+strictPeerDependencies: false
+nodeOptions: "--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning"
 
 catalog:
   "@ariakit/react": "^0.4.17"


### PR DESCRIPTION
- update `pnpm` to 10.14,
- leverage `package.json#runtimes`. This relieves the developer from the burden of having to install / update their global Node.js version. If the specified Node.js version is not available in the developer's machine, it installs the version scoped to the project and uses that version. [More info here](https://pnpm.io/package_json#devenginesruntime),
- reduce config files by removing `.npmrc` and using the same [configuration in `pnpm-workspace.yaml`](https://pnpm.io/settings).