### PR TITLE
feat: `getAssets` tweaks

### DIFF
--- a/apps/wagmi/src/App.tsx
+++ b/apps/wagmi/src/App.tsx
@@ -407,13 +407,7 @@ function AddFunds() {
 }
 
 function Assets() {
-  const { address } = useAccount()
-  const { data, ...assets } = Hooks.useAssets({
-    account: address!,
-    query: {
-      enabled: !!address,
-    },
-  })
+  const { data, ...assets } = Hooks.useAssets()
 
   return (
     <div>

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -98,7 +98,7 @@ export type Mode = {
         /** Internal properties. */
         internal: ActionsInternal
       },
-    ) => Promise<typeof RpcSchema.wallet_getAssets.Response.Encoded>
+    ) => Promise<RpcSchema.wallet_getAssets.Response>
 
     getCallsStatus: (parameters: {
       /** ID of the calls to get the status of. */

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -303,7 +303,9 @@ export function dialog(parameters: dialog.Parameters = {}) {
 
         const provider = getProvider(store)
         const result = await provider.request(request)
-        return result
+        return Schema.decodeSync(RpcSchema_porto.wallet_getAssets.Response)(
+          result,
+        )
       },
 
       async getCallsStatus(parameters) {

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -3,6 +3,7 @@ import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
 import * as ox_Provider from 'ox/Provider'
 import * as RpcResponse from 'ox/RpcResponse'
+import type { ValueOf } from 'viem'
 import * as Account from '../../viem/Account.js'
 import * as Actions from '../../viem/internal/serverActions.js'
 import type * as Key from '../../viem/Key.js'
@@ -891,7 +892,15 @@ export function from<
             },
           })
 
-          return response satisfies typeof Rpc.wallet_getAssets.Response.Encoded
+          const value = Object.entries(response).reduce(
+            (acc, [key, value]) => {
+              acc[Hex.fromNumber(Number(key))] = value
+              return acc
+            },
+            {} as Record<string, ValueOf<typeof response>>,
+          )
+
+          return Schema.encodeSync(Rpc.wallet_getAssets.Response)(value)
         }
 
         case 'wallet_getCallsStatus': {

--- a/src/core/internal/rpcServer/schema/rpc.ts
+++ b/src/core/internal/rpcServer/schema/rpc.ts
@@ -229,7 +229,7 @@ export namespace wallet_getAssets {
       }),
     ),
     assetTypeFilter: Schema.optional(Schema.Array(AssetType)),
-    chainFilter: Schema.optional(Schema.Array(Primitive.Hex)),
+    chainFilter: Schema.optional(Schema.Array(Primitive.Number)),
   }).annotations({
     identifier: 'Rpc.wallet_getAssets.Parameters',
   })
@@ -246,7 +246,7 @@ export namespace wallet_getAssets {
 
   /** Response for `wallet_getAssets`. */
   export const Response = Schema.Record({
-    key: Primitive.Hex,
+    key: Schema.String,
     value: Schema.Array(
       Schema.Struct({
         address: Schema.Union(
@@ -254,7 +254,7 @@ export namespace wallet_getAssets {
           Schema.Literal('native'),
           Schema.Null,
         ),
-        balance: Primitive.Hex,
+        balance: Primitive.BigInt,
         metadata: Schema.NullOr(
           Schema.Struct({
             decimals: Schema.Number,

--- a/src/core/internal/schema/rpc.ts
+++ b/src/core/internal/schema/rpc.ts
@@ -572,65 +572,15 @@ export namespace wallet_disconnect {
 
 export namespace wallet_getAssets {
   /** Parameters  */
-  const AssetType = Schema.Union(
-    Schema.Literal('native'),
-    Schema.Literal('erc20'),
-    Schema.Literal('erc721'),
-    Schema.String,
-  )
-  export const Parameters = Schema.Struct({
-    account: Primitive.Address,
-    assetFilter: Schema.optional(
-      Schema.Record({
-        key: Primitive.Hex,
-        value: Schema.Array(
-          Schema.Struct({
-            address: Schema.Union(Primitive.Address, Schema.Literal('native')),
-            type: AssetType,
-          }),
-        ),
-      }),
-    ),
-    assetTypeFilter: Schema.optional(Schema.Array(AssetType)),
-    chainFilter: Schema.optional(Schema.Array(Primitive.Hex)),
-  }).annotations({
-    identifier: 'Rpc.wallet_getAssets.Parameters',
-  })
+  export const Parameters = Rpc_server.wallet_getAssets.Parameters
   export type Parameters = typeof Parameters.Type
 
   /** Request for `wallet_getAssets`. */
-  export const Request = Schema.Struct({
-    method: Schema.Literal('wallet_getAssets'),
-    params: Schema.Tuple(Parameters),
-  }).annotations({
-    identifier: 'Rpc.wallet_getAssets.Request',
-  })
+  export const Request = Rpc_server.wallet_getAssets.Request
   export type Request = typeof Request.Type
 
   /** Response for `wallet_getAssets`. */
-  export const Response = Schema.Record({
-    key: Primitive.Hex,
-    value: Schema.Array(
-      Schema.Struct({
-        address: Schema.Union(
-          Primitive.Address,
-          Schema.Literal('native'),
-          Schema.Null,
-        ),
-        balance: Primitive.Hex,
-        metadata: Schema.NullOr(
-          Schema.Struct({
-            decimals: Schema.Number,
-            name: Schema.String,
-            symbol: Schema.String,
-          }),
-        ),
-        type: Schema.String,
-      }),
-    ),
-  }).annotations({
-    identifier: 'Rpc.wallet_getAssets.Response',
-  })
+  export const Response = Rpc_server.wallet_getAssets.Response
   export type Response = typeof Response.Type
 }
 

--- a/src/viem/WalletActions.ts
+++ b/src/viem/WalletActions.ts
@@ -5,6 +5,7 @@
  * API is solidified & stable.
  */
 
+import * as Hex from 'ox/Hex'
 import {
   type Call,
   type Calls,
@@ -14,6 +15,7 @@ import {
   type Narrow,
   type PrivateKeyAccount,
   type Transport,
+  type ValueOf,
   type WalletActions as viem_WalletActions,
 } from 'viem'
 import {
@@ -31,7 +33,8 @@ import {
 } from 'viem/actions'
 import * as Schema from '../core/internal/schema/schema.js'
 import * as RpcSchema from '../core/RpcSchema.js'
-import type * as Account from './Account.js'
+import * as Account from './Account.js'
+import type { GetAccountParameter } from './internal/utils.js'
 import type * as RpcSchema_viem from './RpcSchema.js'
 
 const supportedWalletActions = [
@@ -73,10 +76,20 @@ export declare namespace addFunds {
   type ReturnType = RpcSchema.wallet_addFunds.Response
 }
 
-export async function getAssets(
-  client: Client,
-  parameters: getAssets.Parameters,
+export async function getAssets<
+  chain extends Chain | undefined,
+  account extends Account.Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
+  ...parameters: account extends undefined
+    ? [getAssets.Parameters<account>]
+    : [getAssets.Parameters<account>] | []
 ): Promise<getAssets.ReturnType> {
+  const { account = client.account, ...rest } = parameters[0] ?? {}
+
+  const account_ = account ? Account.from(account) : undefined
+  if (!account_) throw new Error('account is required')
+
   const method = 'wallet_getAssets' as const
   type Method = typeof method
   const response = await client.request<
@@ -84,15 +97,29 @@ export async function getAssets(
   >({
     method,
     params: [
-      Schema.encodeSync(RpcSchema.wallet_getAssets.Parameters)(parameters),
+      Schema.encodeSync(RpcSchema.wallet_getAssets.Parameters)({
+        ...rest,
+        account: account_.address,
+      }),
     ],
   })
 
-  return Schema.decodeSync(RpcSchema.wallet_getAssets.Response)(response)
+  const value = Schema.decodeSync(RpcSchema.wallet_getAssets.Response)(response)
+  const decoded = Object.entries(value).reduce(
+    (acc, [key, value]) => {
+      acc[Hex.toNumber(key as `0x${string}`)] = value
+      return acc
+    },
+    {} as Record<number, ValueOf<typeof value>>,
+  )
+
+  return decoded
 }
 
 export declare namespace getAssets {
-  type Parameters = RpcSchema.wallet_getAssets.Parameters
+  type Parameters<account extends Account.Account | undefined = undefined> =
+    Omit<RpcSchema.wallet_getAssets.Parameters, 'account'> &
+      GetAccountParameter<account>
 
   type ReturnType = RpcSchema.wallet_getAssets.Response
 }

--- a/src/viem/internal/serverActions.test.ts
+++ b/src/viem/internal/serverActions.test.ts
@@ -45,9 +45,8 @@ describe('getAssets', () => {
     expect(result).toBeDefined()
     expect(Object.keys(result).length).toBeGreaterThanOrEqual(1)
 
-    const chainId = Hex.fromNumber(client.chain.id)
-    expect(result[chainId]).toBeDefined()
-    expect(Array.isArray(result[chainId])).toBe(true)
+    expect(result[client.chain.id]).toBeDefined()
+    expect(Array.isArray(result[client.chain.id])).toBe(true)
   })
 
   test('behavior: with native balance', async () => {
@@ -65,8 +64,7 @@ describe('getAssets', () => {
       account: account.address,
     })
 
-    const chainId = Hex.fromNumber(client.chain.id)
-    const chainAssets = result[chainId]!
+    const chainAssets = result[client.chain.id]!
 
     const nativeAsset = chainAssets.find((asset) => BigInt(asset.balance) > 0n)
     expect(nativeAsset).toBeDefined()
@@ -97,8 +95,7 @@ describe('getAssets', () => {
       account: account.address,
     })
 
-    const chainId = Hex.fromNumber(client.chain.id)
-    const chainAssets = result[chainId]!
+    const chainAssets = result[client.chain.id]!
 
     // Find ERC20 asset
     const erc20Asset = chainAssets.find(
@@ -145,11 +142,11 @@ describe('getAssets', () => {
       },
     })
 
-    expect(result[chainId]).toBeDefined()
-    expect(Array.isArray(result[chainId])).toBe(true)
+    expect(result[client.chain.id]).toBeDefined()
+    expect(Array.isArray(result[client.chain.id])).toBe(true)
 
     // Should only return erc20 asset
-    const chainAssets = result[chainId]!
+    const chainAssets = result[client.chain.id]!
     expect(chainAssets.every((asset) => asset.type === 'erc20')).toBe(true)
   })
 
@@ -183,8 +180,7 @@ describe('getAssets', () => {
       assetTypeFilter: ['erc20'],
     })
 
-    const chainId = Hex.fromNumber(client.chain.id)
-    const chainAssets = result[chainId]!
+    const chainAssets = result[client.chain.id]!
 
     expect(chainAssets.every((asset) => asset.type === 'erc20')).toBe(true)
     expect(chainAssets.find((asset) => asset.type === 'native')).toBeUndefined()
@@ -196,15 +192,13 @@ describe('getAssets', () => {
       keys: [key],
     })
 
-    const chainId = Hex.fromNumber(client.chain.id)
-
     const result = await getAssets(client, {
       account: account.address,
-      chainFilter: [chainId],
+      chainFilter: [client.chain.id],
     })
 
-    expect(Object.keys(result)).toEqual([chainId])
-    expect(result[chainId]).toBeDefined()
+    expect(Object.keys(result)).toEqual(['0', client.chain.id.toString()])
+    expect(result[client.chain.id]).toBeDefined()
   })
 
   test('behavior: multiple chains; one unsupported', async () => {
@@ -213,13 +207,10 @@ describe('getAssets', () => {
       keys: [key],
     })
 
-    const chainId = Hex.fromNumber(client.chain.id)
-    const otherChainId = Hex.fromNumber(999999) // Non-existent chain
-
     await expect(
       getAssets(client, {
         account: account.address,
-        chainFilter: [chainId, otherChainId],
+        chainFilter: [client.chain.id, 999999],
       }),
     ).rejects.toThrow('unsupported chain 999999')
   })

--- a/src/wagmi/internal/core.ts
+++ b/src/wagmi/internal/core.ts
@@ -19,6 +19,7 @@ import {
   custom,
   type EIP1193Provider,
 } from 'viem'
+import type { PartialBy } from '../../core/internal/types.js'
 import type * as RpcSchema from '../../core/RpcSchema.js'
 import * as AccountActions from '../../viem/AccountActions.js'
 import * as WalletActions from '../../viem/WalletActions.js'
@@ -206,23 +207,21 @@ export declare namespace getAdmins {
 
 export async function getAssets<config extends Config>(
   config: config,
-  parameters: getAssets.Parameters<config>,
+  parameters: getAssets.Parameters = {},
 ): Promise<getAssets.ReturnType> {
-  const { account, chainId, connector } = parameters
+  const { account, connector } = parameters
 
   const client = await getConnectorClient(config, {
     account,
-    chainId,
     connector,
   })
 
-  return WalletActions.getAssets(client, parameters)
+  return WalletActions.getAssets(client as any, parameters)
 }
 
 export declare namespace getAssets {
-  type Parameters<config extends Config = Config> = ChainIdParameter<config> &
-    ConnectorParameter &
-    WalletActions.getAssets.Parameters
+  type Parameters = ConnectorParameter &
+    PartialBy<WalletActions.getAssets.Parameters, 'account'>
 
   type ReturnType = WalletActions.getAssets.ReturnType
 

--- a/src/wagmi/internal/query.ts
+++ b/src/wagmi/internal/query.ts
@@ -36,7 +36,7 @@ export declare namespace getPermissionsQueryKey {
 }
 
 export function getAssetsQueryKey<config extends Config>(
-  options: getAssets.Parameters<config>,
+  options: getAssets.Parameters,
 ) {
   const { connector, ...parameters } = options
   return [

--- a/test/src/config.ts
+++ b/test/src/config.ts
@@ -1,4 +1,4 @@
-import { type Chains, Mode, Porto, Storage } from 'porto'
+import { type Account, type Chains, Mode, Porto, Storage } from 'porto'
 import { http } from 'viem'
 import * as ServerClient from '../../src/viem/ServerClient.js'
 import * as WalletClient from '../../src/viem/WalletClient.js'
@@ -72,8 +72,13 @@ export function getServerClient<
 
 export function getWalletClient<
   const chains extends readonly [Chains.Chain, ...Chains.Chain[]],
->(porto: Porto.Porto<chains>) {
-  return WalletClient.fromPorto(porto)
+  chain extends Chains.Chain | undefined = undefined,
+  account extends Account.Account | undefined = undefined,
+>(
+  porto: Porto.Porto<chains>,
+  config: WalletClient.fromPorto.Config<chain, account> = {},
+) {
+  return WalletClient.fromPorto(porto, config)
 }
 
 export function getContracts<


### PR DESCRIPTION
Small tweaks to `getAssets`:

- Made `account` optional, and default to the connected account
- Added aggregated "view" of balances with a `0` chain id key
- 
- Tweaked balances to decode as `bigint` instead of `Hex`
- Tweaked `chainFilter` to accept `number` instead of `Hex`
- Decoded chain IDs in the response