### PR TITLE
fix: unguarded access to location.hostname

### DIFF
--- a/.changeset/rich-buckets-attack.md
+++ b/.changeset/rich-buckets-attack.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Fixed access to `location.hostname` for non-browser environments.

--- a/src/core/internal/modes/contract.ts
+++ b/src/core/internal/modes/contract.ts
@@ -36,7 +36,7 @@ export function contract(parameters: contract.Parameters = {}) {
     if (parameters.keystoreHost === 'self') return undefined
     if (
       typeof window !== 'undefined' &&
-      window.location.hostname === 'localhost'
+      window.location?.hostname === 'localhost'
     )
       return undefined
     return parameters.keystoreHost

--- a/src/core/internal/modes/rpcServer.ts
+++ b/src/core/internal/modes/rpcServer.ts
@@ -43,7 +43,7 @@ export function rpcServer(parameters: rpcServer.Parameters = {}) {
     if (config.keystoreHost === 'self') return undefined
     if (
       typeof window !== 'undefined' &&
-      window.location.hostname === 'localhost'
+      window.location?.hostname === 'localhost'
     )
       return undefined
     return config.keystoreHost


### PR DESCRIPTION
When running porto from a RN environment (Hermes) the `location` object on global `window` is not defined. This causes a crash at runtime due to unguarded access to window.location.hostname in `src/core/internal/modes/contract.ts` and `src/core/internal/modes/rpcServer.ts` 

This PR replaces:
  `window.location.hostname`
with:
  `window.location?.hostname` 

This uses the optional chaining  to safely access `hostname` only when `location` is defined, preventing runtime errors in non-browser environments.

Tested in an Expo + Hermes RN app