### PR TITLE
fix: spacing in dialog mode

### DIFF
--- a/apps/dialog/src/routes/-components/Layout.tsx
+++ b/apps/dialog/src/routes/-components/Layout.tsx
@@ -11,7 +11,13 @@ export function Layout(props: Layout.Props) {
   const { children, loading = false, loadingTitle } = props
   return (
     <Screen>
-      {loading ? <IndeterminateLoader title={loadingTitle ?? ''} /> : children}
+      {loading ? (
+        <div className="p-3">
+          <IndeterminateLoader title={loadingTitle ?? ''} />
+        </div>
+      ) : (
+        children
+      )}
     </Screen>
   )
 }

--- a/apps/ui/src/Frame/Frame.tsx
+++ b/apps/ui/src/Frame/Frame.tsx
@@ -117,7 +117,6 @@ export function Frame({
   return (
     <FrameContext.Provider value={contextValue}>
       <div
-        data-dialog={mode === 'dialog' ? true : undefined}
         className={cx(
           css({
             containerType: 'inline-size',
@@ -133,6 +132,7 @@ export function Frame({
                 width: '100%',
               }),
         )}
+        data-dialog={mode === 'dialog' ? true : undefined}
         ref={frameRef}
         style={{ colorScheme }}
       >

--- a/apps/ui/src/Frame/Frame.tsx
+++ b/apps/ui/src/Frame/Frame.tsx
@@ -117,6 +117,7 @@ export function Frame({
   return (
     <FrameContext.Provider value={contextValue}>
       <div
+        data-dialog={mode === 'dialog' ? true : undefined}
         className={cx(
           css({
             containerType: 'inline-size',

--- a/apps/ui/src/Screen/Screen.tsx
+++ b/apps/ui/src/Screen/Screen.tsx
@@ -51,7 +51,6 @@ export function Screen({ children, layout }: ScreenProps) {
             position: 'relative',
             width: '100%',
           }),
-          layout === 'compact' && css({ padding: 12 }),
         )}
       >
         <div
@@ -65,9 +64,9 @@ export function Screen({ children, layout }: ScreenProps) {
               css({
                 '@container (min-width: 480px)': {
                   flex: '0 0 auto',
+                  padding: 12,
                 },
                 flex: '1 1 auto',
-                padding: 24,
               }),
           )}
         >


### PR DESCRIPTION
- Add data-dialog to the Frame component so that the app buttons styles
  behave as expected (small radiuses in dialog mode).
- Remove spacing on the Screen component in dialog mode, and let the app
  components handle this for now.
- Add padding around IndeterminateLoader.
