### PR TITLE
feat: screen bottom action

### DIFF
--- a/apps/dialog/src/routes/-components/SignUp.tsx
+++ b/apps/dialog/src/routes/-components/SignUp.tsx
@@ -1,9 +1,8 @@
-import { Button, LightDarkImage } from '@porto/ui'
+import { Screen, ButtonArea, Button, LightDarkImage } from '@porto/ui'
 import { useState } from 'react'
 import * as Dialog from '~/lib/Dialog'
 import { Layout } from '~/routes/-components/Layout'
 import { Permissions } from '~/routes/-components/Permissions'
-import ChevronRight from '~icons/lucide/chevron-right'
 import LucideLogIn from '~icons/lucide/log-in'
 import Question from '~icons/mingcute/question-line'
 
@@ -17,7 +16,17 @@ export function SignUp(props: SignUp.Props) {
   if (showLearn) return <SignUp.Learn onDone={() => setShowLearn(false)} />
 
   return (
-    <Layout>
+    <Screen
+      bottomAction={{
+        onClick: () => setShowLearn(true),
+        children: (
+          <>
+            <Question className="mt-px size-5 text-th_base-secondary" />
+            <span>Learn about passkeys</span>
+          </>
+        ),
+      }}
+    >
       <Layout.Header className="flex-grow">
         <Layout.Header.Default
           content={
@@ -65,22 +74,8 @@ export function SignUp(props: SignUp.Props) {
             Sign up
           </Button>
         </Layout.Footer.Actions>
-
-        <button
-          className="flex w-full cursor-pointer items-center justify-between border-th_base border-t p-3 pb-0"
-          onClick={() => setShowLearn(true)}
-          type="button"
-        >
-          <div className="flex items-center gap-1.5">
-            <Question className="mt-px size-5 text-th_base-secondary" />
-            <span className="font-medium text-[14px]">
-              Learn about passkeys
-            </span>
-          </div>
-          <ChevronRight className="size-5 text-th_base opacity-50" />
-        </button>
       </Layout.Footer>
-    </Layout>
+    </Screen>
   )
 }
 
@@ -95,7 +90,7 @@ export namespace SignUp {
 
   export function Learn({ onDone }: { onDone: () => void }) {
     return (
-      <Layout>
+      <Screen>
         <Layout.Header className="flex-grow space-y-2">
           <LightDarkImage
             alt="Diagram illustrating how passkeys work"
@@ -130,7 +125,7 @@ export namespace SignUp {
             </Button>
           </Layout.Footer.Actions>
         </Layout.Footer>
-      </Layout>
+      </Screen>
     )
   }
 }

--- a/apps/dialog/src/routes/-components/SignUp.tsx
+++ b/apps/dialog/src/routes/-components/SignUp.tsx
@@ -1,4 +1,4 @@
-import { Screen, ButtonArea, Button, LightDarkImage } from '@porto/ui'
+import { Button, LightDarkImage, Screen } from '@porto/ui'
 import { useState } from 'react'
 import * as Dialog from '~/lib/Dialog'
 import { Layout } from '~/routes/-components/Layout'
@@ -18,13 +18,13 @@ export function SignUp(props: SignUp.Props) {
   return (
     <Screen
       bottomAction={{
-        onClick: () => setShowLearn(true),
         children: (
           <>
             <Question className="mt-px size-5 text-th_base-secondary" />
             <span>Learn about passkeys</span>
           </>
         ),
+        onClick: () => setShowLearn(true),
       }}
     >
       <Layout.Header className="flex-grow">

--- a/apps/ui-playground/src/constants.ts
+++ b/apps/ui-playground/src/constants.ts
@@ -4,7 +4,14 @@ export const sections = [
     title: 'Theme',
   },
   {
-    screens: ['Button', 'Input', 'Separator', 'ThemeSwitch', 'Spinner'],
+    screens: [
+      'Button',
+      'ButtonArea',
+      'Input',
+      'Separator',
+      'ThemeSwitch',
+      'Spinner',
+    ],
     title: 'Base',
   },
   {

--- a/apps/ui-playground/src/routeTree.gen.ts
+++ b/apps/ui-playground/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ScreenImport } from './routes/Screen'
 import { Route as InputImport } from './routes/Input'
 import { Route as FrameImport } from './routes/Frame'
 import { Route as ColorsImport } from './routes/Colors'
+import { Route as ButtonAreaImport } from './routes/ButtonArea'
 import { Route as ButtonImport } from './routes/Button'
 import { Route as IndexImport } from './routes/index'
 
@@ -72,6 +73,12 @@ const ColorsRoute = ColorsImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const ButtonAreaRoute = ButtonAreaImport.update({
+  id: '/ButtonArea',
+  path: '/ButtonArea',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const ButtonRoute = ButtonImport.update({
   id: '/Button',
   path: '/Button',
@@ -100,6 +107,13 @@ declare module '@tanstack/react-router' {
       path: '/Button'
       fullPath: '/Button'
       preLoaderRoute: typeof ButtonImport
+      parentRoute: typeof rootRoute
+    }
+    '/ButtonArea': {
+      id: '/ButtonArea'
+      path: '/ButtonArea'
+      fullPath: '/ButtonArea'
+      preLoaderRoute: typeof ButtonAreaImport
       parentRoute: typeof rootRoute
     }
     '/Colors': {
@@ -166,6 +180,7 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/Button': typeof ButtonRoute
+  '/ButtonArea': typeof ButtonAreaRoute
   '/Colors': typeof ColorsRoute
   '/Frame': typeof FrameRoute
   '/Input': typeof InputRoute
@@ -179,6 +194,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/Button': typeof ButtonRoute
+  '/ButtonArea': typeof ButtonAreaRoute
   '/Colors': typeof ColorsRoute
   '/Frame': typeof FrameRoute
   '/Input': typeof InputRoute
@@ -193,6 +209,7 @@ export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/Button': typeof ButtonRoute
+  '/ButtonArea': typeof ButtonAreaRoute
   '/Colors': typeof ColorsRoute
   '/Frame': typeof FrameRoute
   '/Input': typeof InputRoute
@@ -208,6 +225,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/Button'
+    | '/ButtonArea'
     | '/Colors'
     | '/Frame'
     | '/Input'
@@ -220,6 +238,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/Button'
+    | '/ButtonArea'
     | '/Colors'
     | '/Frame'
     | '/Input'
@@ -232,6 +251,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/Button'
+    | '/ButtonArea'
     | '/Colors'
     | '/Frame'
     | '/Input'
@@ -246,6 +266,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ButtonRoute: typeof ButtonRoute
+  ButtonAreaRoute: typeof ButtonAreaRoute
   ColorsRoute: typeof ColorsRoute
   FrameRoute: typeof FrameRoute
   InputRoute: typeof InputRoute
@@ -259,6 +280,7 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ButtonRoute: ButtonRoute,
+  ButtonAreaRoute: ButtonAreaRoute,
   ColorsRoute: ColorsRoute,
   FrameRoute: FrameRoute,
   InputRoute: InputRoute,
@@ -281,6 +303,7 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/Button",
+        "/ButtonArea",
         "/Colors",
         "/Frame",
         "/Input",
@@ -296,6 +319,9 @@ export const routeTree = rootRoute
     },
     "/Button": {
       "filePath": "Button.tsx"
+    },
+    "/ButtonArea": {
+      "filePath": "ButtonArea.tsx"
     },
     "/Colors": {
       "filePath": "Colors.tsx"

--- a/apps/ui-playground/src/routes/ButtonArea.tsx
+++ b/apps/ui-playground/src/routes/ButtonArea.tsx
@@ -1,0 +1,38 @@
+import { ButtonArea } from '@porto/ui'
+import { createFileRoute } from '@tanstack/react-router'
+import { ComponentScreen } from '~/components/ComponentScreen/ComponentScreen'
+
+export const Route = createFileRoute('/ButtonArea')({
+  component: ButtonAreaScreen,
+})
+
+function ButtonAreaScreen() {
+  return (
+    <ComponentScreen title="ButtonArea">
+      <ComponentScreen.Section title="Base">
+        <div className="flex flex-wrap items-center gap-4">
+          <ButtonArea
+            className="w-48 h-40 bg-th_secondary text-th_secondary"
+            title="Button Area"
+          />
+        </div>
+      </ComponentScreen.Section>
+
+      <ComponentScreen.Section title="Styling">
+        <ButtonArea className="bg-th_primary text-th_primary h-40 rounded-t-th_large w-full p-4">
+          bg-th_primary text-th_primary h-40
+        </ButtonArea>
+      </ComponentScreen.Section>
+
+      <ComponentScreen.Section title="Disabled">
+        <ButtonArea
+          className="w-36 h-40 bg-th_disabled text-th_disabled p-4"
+          disabled
+        >
+          disabled
+        </ButtonArea>
+      </ComponentScreen.Section>
+    </ComponentScreen>
+  )
+}
+

--- a/apps/ui-playground/src/routes/ButtonArea.tsx
+++ b/apps/ui-playground/src/routes/ButtonArea.tsx
@@ -12,21 +12,21 @@ function ButtonAreaScreen() {
       <ComponentScreen.Section title="Base">
         <div className="flex flex-wrap items-center gap-4">
           <ButtonArea
-            className="w-48 h-40 bg-th_secondary text-th_secondary"
+            className="h-40 w-48 bg-th_secondary text-th_secondary"
             title="Button Area"
           />
         </div>
       </ComponentScreen.Section>
 
       <ComponentScreen.Section title="Styling">
-        <ButtonArea className="bg-th_primary text-th_primary h-40 rounded-t-th_large w-full p-4">
+        <ButtonArea className="h-40 w-full rounded-t-th_large bg-th_primary p-4 text-th_primary">
           bg-th_primary text-th_primary h-40
         </ButtonArea>
       </ComponentScreen.Section>
 
       <ComponentScreen.Section title="Disabled">
         <ButtonArea
-          className="w-36 h-40 bg-th_disabled text-th_disabled p-4"
+          className="h-40 w-36 bg-th_disabled p-4 text-th_disabled"
           disabled
         >
           disabled
@@ -35,4 +35,3 @@ function ButtonAreaScreen() {
     </ComponentScreen>
   )
 }
-

--- a/apps/ui/src/ButtonArea/ButtonArea.tsx
+++ b/apps/ui/src/ButtonArea/ButtonArea.tsx
@@ -20,10 +20,10 @@ export function ButtonArea({
           _focusVisible: {
             outline: '2px solid var(--color-th_focus)',
           },
-          outlineOffset: 2,
           cursor: 'pointer!',
           display: 'inline-flex',
           flex: '0 0 auto',
+          outlineOffset: 2,
         }),
         className,
       )}

--- a/apps/ui/src/ButtonArea/ButtonArea.tsx
+++ b/apps/ui/src/ButtonArea/ButtonArea.tsx
@@ -1,0 +1,40 @@
+import type { ButtonHTMLAttributes } from 'react'
+import { css, cx } from '../../styled-system/css'
+
+export function ButtonArea({
+  children,
+  className,
+  type = 'button',
+  ...props
+}: ButtonArea.Props) {
+  return (
+    <button
+      className={cx(
+        css({
+          _active: {
+            transform: 'translateY(1px)',
+          },
+          _disabled: {
+            pointerEvents: 'none',
+          },
+          _focusVisible: {
+            outline: '2px solid var(--color-th_focus)',
+          },
+          outlineOffset: 2,
+          cursor: 'pointer!',
+          display: 'inline-flex',
+          flex: '0 0 auto',
+        }),
+        className,
+      )}
+      type={type}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+export namespace ButtonArea {
+  export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {}
+}

--- a/apps/ui/src/Screen/Screen.tsx
+++ b/apps/ui/src/Screen/Screen.tsx
@@ -1,9 +1,9 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 import { useId } from 'react'
-import { css, cx } from '../../styled-system/css'
-import { Frame } from '../Frame/Frame.js'
-import { ButtonArea } from '../ButtonArea/ButtonArea.js'
 import ChevronRight from '~icons/lucide/chevron-right'
+import { css, cx } from '../../styled-system/css'
+import { ButtonArea } from '../ButtonArea/ButtonArea.js'
+import { Frame } from '../Frame/Frame.js'
 
 export function Screen({ children, layout, bottomAction }: Screen.Props) {
   const frame = Frame.useFrame()
@@ -183,9 +183,9 @@ function ScreenBottomAction({
     <div
       className={cx(
         css({
+          borderTop: '1px solid var(--border-color-th_base)',
           display: 'flex',
           width: '100%',
-          borderTop: '1px solid var(--border-color-th_base)',
         }),
         layout === 'full' &&
           css({
@@ -198,32 +198,32 @@ function ScreenBottomAction({
       <ButtonArea
         className={cx(
           css({
-            display: 'flex',
-            width: '100%',
             alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: 12,
             borderRadius: 'var(--radius-th_large)',
             borderTopLeftRadius: 0,
             borderTopRightRadius: 0,
+            display: 'flex',
             fontSize: 14,
             fontWeight: 500,
+            justifyContent: 'space-between',
             outlineOffset: -2,
+            padding: 12,
+            width: '100%',
           }),
           layout === 'full' &&
             css({
-              borderRadius: 0,
               '@container (min-width: 480px)': {
                 borderRadius: 'var(--radius-th_medium)',
               },
+              borderRadius: 0,
             }),
         )}
         {...props}
       >
         <div
           className={css({
-            display: 'flex',
             alignItems: 'center',
+            display: 'flex',
             gap: 6,
           })}
         >

--- a/apps/ui/src/Screen/Screen.tsx
+++ b/apps/ui/src/Screen/Screen.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 import { useId } from 'react'
 import { css, cx } from '../../styled-system/css'
 import { Frame } from '../Frame/Frame.js'
+import { ButtonArea } from '../ButtonArea/ButtonArea.js'
+import ChevronRight from '~icons/lucide/chevron-right'
 
-export function Screen({ children, layout }: Screen.Props) {
+export function Screen({ children, layout, bottomAction }: Screen.Props) {
   const frame = Frame.useFrame()
   const id = useId()
 
@@ -66,23 +68,16 @@ export function Screen({ children, layout }: Screen.Props) {
           )}
         >
           {children}
+          {bottomAction && (
+            <ScreenBottomAction layout={layout} {...bottomAction} />
+          )}
         </div>
       </div>
     </div>
   )
 }
 
-function ScreenHeader({
-  content,
-  icon,
-  layout,
-  title,
-}: {
-  content?: ReactNode
-  icon?: ReactNode
-  layout?: 'compact' | 'full'
-  title: string
-}) {
+function ScreenHeader({ content, icon, layout, title }: Screen.HeaderProps) {
   const frame = Frame.useFrame()
   layout ??= frame.mode === 'dialog' ? 'compact' : 'full'
 
@@ -179,11 +174,93 @@ function ScreenHeader({
   )
 }
 
+function ScreenBottomAction({
+  children,
+  layout,
+  ...props
+}: Screen.BottomActionProps) {
+  return (
+    <div
+      className={cx(
+        css({
+          display: 'flex',
+          width: '100%',
+          borderTop: '1px solid var(--border-color-th_base)',
+        }),
+        layout === 'full' &&
+          css({
+            '@container (min-width: 480px)': {
+              marginTop: 12,
+            },
+          }),
+      )}
+    >
+      <ButtonArea
+        className={cx(
+          css({
+            display: 'flex',
+            width: '100%',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: 12,
+            borderRadius: 'var(--radius-th_large)',
+            borderTopLeftRadius: 0,
+            borderTopRightRadius: 0,
+            fontSize: 14,
+            fontWeight: 500,
+            outlineOffset: -2,
+          }),
+          layout === 'full' &&
+            css({
+              borderRadius: 0,
+              '@container (min-width: 480px)': {
+                borderRadius: 'var(--radius-th_medium)',
+              },
+            }),
+        )}
+        {...props}
+      >
+        <div
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+          })}
+        >
+          {children}
+        </div>
+        <ChevronRight
+          className={css({
+            color: 'var(--text-color-th_base-secondary)',
+          })}
+          height={20}
+          width={20}
+        />
+      </ButtonArea>
+    </div>
+  )
+}
+
 export namespace Screen {
   export interface Props {
+    bottomAction?: ButtonHTMLAttributes<HTMLButtonElement> | undefined
     children?: ReactNode
-    layout?: 'compact' | 'full'
+    layout?: Layout | undefined
   }
+
+  export interface HeaderProps {
+    content?: ReactNode
+    icon?: ReactNode
+    layout?: Layout | undefined
+    title: string
+  }
+
+  export interface BottomActionProps
+    extends ButtonHTMLAttributes<HTMLButtonElement> {
+    layout: Layout
+  }
+
+  export type Layout = 'compact' | 'full'
 
   export const Header = ScreenHeader
 }

--- a/apps/ui/src/index.ts
+++ b/apps/ui/src/index.ts
@@ -1,5 +1,6 @@
 export { css, cva, cx } from '../styled-system/css'
 export { Button } from './Button/Button.js'
+export { ButtonArea } from './ButtonArea/ButtonArea.js'
 export { Frame } from './Frame/Frame.js'
 export { Input } from './Input/Input.js'
 export { LightDarkImage } from './LightDarkImage/LightDarkImage.js'


### PR DESCRIPTION
The `Screen` `bottomAction` prop allows to style its bottom bar-like button (e.g. “Learn about passkeys”) in a way that adapts to the different layouts.

Also improves the focus states & clickable area:

| before | after |
| ------ | ----- |
| <img width=400 src="https://github.com/user-attachments/assets/128b759e-92cc-4d4c-84fa-9d8696341108" /> | <img width=400 src="https://github.com/user-attachments/assets/d827a51d-fd0b-44fd-96cd-3899f66d6677" /> |


### Changes

- Add a bottomAction prop on the Screen component.
- Add a ButtonArea component (base button surface with focus + active states).


