### PR TITLE
fix: silent failing actions

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -12,38 +12,31 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
     steps:
+      - name: Check Membership
+        run: |
+          gh api orgs/${{ env.REPO }}/members/${{ env.PR_AUTHOR }} --silent 2> /dev/null \
+            && echo "IS_ORG_MEMBER=true" >> $GITHUB_ENV || echo "IS_ORG_MEMBER=false" >> $GITHUB_ENV
+
       - name: Auto assign PR to author
+        if: ${{ env.IS_ORG_MEMBER == 'true' }}
+        env:
+          IS_ORG_MEMBER: ${{ env.IS_ORG_MEMBER }}
         uses: actions/github-script@v7
         with:
-          script: |-
+          script: |
             const pr = context.payload.pull_request
-            const author = pr.user.login
 
-            // Check if PR author is not an org member
-            if (!pr.user.site_admin) {
-              console.info(`PR #${pr.number} author is not an org member. Skipping assignment.`)
-              return
-            }
+            if (pr.assignees.length > 0 || pr.user.type.toLowerCase() === 'bot') return
 
-            // Check if PR author is a bot
-            if (pr.user.type === 'Bot') {
-              console.info(`PR #${pr.number} author is a bot. Skipping assignment.`)
-              return
-            }
-
-            // Check if PR already has assignees
-            if (pr.assignees.length > 0) {
-              console.info(`PR #${pr.number} already has assignees. Skipping assignment.`)
-              return
-            }
-
-            // Assign the PR to the author
-            await github.rest.issues.addAssignees({
+            github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              assignees: [author]
+              assignees: [${{ env.PR_AUTHOR }}]
             })
-
-            console.info(`Successfully assigned PR #${pr.number} to ${author}`)
+              .then(() => console.info(`Successfully assigned PR #${pr.number} to ${{ env.PR_AUTHOR }}`))
+              .catch((error) => console.error(error))

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   issue-labeled:
     if: ${{ github.repository_owner == 'ithacaxyz' }}
+    permissions:
+      issues: write
     uses: wevm/actions/.github/workflows/issue-labeled.yml@main
     with:
       needs-reproduction-body: |

--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lock-issue:
     if: ${{ github.repository_owner == 'ithacaxyz' }}
+    permissions:
+      issues: write
     uses: wevm/actions/.github/workflows/lock-issue.yml@main
     with:
       issue-comment: |

--- a/.github/workflows/promote-dialog.yml
+++ b/.github/workflows/promote-dialog.yml
@@ -16,7 +16,7 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 


### PR DESCRIPTION
`issue-labeled.yml` and `lock-issue` have been [failing](https://github.com/ithacaxyz/porto/actions/runs/14971184565/workflow) with:

> The workflow is requesting 'issues: write', but is only allowed 'issues: none'.

`auto-assign-pr.yml` had a bug where it silently fails with `success` and:

> author is not an org member.

even when user is org member.