### PR TITLE
fix: cli bin not found warning on `pnpm i`

### DIFF
--- a/src/bin/index.mjs
+++ b/src/bin/index.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { cac } from 'cac'
 
-import pkgJson from '../../package.json' with { type: 'json' }
+import pkgJson from '../package.json' with { type: 'json' }
 
 const cli = cac('porto')
 
@@ -24,7 +24,7 @@ cli
     default: 'stg.id.porto.sh',
   })
   .action(async (_, args) => {
-    const Commands = await import('../internal/commands.js')
+    const Commands = await import('../cli/internal/commands.js')
     return Commands.createAccount(null, args)
   })
 

--- a/src/cli/bin/tsconfig.json
+++ b/src/cli/bin/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../../tsconfig.base.json",
-  "include": ["."],
-  "compilerOptions": {
-    "noEmit": true,
-    "resolveJsonModule": true
-  }
-}

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.68",
   "type": "module",
   "bin": {
-    "porto": "./_dist/cli/bin/index.js"
+    "porto": "./bin/index.mjs"
   },
   "main": "./_dist/index.js",
   "types": "./_dist/index.d.ts",
@@ -12,6 +12,7 @@
   "sideEffects": false,
   "files": [
     "*",
+    "!**/_/**",
     "!**/_test/**",
     "!**/*.tsbuildinfo",
     "!tsconfig.build.json",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,5 +12,6 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "files": ["./bin/index.mjs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     { "path": "./docker/proxy/tsconfig.json" },
     { "path": "./scripts/tsconfig.json" },
     { "path": "./src/tsconfig.json" },
-    { "path": "./src/cli/bin/tsconfig.json" },
     { "path": "./test/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
removes this warning on `pnpm i`:

> WARN  Failed to create bin at /Users/o/dev/ithaca/porto/apps/docs/node_modules/.bin/porto. ENOENT: no such file or directory, open '/Users/o/dev/ithaca/porto/src/_dist/cli/bin/index.js'
 WARN  Failed to create bin at /Users/o/dev/ithaca/porto/apps/dialog/node_modules/.bin/porto. ENOENT: no such file or directory, open '/Users/o/dev/ithaca/porto/src/_dist/cli/bin/index.js'
 WARN  Failed to create bin at /Users/o/dev/ithaca/porto/apps/id/node_modules/.bin/porto. ENOENT: no such file or directory, open '/Users/o/dev/ithaca/porto/src/_dist/cli/bin/index.js'
 WARN  Failed to create bin at /Users/o/dev/ithaca/porto/apps/playground/node_modules/.bin/porto. ENOENT: no such file or directory, open '/Users/o/dev/ithaca/porto/src/_dist/cli/bin/index.js'
 WARN  Failed to create bin at /Users/o/dev/ithaca/porto/apps/extension/node_modules/.bin/porto. ENOENT: no such file or directory, open '/Users/o/dev/ithaca/porto/src/_dist/cli/bin/index.js'
 WARN  36 other warnings

<img width="1767" height="539" alt="image" src="https://github.com/user-attachments/assets/88ce10b3-c17f-49d0-8efc-7884249c0e7b" />
