### PR TITLE
feat: support chainIds parameter in wallet_connect for app-declared chain support

### DIFF
--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -4,7 +4,7 @@ import { Events } from 'porto/remote'
 import { Actions } from 'porto/wagmi'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { getConnectors } from 'wagmi/actions'
+import { getConnectors, switchChain } from 'wagmi/actions'
 
 import * as Dialog from '~/lib/Dialog.ts'
 import { porto } from '~/lib/Porto.js'
@@ -74,18 +74,25 @@ const offInitialized = Events.onInitialized(porto, (payload, event) => {
 
 const offDialogRequest = Events.onDialogRequest(
   porto,
-  ({ account, request, requireUpdatedAccount }) => {
+  ({ account, request, requireChainSync, requireUpdatedAccount }) => {
+    const chainId = porto._internal.store.getState().chainIds[0]
     const connectedAccount = porto._internal.store.getState().accounts[0]
-    const needsSync = account && account.address !== connectedAccount?.address
+    const requireAccountSync =
+      account && account.address !== connectedAccount?.address
 
     // Clear errors when the request is null (i.e. when the dialog is closed).
     if (!request) Dialog.store.setState({ error: null })
 
-    if (needsSync)
+    if (requireAccountSync)
       Actions.connect(Wagmi.config, {
         connector: getConnectors(Wagmi.config)[0]!,
         force: true,
         selectAccount: account,
+      })
+
+    if (requireChainSync)
+      switchChain(Wagmi.config, {
+        chainId,
       })
 
     Router.router.navigate({

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -143,7 +143,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
         const account = await (async () => {
           if (request.method === 'wallet_connect') {
             // Extract the capabilities from the request.
-            const [{ capabilities }] = request._decoded.params ?? [{}]
+            const [{ capabilities, chainIds }] = request._decoded.params ?? [{}]
 
             const authUrl = getAuthUrl(
               capabilities?.signInWithEthereum?.authUrl ?? config.authUrl,
@@ -184,6 +184,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
                           }
                         : undefined,
                   },
+                  chainIds: chainIds?.map((chainId) => Hex.fromNumber(chainId)),
                 },
               ],
             })

--- a/src/core/internal/schema/rpc.ts
+++ b/src/core/internal/schema/rpc.ts
@@ -511,15 +511,15 @@ export namespace wallet_connect {
   })
   export type Capabilities = typeof Capabilities.Type
 
+  export const Parameters = Schema.Struct({
+    capabilities: Schema.optional(Capabilities),
+    chainIds: Schema.optional(Schema.Array(Primitive.Number)),
+  })
+  export type Parameters = typeof Parameters.Type
+
   export const Request = Schema.Struct({
     method: Schema.Literal('wallet_connect'),
-    params: Schema.optional(
-      Schema.Tuple(
-        Schema.Struct({
-          capabilities: Schema.optional(Capabilities),
-        }),
-      ),
-    ),
+    params: Schema.optional(Schema.Tuple(Parameters)),
   }).annotations({
     identifier: 'Rpc.wallet_connect.Request',
   })

--- a/src/viem/WalletActions.ts
+++ b/src/viem/WalletActions.ts
@@ -128,6 +128,7 @@ export async function connect(
   client: Client,
   parameters: connect.Parameters = {},
 ): Promise<connect.ReturnType> {
+  const { chainIds, ...capabilities } = parameters
   const method = 'wallet_connect' as const
   type Method = typeof method
   const response = await client.request<
@@ -135,11 +136,10 @@ export async function connect(
   >({
     method,
     params: [
-      {
-        capabilities: Schema.encodeSync(RpcSchema.wallet_connect.Capabilities)(
-          parameters,
-        ),
-      },
+      Schema.encodeSync(RpcSchema.wallet_connect.Parameters)({
+        capabilities,
+        chainIds,
+      }),
     ],
   })
 
@@ -147,7 +147,8 @@ export async function connect(
 }
 
 export declare namespace connect {
-  type Parameters = RpcSchema.wallet_connect.Capabilities
+  type Parameters = RpcSchema.wallet_connect.Capabilities &
+    Omit<RpcSchema.wallet_connect.Parameters, 'capabilities'>
 
   type ReturnType = RpcSchema.wallet_connect.Response
 }

--- a/src/viem/internal/relayActions.ts
+++ b/src/viem/internal/relayActions.ts
@@ -62,7 +62,7 @@ export async function getCapabilities<
           method,
           params: [chainIds],
         }),
-      { cacheKey: `${client.uid}.${method}` },
+      { cacheKey: `${client.uid}.${method}.${chainIds.join(',')}` },
     )
     const parsed = (() => {
       if (options.raw) return result as never


### PR DESCRIPTION
### Summary

Added support for `chainIds` parameter on `wallet_connect` method, allowing applications to declare which chain IDs they support. This enables better chain synchronization between the application and Porto dialog.

### Details

- **Core Schema**: Extended `wallet_connect` RPC schema to include optional `chainIds` parameter alongside existing `capabilities`
- **Provider Logic**: Updated provider to handle `chainIds` parameter and set the client to use the requested chain
- **Dialog Mode**: Modified dialog mode to extract and process `chainIds` from connect requests
- **Chain Synchronization**: Added logic to find compatible chains between app and dialog, with error handling for unsupported chains
- **Dialog UI**: Enhanced dialog to trigger chain switching when `requireChainSync` is needed
- **Wagmi Integration**: Updated wagmi connector to pass through `chainIds` and handle chain switching
- **Wallet Actions**: Modified `connect` action to accept and process `chainIds` parameter
- **Event Handling**: Added `requireChainSync` flag to dialog request events for UI coordination
- **Relay Actions**: Updated caching strategy to include chain IDs in cache keys for better isolation

### Areas Touched

- Dialog (`apps/dialog`)
- `porto` Library (`src/`)
  - Core internal modules (modes, provider, RPC schema)
  - Remote events system
  - Viem wallet actions and relay actions  
  - Wagmi internal core integration