### PR TITLE
feat: pass chainIds to wallet_connect in porto Connector

### DIFF
--- a/.changeset/silent-gifts-attack.md
+++ b/.changeset/silent-gifts-attack.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Passed through `chainIds` to `wallet_connect` on the `porto` Connector.


### PR DESCRIPTION
### Summary

Modified the porto Connector to pass through `chainIds` to `wallet_connect` and removed subsequent switch chain logic.

### Details

- Pass `chainIds` array to `wallet_connect` RPC call with requested chainId first, followed by other configured chains
- Remove explicit chain switching logic after connection since chainId is now handled in the initial connect call
- Set `currentChainId` from the response's first chainId
- Improve reconnection logic to fetch both accounts and chainId in parallel
- Add proper error handling when currentChainId is not available

### Areas Touched

- `porto` Library (`src/`) - Wagmi Connector module