### PR TITLE
chore: remove redundant `wallet_addFaucetFunds` provider methods

### DIFF
--- a/.changeset/metal-bushes-film.md
+++ b/.changeset/metal-bushes-film.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+**Breaking:** Removed `addFaucetFunds` from `Mode`.

--- a/src/core/RpcSchema.ts
+++ b/src/core/RpcSchema.ts
@@ -12,7 +12,6 @@ export type Schema =
       {
         Request: {
           method:
-            | 'wallet_addFaucetFunds'
             | 'wallet_getCapabilities'
             | 'wallet_getAssets'
             | 'wallet_getCallsStatus'
@@ -27,10 +26,6 @@ export type Schema =
       }
     >
   | RpcSchema.From<
-      | {
-          Request: typeof Rpc.wallet_addFaucetFunds.Request.Encoded
-          ReturnType: typeof Rpc.wallet_addFaucetFunds.Response.Encoded
-        }
       | {
           Request: typeof Rpc.account_verifyEmail.Request.Encoded
           ReturnType: typeof Rpc.account_verifyEmail.Response.Encoded

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -49,13 +49,6 @@ export type Mode = {
       value?: string | undefined
     }) => Promise<{ id: Hex.Hex }>
 
-    addFaucetFunds: (
-      parameters: RpcSchema.wallet_addFaucetFunds.Parameters & {
-        /** Internal properties. */
-        internal: ActionsInternal
-      },
-    ) => Promise<RpcSchema.wallet_addFaucetFunds.Response>
-
     createAccount: (parameters: {
       /** Admins to grant. */
       admins?: readonly Pick<Key.Key, 'publicKey' | 'type'>[] | undefined

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -123,18 +123,6 @@ export function dialog(parameters: dialog.Parameters = {}) {
 
   return Mode.from({
     actions: {
-      async addFaucetFunds(parameters) {
-        const { internal } = parameters
-        const { request, store } = internal
-
-        if (request.method !== 'wallet_addFaucetFunds')
-          throw new Error(
-            'Cannot add faucet funds for method: ' + request.method,
-          )
-
-        const provider = getProvider(store)
-        return await provider.request(request)
-      },
       async addFunds(parameters) {
         const { internal } = parameters
         const { request, store } = internal

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -53,15 +53,6 @@ export function relay(parameters: relay.Parameters = {}) {
 
   return Mode.from({
     actions: {
-      async addFaucetFunds(parameters) {
-        const { internal, ...params } = parameters
-
-        return await RelayActions_internal.addFaucetFunds(
-          internal.client,
-          params,
-        )
-      },
-
       async addFunds() {
         throw new Provider.UnsupportedMethodError()
       },

--- a/src/core/internal/provider.test.ts
+++ b/src/core/internal/provider.test.ts
@@ -1,4 +1,3 @@
-import { setTimeout } from 'node:timers/promises'
 import {
   Address,
   Hex,
@@ -174,59 +173,6 @@ describe.each([['relay', Mode.relay]] as const)('%s', (type, mode) => {
         ],
       })
       expect(valid).toBe(true)
-    })
-  })
-
-  describe('wallet_addFaucetFunds', () => {
-    test('default', async () => {
-      const porto = getPorto()
-      const contracts = await TestConfig.getContracts(porto)
-      const client = TestConfig.getRelayClient(porto)
-
-      const alice = Hex.random(20)
-
-      const result = await porto.provider.request({
-        method: 'wallet_addFaucetFunds',
-        params: [
-          {
-            address: alice,
-            chainId: Hex.fromNumber(client.chain.id),
-            tokenAddress: contracts.exp1.address,
-            value: Hex.fromNumber(Value.fromEther('10')),
-          },
-        ],
-      })
-      await setTimeout(2_000)
-
-      expect(result).toBeDefined()
-      expect(result.transactionHash).toBeDefined()
-
-      const balance = await readContract(client, {
-        abi: contracts.exp1.abi,
-        address: contracts.exp1.address,
-        args: [alice],
-        functionName: 'balanceOf',
-      })
-      expect(balance).toBe(Value.fromEther('10'))
-    })
-
-    test('behavior: unsupported chain', async () => {
-      const porto = getPorto()
-      const contracts = await TestConfig.getContracts(porto)
-
-      await expect(
-        porto.provider.request({
-          method: 'wallet_addFaucetFunds',
-          params: [
-            {
-              address: Hex.random(20),
-              chainId: Hex.fromNumber(999999),
-              tokenAddress: contracts.exp1.address,
-              value: Hex.fromNumber(Value.fromEther('1')),
-            },
-          ],
-        }),
-      ).rejects.toThrow()
     })
   })
 

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -139,28 +139,6 @@ export function from<
           return result
         }
 
-        case 'wallet_addFaucetFunds': {
-          const { address, chainId, tokenAddress, value } =
-            request._decoded.params[0]!
-
-          const client = getClient()
-
-          const result = await getMode().actions.addFaucetFunds({
-            address,
-            chainId,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            tokenAddress,
-            value,
-          })
-
-          return result satisfies typeof Rpc.wallet_addFaucetFunds.Response.Encoded
-        }
-
         case 'eth_accounts': {
           if (state.accounts.length === 0)
             throw new ox_Provider.DisconnectedError()

--- a/src/core/internal/schema/request.ts
+++ b/src/core/internal/schema/request.ts
@@ -10,7 +10,6 @@ export * from './rpc.js'
 
 export const Request = Schema.Union(
   RpcRequest.account_verifyEmail.Request,
-  RpcRequest.wallet_addFaucetFunds.Request,
   RpcRequest.wallet_addFunds.Request,
   RpcRequest.eth_accounts.Request,
   RpcRequest.eth_chainId.Request,

--- a/src/core/internal/schema/rpc.ts
+++ b/src/core/internal/schema/rpc.ts
@@ -64,34 +64,6 @@ export namespace account_verifyEmail {
   export type Response = typeof Response.Type
 }
 
-export namespace wallet_addFaucetFunds {
-  export const Parameters = Schema.Struct({
-    address: Primitive.Address,
-    chainId: Primitive.Number,
-    tokenAddress: Primitive.Address,
-    value: Primitive.BigInt,
-  }).annotations({
-    identifier: 'Rpc.wallet_addFaucetFunds.Parameters',
-  })
-  export type Parameters = typeof Parameters.Type
-
-  export const Request = Schema.Struct({
-    method: Schema.Literal('wallet_addFaucetFunds'),
-    params: Schema.Tuple(Parameters),
-  }).annotations({
-    identifier: 'Rpc.wallet_addFaucetFunds.Request',
-  })
-  export type Request = typeof Request.Type
-
-  export const Response = Schema.Struct({
-    message: Schema.optional(Schema.String),
-    transactionHash: Primitive.Hex,
-  }).annotations({
-    identifier: 'Rpc.wallet_addFaucetFunds.Response',
-  })
-  export type Response = typeof Response.Type
-}
-
 export namespace wallet_addFunds {
   export const Parameters = Schema.Struct({
     address: Schema.optional(Primitive.Address),

--- a/src/viem/WalletActions.ts
+++ b/src/viem/WalletActions.ts
@@ -76,26 +76,6 @@ export declare namespace addFunds {
   type ReturnType = RpcSchema.wallet_addFunds.Response
 }
 
-export async function addFaucetFunds(
-  client: Client,
-  parameters: addFaucetFunds.Parameters,
-): Promise<void> {
-  const method = 'wallet_addFaucetFunds' as const
-  type Method = typeof method
-  await client.request<
-    Extract<RpcSchema_viem.Wallet[number], { Method: Method }>
-  >({
-    method,
-    params: [
-      Schema.encodeSync(RpcSchema.wallet_addFaucetFunds.Parameters)(parameters),
-    ],
-  })
-}
-
-export declare namespace addFaucetFunds {
-  type Parameters = RpcSchema.wallet_addFaucetFunds.Parameters
-}
-
 export async function getAssets<
   chain extends Chain | undefined,
   account extends Account.Account | undefined,


### PR DESCRIPTION
We don't need to have `wallet_addFaucetFunds` built into the provider as we can call the Relay directly. Less code to maintain :D