### PR TITLE
fix: rehydrate chains

### DIFF
--- a/.changeset/short-cycles-wink.md
+++ b/.changeset/short-cycles-wink.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Ensured that chains are rehydrated on state initialization.

--- a/src/core/Porto.ts
+++ b/src/core/Porto.ts
@@ -96,8 +96,8 @@ export function create(
                 .filter((id) => id !== currentChainId),
             ] as const
             return {
-              ...persistedState,
               ...currentState,
+              ...persistedState,
               chainIds,
             }
           },


### PR DESCRIPTION
Ensure that chains never go stale and are always in sync with the config. 

Example: 
1. State is initialized with `chainIds: 1, 10`
2. Chain ID `20` gets added
3. State should now be `chainIds: 1, 10, 20`, and not the cached `chainIds: 1, 10`