### PR TITLE
fix: close button width

### DIFF
--- a/apps/ui/src/Frame/Frame.tsx
+++ b/apps/ui/src/Frame/Frame.tsx
@@ -493,9 +493,6 @@ function FrameBar({
                 outline: '2px solid var(--color-th_focus)',
                 outlineOffset: -2,
               },
-              '@container (min-width: 480px)': {
-                padding: '0 20px',
-              },
               alignItems: 'center',
               background: 'transparent',
               border: 'none',
@@ -504,6 +501,12 @@ function FrameBar({
               height: '100%',
               padding: '0 12px',
             }),
+            mode.name === 'full' &&
+              css({
+                '@container (min-width: 480px)': {
+                  padding: '0 20px',
+                },
+              }),
             mode.name === 'dialog' &&
               css({
                 borderTopRightRadius: 'var(--radius-th_frame)',


### PR DESCRIPTION
Fixed a style priority issue which was making the close button too wide in dialog mode.
