### PR TITLE
feat: new `id` multichain permissions

### DIFF
--- a/apps/id/src/App.tsx
+++ b/apps/id/src/App.tsx
@@ -1,5 +1,5 @@
 import { Query } from '@porto/apps'
-import { Ui } from '@porto/ui'
+import * as UI from '@porto/ui'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { RouterProvider } from '@tanstack/react-router'
 import { useAccount, WagmiProvider } from 'wagmi'
@@ -19,7 +19,7 @@ export function Providers(props: React.PropsWithChildren) {
         client={Query.client}
         persistOptions={{ persister: Query.persister }}
       >
-        <Ui>{props.children}</Ui>
+        <UI.Ui>{props.children}</UI.Ui>
       </PersistQueryClientProvider>
     </WagmiProvider>
   )

--- a/apps/id/src/routeTree.gen.ts
+++ b/apps/id/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as DashAssetsImport } from './routes/_dash/assets'
 import { Route as DashActivityImport } from './routes/_dash/activity'
 import { Route as DashSettingsIndexImport } from './routes/_dash/settings/index'
 import { Route as DashSettingsRecoveryImport } from './routes/_dash/settings/recovery'
+import { Route as DashSettingsPermissionsImport } from './routes/_dash/settings/permissions'
 
 // Create/Update Routes
 
@@ -87,6 +88,12 @@ const DashSettingsIndexRoute = DashSettingsIndexImport.update({
 const DashSettingsRecoveryRoute = DashSettingsRecoveryImport.update({
   id: '/settings/recovery',
   path: '/settings/recovery',
+  getParentRoute: () => DashRoute,
+} as any)
+
+const DashSettingsPermissionsRoute = DashSettingsPermissionsImport.update({
+  id: '/settings/permissions',
+  path: '/settings/permissions',
   getParentRoute: () => DashRoute,
 } as any)
 
@@ -157,6 +164,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashIndexImport
       parentRoute: typeof DashImport
     }
+    '/_dash/settings/permissions': {
+      id: '/_dash/settings/permissions'
+      path: '/settings/permissions'
+      fullPath: '/settings/permissions'
+      preLoaderRoute: typeof DashSettingsPermissionsImport
+      parentRoute: typeof DashImport
+    }
     '/_dash/settings/recovery': {
       id: '/_dash/settings/recovery'
       path: '/settings/recovery'
@@ -182,6 +196,7 @@ interface DashRouteChildren {
   DashReceiveRoute: typeof DashReceiveRoute
   DashSavingsRoute: typeof DashSavingsRoute
   DashIndexRoute: typeof DashIndexRoute
+  DashSettingsPermissionsRoute: typeof DashSettingsPermissionsRoute
   DashSettingsRecoveryRoute: typeof DashSettingsRecoveryRoute
   DashSettingsIndexRoute: typeof DashSettingsIndexRoute
 }
@@ -192,6 +207,7 @@ const DashRouteChildren: DashRouteChildren = {
   DashReceiveRoute: DashReceiveRoute,
   DashSavingsRoute: DashSavingsRoute,
   DashIndexRoute: DashIndexRoute,
+  DashSettingsPermissionsRoute: DashSettingsPermissionsRoute,
   DashSettingsRecoveryRoute: DashSettingsRecoveryRoute,
   DashSettingsIndexRoute: DashSettingsIndexRoute,
 }
@@ -208,6 +224,7 @@ export interface FileRoutesByFullPath {
   '/receive': typeof DashReceiveRoute
   '/savings': typeof DashSavingsRoute
   '/': typeof DashIndexRoute
+  '/settings/permissions': typeof DashSettingsPermissionsRoute
   '/settings/recovery': typeof DashSettingsRecoveryRoute
   '/settings': typeof DashSettingsIndexRoute
 }
@@ -221,6 +238,7 @@ export interface FileRoutesByTo {
   '/receive': typeof DashReceiveRoute
   '/savings': typeof DashSavingsRoute
   '/': typeof DashIndexRoute
+  '/settings/permissions': typeof DashSettingsPermissionsRoute
   '/settings/recovery': typeof DashSettingsRecoveryRoute
   '/settings': typeof DashSettingsIndexRoute
 }
@@ -236,6 +254,7 @@ export interface FileRoutesById {
   '/_dash/receive': typeof DashReceiveRoute
   '/_dash/savings': typeof DashSavingsRoute
   '/_dash/': typeof DashIndexRoute
+  '/_dash/settings/permissions': typeof DashSettingsPermissionsRoute
   '/_dash/settings/recovery': typeof DashSettingsRecoveryRoute
   '/_dash/settings/': typeof DashSettingsIndexRoute
 }
@@ -252,6 +271,7 @@ export interface FileRouteTypes {
     | '/receive'
     | '/savings'
     | '/'
+    | '/settings/permissions'
     | '/settings/recovery'
     | '/settings'
   fileRoutesByTo: FileRoutesByTo
@@ -264,6 +284,7 @@ export interface FileRouteTypes {
     | '/receive'
     | '/savings'
     | '/'
+    | '/settings/permissions'
     | '/settings/recovery'
     | '/settings'
   id:
@@ -277,6 +298,7 @@ export interface FileRouteTypes {
     | '/_dash/receive'
     | '/_dash/savings'
     | '/_dash/'
+    | '/_dash/settings/permissions'
     | '/_dash/settings/recovery'
     | '/_dash/settings/'
   fileRoutesById: FileRoutesById
@@ -320,6 +342,7 @@ export const routeTree = rootRoute
         "/_dash/receive",
         "/_dash/savings",
         "/_dash/",
+        "/_dash/settings/permissions",
         "/_dash/settings/recovery",
         "/_dash/settings/"
       ]
@@ -351,6 +374,10 @@ export const routeTree = rootRoute
     },
     "/_dash/": {
       "filePath": "_dash/index.tsx",
+      "parent": "/_dash"
+    },
+    "/_dash/settings/permissions": {
+      "filePath": "_dash/settings/permissions.tsx",
       "parent": "/_dash"
     },
     "/_dash/settings/recovery": {

--- a/apps/id/src/routes/_dash/settings/index.tsx
+++ b/apps/id/src/routes/_dash/settings/index.tsx
@@ -8,7 +8,14 @@ function RouteComponent() {
   return (
     <div>
       <p>Hello "/_dash/settings/"!</p>
-      <Link to="/settings/recovery">Recovery</Link>
+      <ul>
+        <li>
+          <Link to="/settings/recovery">Recovery</Link>
+        </li>
+        <li>
+          <Link to="/settings/permissions">Permissions</Link>
+        </li>
+      </ul>
     </div>
   )
 }

--- a/apps/id/src/routes/_dash/settings/permissions.tsx
+++ b/apps/id/src/routes/_dash/settings/permissions.tsx
@@ -1,0 +1,108 @@
+import * as UI from '@porto/ui'
+import { CatchBoundary, createFileRoute } from '@tanstack/react-router'
+import { Json } from 'ox'
+import { Hooks } from 'porto/wagmi'
+import type { getPermissions } from 'porto/wagmi/Actions'
+import { DateFormatter, StringFormatter, ValueFormatter } from '~/utils'
+
+export const Route = createFileRoute('/_dash/settings/permissions')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { account } = Route.useRouteContext()
+
+  const permissions = Hooks.usePermissions()
+  const revokePermissions = Hooks.useRevokePermissions()
+
+  return (
+    <CatchBoundary
+      getResetKey={() => 'permissions'}
+      onCatch={(error, errorInfo) => {
+        console.error(error, errorInfo)
+      }}
+    >
+      <section className="w-full overflow-x-auto">
+        <div>Hello "/_dash/settings/permissions"!</div>
+        <div>Account: {account?.address}</div>
+        <p>
+          Chains with permissions: {permissions.data?.length} (
+          {permissions.data?.map((permission) => permission.chainId).join(', ')}
+          )
+        </p>
+        <ul>
+          {permissions.data?.map((permission, index) => (
+            <div key={permission.id}>
+              <p>#{index + 1}</p>
+              <PermissionRow
+                onAction={() => {
+                  revokePermissions.mutate({
+                    address: account.address,
+                    chainId: permission.chainId as never,
+                    id: permission.id,
+                  })
+                }}
+                permission={permission}
+              />
+            </div>
+          ))}
+        </ul>
+        <details>
+          <summary>raw permissions</summary>
+          <pre>{Json.stringify(permissions.data, null, 2)}</pre>
+        </details>
+      </section>
+    </CatchBoundary>
+  )
+}
+
+type Permission = Awaited<ReturnType<typeof getPermissions>>[number]
+
+function PermissionRow(props: PermissionRow.Props) {
+  const { permission, onAction } = props
+
+  return (
+    <div>
+      <p>Chain: {permission.chainId}</p>
+      <p>ID: {StringFormatter.truncate(permission.id)}</p>
+      <p>
+        Expires in: {DateFormatter.timeToDuration(permission.expiry * 1_000)}
+      </p>
+      <p>Spend:</p>
+      <ol>
+        {permission.permissions.spend?.map((spend) => (
+          <li key={spend.token ?? spend.period}>
+            <ul>
+              <li>
+                Limit: {ValueFormatter.format(spend.limit)} {spend.token}
+              </li>
+              <li>Period: {spend.period}</li>
+              <li>Token: {spend.token}</li>
+            </ul>
+          </li>
+        ))}
+      </ol>
+      <p>Calls:</p>
+      <ol>
+        {permission.permissions.calls?.map((call) => (
+          <li key={call.to ?? call.signature}>
+            <ul>
+              <li>To: {call.to}</li>
+              <li>Signature: {call.signature}</li>
+            </ul>
+          </li>
+        ))}
+      </ol>
+      <UI.Button onClick={onAction} type="button" variant="strong">
+        Revoke
+      </UI.Button>
+    </div>
+  )
+}
+
+declare namespace PermissionRow {
+  type Props = {
+    permission: Permission
+    onAction: React.MouseEventHandler<HTMLButtonElement>
+  }
+}

--- a/apps/id/src/routes/_dash/settings/permissions.tsx
+++ b/apps/id/src/routes/_dash/settings/permissions.tsx
@@ -63,32 +63,33 @@ function PermissionRow(props: PermissionRow.Props) {
 
   return (
     <div>
-      <p>Chain: {permission.chainId}</p>
+      <strong>Chain: {permission.chainId}</strong>
       <p>ID: {StringFormatter.truncate(permission.id)}</p>
       <p>
         Expires in: {DateFormatter.timeToDuration(permission.expiry * 1_000)}
       </p>
-      <p>Spend:</p>
+      <strong>Spend:</strong>
       <ol>
         {permission.permissions.spend?.map((spend) => (
           <li key={spend.token ?? spend.period}>
             <ul>
+              <li>Limit: {spend.limit ?? '––'}</li>
               <li>
                 Limit: {ValueFormatter.format(spend.limit)} {spend.token}
               </li>
-              <li>Period: {spend.period}</li>
-              <li>Token: {spend.token}</li>
+              <li>Period: {spend.period ?? '––'}</li>
+              <li>Token: {spend.token ?? '––'}</li>
             </ul>
           </li>
         ))}
       </ol>
-      <p>Calls:</p>
+      <strong>Calls:</strong>
       <ol>
         {permission.permissions.calls?.map((call) => (
           <li key={call.to ?? call.signature}>
             <ul>
-              <li>To: {call.to}</li>
-              <li>Signature: {call.signature}</li>
+              <li>To: {call.to ?? '––'}</li>
+              <li>Signature: {call.signature ?? '––'}</li>
             </ul>
           </li>
         ))}

--- a/apps/id/src/styles.css
+++ b/apps/id/src/styles.css
@@ -1,3 +1,4 @@
+@import "@porto/ui/styles.css";
 @import "@porto/apps/styles.css";
 @import "@ariakit/tailwind";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: ^5.74.3
       version: 5.77.1
     '@tanstack/react-query':
-      specifier: ^5.74.3
-      version: 5.77.1
+      specifier: ^5.81.5
+      version: 5.85.9
     '@tanstack/react-query-devtools':
       specifier: ^5.81.5
       version: 5.81.5
@@ -165,7 +165,7 @@ importers:
         version: 11.2.0(bufferutil@4.0.9)(size-limit@11.2.0)(utf-8-validate@5.0.10)
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       '@types/http-proxy':
         specifier: ^1.17.16
         version: 1.17.16
@@ -186,7 +186,7 @@ importers:
         version: 2.3.1(patch_hash=6b99a8b8575a6640e47965065cf75f39120a1f07ea3ae1776a366a0ec296bfbb)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
+        version: 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
       cac:
         specifier: ^6
         version: 6.7.14
@@ -243,7 +243,7 @@ importers:
         version: 3.1.4(@types/debug@4.1.12)(@types/node@22.15.32)(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.1)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
       yaml:
         specifier: ^2.8.1
         version: 2.8.1
@@ -273,16 +273,16 @@ importers:
         version: 5.77.1
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       '@tanstack/react-query-persist-client':
         specifier: 'catalog:'
-        version: 5.77.1(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.77.1(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.120.10(patch_hash=d040a32b2882bb1304fb0c2ba45e98919dec02b25c255882a212122728960907)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
+        version: 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
       cuer:
         specifier: ^0.0.2
         version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -306,7 +306,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
       zustand:
         specifier: 'catalog:'
         version: 5.0.5(@types/react@19.1.5)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
@@ -325,7 +325,7 @@ importers:
         version: 4.1.11(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.1))
       '@tanstack/react-query-devtools':
         specifier: 'catalog:'
-        version: 5.81.5(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.81.5(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       '@tanstack/react-router-devtools':
         specifier: 'catalog:'
         version: 1.120.10(@tanstack/react-router@1.120.10(patch_hash=d040a32b2882bb1304fb0c2ba45e98919dec02b25c255882a212122728960907)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.120.10)(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tiny-invariant@1.3.3)
@@ -379,10 +379,10 @@ importers:
         version: 5.77.1
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       '@tanstack/react-query-persist-client':
         specifier: 'catalog:'
-        version: 5.77.1(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.77.1(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       cva:
         specifier: 'catalog:'
         version: class-variance-authority@0.7.1
@@ -415,7 +415,7 @@ importers:
         version: 1.0.13(@types/node@22.15.32)(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(acorn@8.15.0)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.41.1)(terser@5.39.2)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.1)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@iconify/json':
         specifier: 'catalog:'
@@ -425,7 +425,7 @@ importers:
         version: 8.1.0(typescript@5.8.3)
       '@tanstack/react-query-devtools':
         specifier: 'catalog:'
-        version: 5.81.5(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.81.5(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       '@types/react':
         specifier: 'catalog:'
         version: 19.1.5
@@ -483,16 +483,16 @@ importers:
         version: 5.77.1
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       '@tanstack/react-query-persist-client':
         specifier: 'catalog:'
-        version: 5.77.1(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.77.1(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.120.10(patch_hash=d040a32b2882bb1304fb0c2ba45e98919dec02b25c255882a212122728960907)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
+        version: 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
       cuer:
         specifier: ^0.0.2
         version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -519,7 +519,7 @@ importers:
         version: 1.1.0(typescript@5.8.3)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@iconify/json':
         specifier: 'catalog:'
@@ -535,7 +535,7 @@ importers:
         version: 4.1.11(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.1))
       '@tanstack/react-query-devtools':
         specifier: 'catalog:'
-        version: 5.81.5(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.81.5(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       '@tanstack/react-router-devtools':
         specifier: 'catalog:'
         version: 1.120.10(@tanstack/react-router@1.120.10(patch_hash=d040a32b2882bb1304fb0c2ba45e98919dec02b25c255882a212122728960907)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.120.10)(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tiny-invariant@1.3.3)
@@ -644,7 +644,7 @@ importers:
         version: 4.1.11(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(tsx@4.20.3)(yaml@2.8.1))
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       porto:
         specifier: workspace:*
         version: link:../../src
@@ -662,7 +662,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -876,7 +876,7 @@ importers:
         version: link:../~internal
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       porto:
         specifier: workspace:*
         version: link:../../src
@@ -891,7 +891,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -925,10 +925,10 @@ importers:
         version: 5.77.1
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 5.77.1(react@19.1.0)
+        version: 5.85.9(react@19.1.0)
       '@tanstack/react-query-persist-client':
         specifier: 'catalog:'
-        version: 5.77.1(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)
+        version: 5.77.1(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)
       cva:
         specifier: 'catalog:'
         version: class-variance-authority@0.7.1
@@ -949,7 +949,7 @@ importers:
         version: 1.3.4
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -995,7 +995,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.7.5
@@ -1062,7 +1062,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.7.5
@@ -1102,7 +1102,7 @@ importers:
     dependencies:
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.8
-        version: 2.2.8(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(wagmi@2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28))
+        version: 2.2.8(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(wagmi@2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28))
       '@tanstack/react-query':
         specifier: ^5
         version: 5.77.1(react@19.1.0)
@@ -1123,7 +1123,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.7.5
@@ -1178,7 +1178,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -1212,7 +1212,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -1255,7 +1255,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -1310,7 +1310,7 @@ importers:
         version: 0.21.1
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/cors':
         specifier: ^2.8.19
@@ -1362,7 +1362,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -1396,7 +1396,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.7.5
@@ -1445,7 +1445,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -1488,7 +1488,7 @@ importers:
         version: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       wagmi:
         specifier: ^2
-        version: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+        version: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -4796,6 +4796,9 @@ packages:
   '@tanstack/query-core@5.77.1':
     resolution: {integrity: sha512-nfxVhy4UynChMFfN4NxwI8pktV9R3Zt/ROxOAe6pdOf8CigDLn26p+ex1YW5uien26BBICLmN0dTvIELHCs5vw==}
 
+  '@tanstack/query-core@5.85.9':
+    resolution: {integrity: sha512-5fxb9vwyftYE6KFLhhhDyLr8NO75+Wpu7pmTo+TkwKmMX2oxZDoLwcqGP8ItKSpUMwk3urWgQDZfyWr5Jm9LsQ==}
+
   '@tanstack/query-devtools@5.81.2':
     resolution: {integrity: sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==}
 
@@ -4819,6 +4822,11 @@ packages:
 
   '@tanstack/react-query@5.77.1':
     resolution: {integrity: sha512-qBwpxFg0+MZF0fICQwgvzwrVbcs7TdQlLyEd1f1dN83oeIALofCIAJHV7sPWu+BCS5tcXkG5CvOuf7yla8GYqQ==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.85.9':
+    resolution: {integrity: sha512-2T5zgSpcOZXGkH/UObIbIkGmUPQqZqn7esVQFXLOze622h4spgWf5jmvrqAo9dnI13/hyMcNsF1jsoDcb59nJQ==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -14028,7 +14036,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.8(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(wagmi@2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28))':
+  '@rainbow-me/rainbowkit@2.2.8(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(wagmi@2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28))':
     dependencies:
       '@tanstack/react-query': 5.77.1(react@19.1.0)
       '@vanilla-extract/css': 1.17.3
@@ -14041,7 +14049,7 @@ snapshots:
       react-remove-scroll: 2.6.2(@types/react@19.1.5)(react@19.1.0)
       ua-parser-js: 1.0.40
       viem: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
-      wagmi: 2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+      wagmi: 2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -15019,6 +15027,8 @@ snapshots:
 
   '@tanstack/query-core@5.77.1': {}
 
+  '@tanstack/query-core@5.85.9': {}
+
   '@tanstack/query-devtools@5.81.2': {}
 
   '@tanstack/query-persist-client-core@5.77.1':
@@ -15030,21 +15040,26 @@ snapshots:
       '@tanstack/query-core': 5.77.1
       '@tanstack/query-persist-client-core': 5.77.1
 
-  '@tanstack/react-query-devtools@5.81.5(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-query-devtools@5.81.5(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/query-devtools': 5.81.2
-      '@tanstack/react-query': 5.77.1(react@19.1.0)
+      '@tanstack/react-query': 5.85.9(react@19.1.0)
       react: 19.1.0
 
-  '@tanstack/react-query-persist-client@5.77.1(@tanstack/react-query@5.77.1(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-query-persist-client@5.77.1(@tanstack/react-query@5.85.9(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/query-persist-client-core': 5.77.1
-      '@tanstack/react-query': 5.77.1(react@19.1.0)
+      '@tanstack/react-query': 5.85.9(react@19.1.0)
       react: 19.1.0
 
   '@tanstack/react-query@5.77.1(react@19.1.0)':
     dependencies:
       '@tanstack/query-core': 5.77.1
+      react: 19.1.0
+
+  '@tanstack/react-query@5.85.9(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.85.9
       react: 19.1.0
 
   '@tanstack/react-router-devtools@1.120.10(@tanstack/react-router@1.120.10(patch_hash=d040a32b2882bb1304fb0c2ba45e98919dec02b25c255882a212122728960907)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.120.10)(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tiny-invariant@1.3.3)':
@@ -15775,13 +15790,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@wagmi/connectors@5.8.3(@types/react@19.1.5)(@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)':
+  '@wagmi/connectors@5.8.3(@types/react@19.1.5)(@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)':
     dependencies:
       '@coinbase/wallet-sdk': 4.3.0
       '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
-      '@wagmi/core': 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
+      '@wagmi/core': 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
       '@walletconnect/ethereum-provider': 2.20.2(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       viem: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
@@ -15814,14 +15829,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))':
+  '@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.8.3)
       viem: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       zustand: 5.0.0(@types/react@19.1.5)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
     optionalDependencies:
-      '@tanstack/query-core': 5.77.1
+      '@tanstack/query-core': 5.85.9
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/react'
@@ -15829,14 +15844,14 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))':
+  '@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.8.3)
       viem: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
       zustand: 5.0.0(@types/react@19.1.5)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     optionalDependencies:
-      '@tanstack/query-core': 5.77.1
+      '@tanstack/query-core': 5.85.9
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/react'
@@ -22922,11 +22937,49 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  wagmi@2.15.4(@tanstack/query-core@5.77.1)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28):
+  wagmi@2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.77.1(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28):
     dependencies:
       '@tanstack/react-query': 5.77.1(react@19.1.0)
-      '@wagmi/connectors': 5.8.3(@types/react@19.1.5)(@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
-      '@wagmi/core': 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.77.1)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
+      '@wagmi/connectors': 5.8.3(@types/react@19.1.5)(@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+      '@wagmi/core': 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
+      react: 19.1.0
+      use-sync-external-store: 1.4.0(react@19.1.0)
+      viem: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - immer
+      - ioredis
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  wagmi@2.15.4(@tanstack/query-core@5.85.9)(@tanstack/react-query@5.85.9(react@19.1.0))(@types/react@19.1.5)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28):
+    dependencies:
+      '@tanstack/react-query': 5.85.9(react@19.1.0)
+      '@wagmi/connectors': 5.8.3(@types/react@19.1.5)(@wagmi/core@2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))(zod@3.25.28)
+      '@wagmi/core': 2.17.2(patch_hash=049ef0ca2574b9586b51482584b89fb1376b94c1a64fe84d4c0ed4a1e795d9f3)(@tanstack/query-core@5.85.9)(@types/react@19.1.5)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28))
       react: 19.1.0
       use-sync-external-store: 1.4.0(react@19.1.0)
       viem: 2.37.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.28)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   "@svgr/core": "^8.1.0"
   "@svgr/plugin-jsx": "^8.1.0"
   "@tanstack/query-sync-storage-persister": "^5.74.3"
-  "@tanstack/react-query": "^5.74.3"
+  "@tanstack/react-query": "^5.81.5"
   "@tanstack/react-query-persist-client": "^5.74.3"
   "@tanstack/react-router": "^1.114.25"
   "@tanstack/router-plugin": "^1.114.17"

--- a/src/wagmi/internal/core.ts
+++ b/src/wagmi/internal/core.ts
@@ -222,13 +222,12 @@ export declare namespace getAssets {
 
 export async function getPermissions<config extends Config>(
   config: config,
-  parameters: getPermissions.Parameters<config> = {},
+  parameters: getPermissions.Parameters = {},
 ): Promise<getPermissions.ReturnType> {
-  const { address, chainId, connector } = parameters
+  const { address, connector } = parameters
 
   const client = await getConnectorClient(config, {
     account: address,
-    chainId,
     connector,
   })
 
@@ -236,9 +235,7 @@ export async function getPermissions<config extends Config>(
 }
 
 export declare namespace getPermissions {
-  type Parameters<config extends Config = Config> = ChainIdParameter<config> &
-    ConnectorParameter &
-    WalletActions.getPermissions.Parameters
+  type Parameters = ConnectorParameter & WalletActions.getPermissions.Parameters
 
   type ReturnType = WalletActions.getPermissions.ReturnType
 

--- a/src/wagmi/internal/query.ts
+++ b/src/wagmi/internal/query.ts
@@ -20,7 +20,7 @@ export declare namespace getAdminsQueryKey {
 }
 
 export function getPermissionsQueryKey<config extends Config>(
-  options: getPermissions.Parameters<config> = {},
+  options: getPermissions.Parameters = {},
 ) {
   const { connector, ...parameters } = options
   return [


### PR DESCRIPTION
- [#relay 1254](https://github.com/ithacaxyz/relay/pull/1254) updates `wallet_getKeys` (what permissions use under the hood) to be multichain, accepting optional `chainIds` instead of a single `chainId` and returning public keys for all supported chains by default,
- [porto 778](https://github.com/ithacaxyz/porto/pull/778) introduces multichain permissions to core Porto SDK, reflecting the relay change,
- this updates the porto Wagmi hook to match the behavior of `provider.request({ method: 'wallet_getPermissions' })` and wires up multichain permissions data in the new `id` dashboard.