### PR TITLE
chore: dedupe keys while preserving per-chain session keys

### DIFF
--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -370,9 +370,11 @@ export function dialog(parameters: dialog.Parameters = {}) {
           )
         })()
 
-        return U.uniqBy(
-          [...keys, ...(account.keys ?? [])],
-          (key) => key.publicKey,
+        // deduplicate keys while preserving per-chain session keys
+        return U.uniqBy([...keys, ...(account.keys ?? [])], (key) =>
+          key.role === 'session'
+            ? `${key.publicKey}:${key.chainId ?? ''}`
+            : key.publicKey,
         )
       },
 

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -271,9 +271,11 @@ export function relay(parameters: relay.Parameters = {}) {
           chainIds,
         })
 
-        return U.uniqBy(
-          [...keys, ...(account.keys ?? [])],
-          (key) => key.publicKey,
+        // deduplicate keys while preserving per-chain session keys
+        return U.uniqBy([...keys, ...(account.keys ?? [])], (key) =>
+          key.role === 'session'
+            ? `${key.publicKey}:${key.chainId ?? ''}`
+            : key.publicKey,
         )
       },
 


### PR DESCRIPTION
Deduplicates keys while preserving per-chain session keys.

- Admin keys: global (no chain scoping) -> should be unique by `publicKey`
- Session keys: chain-scoped -> should be unique by `publicKey:chainId`