### PR TITLE
feat: forward `webAuthn` adapters into signing paths on native

### DIFF
--- a/.changeset/angry-knives-tease.md
+++ b/.changeset/angry-knives-tease.md
@@ -1,0 +1,7 @@
+---
+"porto": patch
+---
+
+Fix: forward `webAuthn` adapters into signing paths for `Mode.Relay`.
+
+- This prevents WebAuthn signing on React Native from defaulting to `window.navigator.credentials`, which is undefined on native.

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -836,6 +836,7 @@ export function relay(parameters: relay.Parameters = {}) {
         const signature = await Account.sign(account, {
           key,
           payload: PersonalMessage.getSignPayload(data),
+          webAuthn,
         })
 
         return Erc8010.wrap(client, { address: account.address, signature })
@@ -858,6 +859,7 @@ export function relay(parameters: relay.Parameters = {}) {
           payload: TypedData.getSignPayload(data),
           // If the domain is the Orchestrator, we don't need to replay-safe sign.
           replaySafe: !isOrchestrator,
+          webAuthn,
         })
 
         return isOrchestrator
@@ -897,6 +899,7 @@ export function relay(parameters: relay.Parameters = {}) {
         const signature = await Account.sign(account, {
           key,
           payload: Hash.keccak256(Hex.fromString(`${email}${token}`)),
+          webAuthn,
         })
 
         return await RelayActions.verifyEmail(client, {

--- a/src/viem/Account.ts
+++ b/src/viem/Account.ts
@@ -3,6 +3,7 @@ import type * as Hex from 'ox/Hex'
 import * as Secp256k1 from 'ox/Secp256k1'
 import * as Signature from 'ox/Signature'
 import * as TypedData from 'ox/TypedData'
+import type * as WebAuthnP256 from 'ox/WebAuthnP256'
 import {
   hashMessage,
   hashTypedData,
@@ -184,7 +185,7 @@ export async function sign(
   account: Account,
   parameters: sign.Parameters,
 ): Promise<Compute<Hex.Hex>> {
-  const { storage, replaySafe = true, wrap = true } = parameters
+  const { storage, replaySafe = true, wrap = true, webAuthn } = parameters
 
   const key = getKey(account, parameters)
 
@@ -212,6 +213,7 @@ export async function sign(
         address: null,
         payload: hash,
         storage,
+        webAuthn,
         wrap,
       })
   })()
@@ -255,5 +257,16 @@ export declare namespace sign {
      * Whether to wrap the signature with key metadata.
      */
     wrap?: boolean | undefined
+    /**
+     * WebAuthn helpers for non-browser environments (e.g., React Native passkeys).
+     */
+    webAuthn?:
+      | {
+          createFn?:
+            | WebAuthnP256.createCredential.Options['createFn']
+            | undefined
+          getFn?: WebAuthnP256.sign.Options['getFn'] | undefined
+        }
+      | undefined
   }
 }


### PR DESCRIPTION
- `src/viem/Account.ts`: added optional `webAuthn` to `sign.Parameters` and forward to `Key.sign`.
- `src/core/internal/modes/relay.ts`: passed `webAuthn` through for `signPersonalMessage`, `signTypedData`, and `verifyEmail` actions.

Without passing `webAuthn` down in Relay Actions, `Key.sign` → `WebAuthnP256.sign` uses the default `window.navigator.credentials` on native, causing `Cannot read property 'get' of undefined`. 