### PR TITLE
fix(worker): deploy when `trusted-hosts.ts` is updated

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'apps/service/**'
+      - 'apps/~internal/**'
+      - 'src/trusted-hosts.ts'
+      - '.github/workflows/deploy-workers.yml'
   workflow_dispatch:
 
 concurrency:

--- a/apps/service/env.d.ts
+++ b/apps/service/env.d.ts
@@ -1,3 +1,5 @@
+declare const __APP_VERSION__: string
+
 interface EnvironmentVariables {
   readonly ENVIRONMENT: 'local' | 'production'
 

--- a/apps/service/src/index.ts
+++ b/apps/service/src/index.ts
@@ -24,7 +24,7 @@ app.use(trimTrailingSlash())
 app.get('/', (context) =>
   context.json({
     routes: ['/cors', '/verify', '/snapshot'],
-    version: context.env.WORKERS_CI_COMMIT_SHA ?? 'running locally',
+    version: __APP_VERSION__,
   }),
 )
 

--- a/apps/service/vite.config.ts
+++ b/apps/service/vite.config.ts
@@ -1,7 +1,15 @@
+import ChildProcess from 'node:child_process'
 import { cloudflare } from '@cloudflare/vite-plugin'
 import { defineConfig } from 'vite'
 
+const commitSha =
+  ChildProcess.execSync('git rev-parse --short HEAD').toString().trim() ||
+  process.env.WORKERS_CI_COMMIT_SHA?.slice(0, 7)
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(commitSha),
+  },
   plugins: [cloudflare()],
   server: {
     cors: false,


### PR DESCRIPTION
- fix: `app.uniswap.org` is `unknown` because worker didn't deploy when `trusted-hosts.ts` was updated:
	<img width="911" height="202" alt="image" src="https://github.com/user-attachments/assets/366be251-27cd-44a0-b563-ed8ca988725d" />

- fix: the `version` always showed `running locally` - now it shows the actual version (aka commit sha)