### PR TITLE
Add ENS to trusted-hosts.ts

### DIFF
--- a/src/trusted-hosts.ts
+++ b/src/trusted-hosts.ts
@@ -19,4 +19,5 @@ export const hostnames = [
   'jumper.exchange',
   'playground.li.fi',
   'happypath.enso.build',
+  'app.ens.domains',
 ]


### PR DESCRIPTION
Ensures https://github.com/ensdomains/ens-app-v3/pull/1057 works consistently across browsers as [recommended in the docs](https://porto.sh/sdk/production#1-trusted-hosts)