### PR TITLE
fix: async stuff and module paths

### DIFF
--- a/scripts/relay:up.ts
+++ b/scripts/relay:up.ts
@@ -4,6 +4,7 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { createClient, http } from 'viem'
 import * as RelayActions from '../src/viem/RelayActions.js'
 
@@ -30,50 +31,54 @@ const versionRegex = /v?(\d+\.\d+\.\d+)/
 
 let version = process.argv[2]
 
-if (!version) {
-  console.log(`No version provided, fetching latest from ${relayUrl}...\n`)
-  try {
-    const client = createClient({
-      transport: http(relayUrl),
-    })
+const main = async () => {
+  if (!version) {
+    console.log(`No version provided, fetching latest from ${relayUrl}...\n`)
+    try {
+      const client = createClient({
+        transport: http(relayUrl),
+      })
 
-    const health = await RelayActions.health(client)
+      const health = await RelayActions.health(client)
 
-    // Extract version from response like "23.0.8-dev (54a851c)" -> "23.0.8"
-    const match = health.version.match(versionRegex)
-    if (!match) {
-      console.error(
-        'Could not extract version from health response:',
-        health.version,
-      )
+      const match = health.version.match(versionRegex)
+      if (!match) {
+        console.error(
+          'Could not extract version from health response:',
+          health.version,
+        )
+        process.exit(1)
+      }
+
+      version = match[1]
+    } catch (error) {
+      console.error(`❌ Failed to fetch version from ${relayUrl}:`, error)
+      console.error('Please provide a version as the first argument')
+      console.error('Usage: pnpm relay:up <version>')
+      console.error('Example: pnpm relay:up 23.1.0')
       process.exit(1)
     }
+  }
 
-    version = match[1]
-  } catch (error) {
-    console.error(`❌ Failed to fetch version from ${relayUrl}:`, error)
-    console.error('Please provide a version as the first argument')
-    console.error('Usage: pnpm relay:up <version>')
-    console.error('Example: pnpm relay:up 23.1.0')
+  const match = version?.match(versionRegex)
+  if (!match) {
+    console.error(`❌ Invalid version: ${version}`)
+    console.error('Please provide a version in the format of x.x.x')
     process.exit(1)
   }
+
+  version = match[1]
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const rootDir = path.resolve(__dirname, '..')
+  for (const { path: relativePath, find, replace } of updateFiles(version)) {
+    const filePath = path.resolve(rootDir, relativePath)
+    let content = fs.readFileSync(filePath, 'utf8')
+    content = content.replace(find, replace)
+    fs.writeFileSync(filePath, content)
+  }
+
+  console.log(`Successfully updated Relay to ${version}`)
 }
 
-const match = version?.match(versionRegex)
-if (!match) {
-  console.error(`❌ Invalid version: ${version}`)
-  console.error('Please provide a version in the format of x.x.x')
-  process.exit(1)
-}
-
-version = match[1]
-
-const rootDir = path.resolve(import.meta.dirname, '..')
-for (const { path: relativePath, find, replace } of updateFiles(version!)) {
-  const filePath = path.resolve(rootDir, relativePath)
-  let content = fs.readFileSync(filePath, 'utf8')
-  content = content.replace(find, replace)
-  fs.writeFileSync(filePath, content)
-}
-
-console.log(`Successfully updated Relay to ${version}`)
+main()


### PR DESCRIPTION
wrapped the async code in `async function main()` so Node.js doesn’t choke on top-level await.
swapped `import.meta.dirname` for `__dirname` using `fileURLToPath` - Node way works here.
cleaned up some unnecessary `!` after version checks, makes the code a bit safer and easier to read.
