### PR TITLE
remove unused useWalletClient.Parameters type

### DIFF
--- a/src/remote/Hooks.ts
+++ b/src/remote/Hooks.ts
@@ -186,9 +186,3 @@ export function useWalletClient<
 >(porto: Pick<Remote.Porto<chains>, '_internal' | 'provider'>) {
   return useMemo(() => WalletClient.fromPorto(porto), [porto])
 }
-
-export namespace useWalletClient {
-  export type Parameters = {
-    chainId?: number | undefined
-  }
-}


### PR DESCRIPTION
The useWalletClient hook is intentionally chain-agnostic and builds a Viem client solely from the Porto EIP-1193 provider. WalletClient.fromPorto does not accept a chainId, and the config type explicitly omits chain. The useWalletClient.Parameters namespace suggesting a chainId option was a leftover, unused, and misleading API surface. Removing it prevents confusion, aligns with current implementation and docs, and keeps the hook’s API accurate without changing runtime behavior.