### PR TITLE
fix: exclude `clipboard-write` permission when firefox

### DIFF
--- a/.changeset/loud-pens-look.md
+++ b/.changeset/loud-pens-look.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Excluded `clipboard-write` permission from `allow` in `iframe` when browser is Firefox

--- a/src/core/Dialog.ts
+++ b/src/core/Dialog.ts
@@ -99,10 +99,14 @@ export function iframe(options: iframe.Options = {}) {
 
       const iframe = document.createElement('iframe')
       iframe.setAttribute('data-testid', 'porto')
-      iframe.setAttribute(
-        'allow',
-        `publickey-credentials-get ${hostUrl.origin}; publickey-credentials-create ${hostUrl.origin}; clipboard-write`,
-      )
+      const iframeAllow = [
+        `publickey-credentials-get ${hostUrl.origin}`,
+        `publickey-credentials-create ${hostUrl.origin}`,
+      ]
+
+      if (!UserAgent.isFirefox()) iframeAllow.push('clipboard-write')
+
+      iframe.setAttribute('allow', iframeAllow.join('; '))
       iframe.setAttribute('tabindex', '0')
       iframe.setAttribute(
         'sandbox',

--- a/src/core/internal/userAgent.ts
+++ b/src/core/internal/userAgent.ts
@@ -11,6 +11,14 @@ export function isSafari() {
   return ua.includes('safari') && !ua.includes('chrome')
 }
 
+export function isFirefox() {
+  const ua = navigator.userAgent.toLowerCase()
+  return (
+    (ua.includes('firefox') || ua.includes('fxios')) &&
+    !ua.includes('seamonkey')
+  )
+}
+
 export function isMobile() {
   if (window.navigator?.userAgentData?.mobile) return true
 


### PR DESCRIPTION
https://caniuse.com/mdn-api_permissions_permission_clipboard-write