### PR TITLE
fix: relay mode loadAccounts and sendCalls

### DIFF
--- a/.changeset/silver-squids-brush.md
+++ b/.changeset/silver-squids-brush.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added `webAuthn` usage downstream to `Mode.relay`.

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -428,8 +428,8 @@ export function relay(parameters: relay.Parameters = {}) {
                       id: credentialId!,
                       publicKey: PublicKey.fromHex(key.publicKey),
                     },
-                    rpId: keystoreHost,
                     id: address,
+                    rpId: keystoreHost,
                   })
               }
               return key
@@ -737,7 +737,7 @@ export function relay(parameters: relay.Parameters = {}) {
           key,
           merchantUrl,
           requiredFunds: multichain ? requiredFunds : undefined,
-          webAuthn
+          webAuthn,
         })
 
         if (asTxHash) {

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -289,6 +289,7 @@ export function relay(parameters: relay.Parameters = {}) {
           account,
           authorizeKeys: [authorizeKey],
           feeToken: feeToken?.address,
+          webAuthn,
         })
         await waitForCallsStatus(client, {
           id,
@@ -652,6 +653,7 @@ export function relay(parameters: relay.Parameters = {}) {
             account,
             feeToken: feeToken?.address,
             revokeKeys: [key],
+            webAuthn,
           })
           await waitForCallsStatus(client, {
             id,
@@ -686,6 +688,7 @@ export function relay(parameters: relay.Parameters = {}) {
             account,
             feeToken: feeToken?.address,
             revokeKeys: [key],
+            webAuthn,
           })
           await waitForCallsStatus(client, {
             id,

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -428,6 +428,7 @@ export function relay(parameters: relay.Parameters = {}) {
                       id: credentialId!,
                       publicKey: PublicKey.fromHex(key.publicKey),
                     },
+                    rpId: keystoreHost,
                     id: address,
                   })
               }
@@ -736,6 +737,7 @@ export function relay(parameters: relay.Parameters = {}) {
           key,
           merchantUrl,
           requiredFunds: multichain ? requiredFunds : undefined,
+          webAuthn
         })
 
         if (asTxHash) {

--- a/src/viem/RelayActions.ts
+++ b/src/viem/RelayActions.ts
@@ -452,6 +452,7 @@ export async function sendCalls<
       return await Key.sign(key, {
         address: null,
         payload: digest,
+        webAuthn,
         wrap: false,
       })
     return await account_.sign({

--- a/src/viem/RelayActions.ts
+++ b/src/viem/RelayActions.ts
@@ -22,6 +22,7 @@ import type {
   GetChainParameter,
 } from './internal/utils.js'
 import * as Key from './Key.js'
+import type { relay } from '../core/Mode.js'
 
 export {
   addFaucetFunds,
@@ -395,7 +396,7 @@ export async function sendCalls<
   client: Client<Transport, chain, account>,
   parameters: sendCalls.Parameters<calls, chain, account>,
 ): Promise<sendCalls.ReturnType> {
-  const { account = client.account, chain = client.chain } = parameters
+  const { account = client.account, chain = client.chain, webAuthn } = parameters
 
   if (!chain) throw new Error('`chain` is required.')
 
@@ -426,6 +427,7 @@ export async function sendCalls<
       const signature = await Key.sign(key, {
         address: null,
         payload: digest,
+        webAuthn
       })
       return { context, signature }
     }),
@@ -498,6 +500,7 @@ export declare namespace sendCalls {
         | undefined
       /** Merchant RPC URL. */
       merchantUrl?: string | undefined
+      webAuthn?: relay.Parameters['webAuthn']
     }
 
   export type ReturnType = RelayActions.sendPreparedCalls.ReturnType

--- a/src/viem/RelayActions.ts
+++ b/src/viem/RelayActions.ts
@@ -14,6 +14,7 @@ import type { Chain } from '../core/Chains.js'
 import type * as Capabilities from '../core/internal/relay/schema/capabilities.js'
 import type * as Quotes from '../core/internal/relay/schema/quotes.js'
 import type { OneOf, PartialBy, RequiredBy } from '../core/internal/types.js'
+import type { relay } from '../core/Mode.js'
 import { hostnames } from '../trusted-hosts.js'
 import * as Account from './Account.js'
 import * as RelayActions from './internal/relayActions.js'
@@ -22,7 +23,6 @@ import type {
   GetChainParameter,
 } from './internal/utils.js'
 import * as Key from './Key.js'
-import type { relay } from '../core/Mode.js'
 
 export {
   addFaucetFunds,
@@ -396,7 +396,11 @@ export async function sendCalls<
   client: Client<Transport, chain, account>,
   parameters: sendCalls.Parameters<calls, chain, account>,
 ): Promise<sendCalls.ReturnType> {
-  const { account = client.account, chain = client.chain, webAuthn } = parameters
+  const {
+    account = client.account,
+    chain = client.chain,
+    webAuthn,
+  } = parameters
 
   if (!chain) throw new Error('`chain` is required.')
 
@@ -427,7 +431,7 @@ export async function sendCalls<
       const signature = await Key.sign(key, {
         address: null,
         payload: digest,
-        webAuthn
+        webAuthn,
       })
       return { context, signature }
     }),


### PR DESCRIPTION
### Summary

Fix relay mode functionality by improving account loading and call handling mechanisms.

### Details

- Pass keystoreHost to account creation in loadAccounts
- Pass webAuthn object properly in sendCalls