### PR TITLE
fix: session key validation error

### DIFF
--- a/.changeset/unlucky-hotels-live.md
+++ b/.changeset/unlucky-hotels-live.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Fixed selector check on call permissions.

--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -480,8 +480,8 @@ export async function getAuthorizedExecuteKey(parameters: {
         if (scope.signature) {
           if (!call.data) return false
           const selector = Hex.slice(call.data, 0, 4)
-          if (Hex.validate(scope.signature) && scope.signature !== selector)
-            return false
+          if (Hex.validate(scope.signature))
+            return scope.signature === selector
           if (AbiItem.getSelector(scope.signature) !== selector) return false
         }
         return true


### PR DESCRIPTION
When checking for covered calls in a session key, the control flow erroneously falls through when the scope signature is a hex string and the signature matches the call function selector. This causes an error in the next check when the code tries to pass in the scope signature to AbiItem.getSelector which throws an error "Unable to normalize signature." because it's not a valid human-readable function signature.