### PR TITLE
fix: align comments with correct field definitions in Intent schema

### DIFF
--- a/src/core/internal/relay/schema/intent.ts
+++ b/src/core/internal/relay/schema/intent.ts
@@ -141,8 +141,10 @@ export const Intent = z.union([
      */
     settlerContext: u.hex(),
     /**
-     * The actual total payment amount, requested by the filler.
-     * MUST be less than or equal to `totalPaymentMaxAmount`
+     * The wrapped signature.
+     *
+     * The format is `abi.encodePacked(innerSignature, keyHash, prehash)` for most signatures,
+     * except if it is signed by the EOA root key, in which case `abi.encodePacked(r, s, v)` is valid as well.
      */
     signature: u.hex(),
     /**
@@ -152,10 +154,8 @@ export const Intent = z.union([
      */
     supportedAccountImplementation: u.address(),
     /**
-     * The wrapped signature.
-     *
-     * The format is `abi.encodePacked(innerSignature, keyHash, prehash)` for most signatures,
-     * except if it is signed by the EOA root key, in which case `abi.encodePacked(r, s, v)` is valid as well.
+     * The actual total payment amount, requested by the filler.
+     * MUST be less than or equal to `totalPaymentMaxAmount`
      */
     totalPaymentAmount: u.bigint(),
     /**


### PR DESCRIPTION
This fix ensures proper field documentation alignment to prevent developer confusion and potential implementation errors.

The comments for `signature` and `totalPaymentAmount` fields were swapped:
- "wrapped signature" documentation was incorrectly placed before `totalPaymentAmount` field
- "actual total payment amount" documentation was incorrectly placed before `signature` field

