### PR TITLE
tweak: design alignments

### DIFF
--- a/apps/dialog/src/routes/-components/Swap.tsx
+++ b/apps/dialog/src/routes/-components/Swap.tsx
@@ -202,7 +202,7 @@ export namespace Swap {
     return (
       <div className="flex w-full flex-row items-center gap-[4px]">
         <div className="shrink-0">
-          <TokenIcon size={20} symbol={asset.symbol} />
+          <TokenIcon border={3} size={24} symbol={asset.symbol} />
         </div>
         <div className="flex h-[24px] min-w-0 flex-grow items-center justify-between gap-[8px]">
           <div className="flex min-w-[120px] items-center gap-[4px]">

--- a/apps/dialog/src/routes/-components/Swap.tsx
+++ b/apps/dialog/src/routes/-components/Swap.tsx
@@ -201,10 +201,10 @@ export namespace Swap {
 
     return (
       <div className="flex w-full flex-row items-center gap-[4px]">
-        <div className="shrink-0">
-          <TokenIcon size={24} symbol={asset.symbol} />
+        <div className="flex size-[24px] shrink-0 items-center justify-center rounded-full bg-th_badge">
+          <TokenIcon size={18} symbol={asset.symbol} />
         </div>
-        <div className="flex h-[24px] min-w-0 flex-grow items-center gap-[8px]">
+        <div className="flex h-[24px] min-w-0 flex-grow items-center justify-between gap-[8px]">
           <div className="flex min-w-[120px] items-center gap-[4px]">
             <div
               className="max-w-[120px] truncate font-medium text-[14px] text-th_base"
@@ -222,7 +222,7 @@ export namespace Swap {
             onClick={() => onFiatDisplayChange(!fiatDisplay)}
             style={{ flex: '1 1 auto' }}
           >
-            <div className="flex items-center justify-end">
+            <div className="flex w-full items-center justify-end">
               <span
                 className="truncate"
                 title={fiatDisplay && fiatValue ? fiatValue : tokenValue}

--- a/apps/dialog/src/routes/-components/Swap.tsx
+++ b/apps/dialog/src/routes/-components/Swap.tsx
@@ -201,8 +201,8 @@ export namespace Swap {
 
     return (
       <div className="flex w-full flex-row items-center gap-[4px]">
-        <div className="flex size-[24px] shrink-0 items-center justify-center rounded-full bg-th_badge">
-          <TokenIcon size={18} symbol={asset.symbol} />
+        <div className="shrink-0">
+          <TokenIcon size={20} symbol={asset.symbol} />
         </div>
         <div className="flex h-[24px] min-w-0 flex-grow items-center justify-between gap-[8px]">
           <div className="flex min-w-[120px] items-center gap-[4px]">


### PR DESCRIPTION
Noticed a couple of things were out of alignment with designs while testing, so fixed them.

- Token icon seemed a bit larger than the designs – changed to 20px (same as `Balance` component).
- Swap value not right aligned.

<img width="732" height="336" alt="CleanShot 2025-09-19 at 09 43 20@2x" src="https://github.com/user-attachments/assets/d577aebe-66c5-468a-a370-324202ac1f2b" />

