### PR TITLE
feat: infer `Account#source`

### DIFF
--- a/.changeset/rare-berries-drive.md
+++ b/.changeset/rare-berries-drive.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Inferred `Account#source` based on the `sign` parameter.

--- a/src/viem/Account.test.ts
+++ b/src/viem/Account.test.ts
@@ -67,6 +67,28 @@ describe('from', () => {
       }
     `)
   })
+
+  test('behavior: custom sign', () => {
+    const account = Account.from({
+      address: '0x0000000000000000000000000000000000000000',
+      sign: async () => {
+        return '0x'
+      },
+    })
+
+    expect(account).toMatchInlineSnapshot(`
+      {
+        "address": "0x0000000000000000000000000000000000000000",
+        "keys": undefined,
+        "sign": [Function],
+        "signMessage": [Function],
+        "signTransaction": [Function],
+        "signTypedData": [Function],
+        "source": "privateKey",
+        "type": "local",
+      }
+    `)
+  })
 })
 
 describe('fromPrivateKey', () => {

--- a/src/viem/Account.ts
+++ b/src/viem/Account.ts
@@ -34,6 +34,8 @@ export function from<const account extends from.Parameters>(
   const account = (
     typeof parameters === 'string' ? { address: parameters } : parameters
   ) as from.AccountParameter
+  const source = account.sign ? 'privateKey' : 'porto'
+
   const {
     address,
     sign: sign_,
@@ -44,7 +46,7 @@ export function from<const account extends from.Parameters>(
   } = toAccount({
     address: account.address,
     sign({ hash }) {
-      if (account.source === 'privateKey') return account.sign!({ hash })
+      if (source === 'privateKey') return account.sign!({ hash })
       throw new Error('`sign` not supported on porto accounts.')
     },
     signMessage({ message }) {
@@ -68,15 +70,15 @@ export function from<const account extends from.Parameters>(
     signMessage,
     signTransaction,
     signTypedData,
-    source: account.source ?? 'porto',
+    source,
     type,
   } as never
 }
 
 export declare namespace from {
   type AccountParameter = PartialBy<
-    Pick<Account, 'address' | 'keys' | 'sign' | 'source'>,
-    'sign' | 'source'
+    Pick<Account, 'address' | 'keys' | 'sign'>,
+    'sign'
   >
 
   type Parameters<


### PR DESCRIPTION
Inferred `Account#source` based on the `sign` parameter.