### PR TITLE
Update faq.mdx

### DIFF
--- a/apps/docs/pages/sdk/faq.mdx
+++ b/apps/docs/pages/sdk/faq.mdx
@@ -15,6 +15,7 @@ Porto supports the following browsers:
 - Chrome
 - Firefox
 - Brave
+- Arc
 
 If a browser is not listed above, it likely works but is not officially supported.
 If you would like to request support, please open up a GitHub issue.


### PR DESCRIPTION
Adding Arc to the list of supported browsers.

Reason: Porto works well on Arc