### PR TITLE
feat: add dedupe mechanism to 1193 provider

### DIFF
--- a/.changeset/huge-birds-attack.md
+++ b/.changeset/huge-birds-attack.md
@@ -1,0 +1,5 @@
+---
+"porto": patch
+---
+
+Added EIP-1193 Provider deduplication mechanism.

--- a/src/core/internal/provider.ts
+++ b/src/core/internal/provider.ts
@@ -18,7 +18,8 @@ import * as RpcRequest from './schema/request.js'
 import * as Rpc from './schema/rpc.js'
 import * as Store from './store.js'
 import * as UrlString from './urlString.js'
-import { uuidv4 } from './utils.js'
+import { uuidv4, withDedupe } from './utils.js'
+import * as Json from 'ox/Json'
 
 export type Provider = ox_Provider.Provider<{
   includeEvents: true
@@ -87,1021 +88,1058 @@ export function from<
     async request(request_) {
       await Store.waitForHydration(store)
 
-      let request: RpcRequest.Request
-      try {
-        request = RpcRequest.validate(RpcRequest.Request, request_)
-      } catch (e) {
-        const error = e as Error
-        if (!(error instanceof RpcResponse.MethodNotSupportedError)) throw error
-
-        // catch unsupported methods
-        if ((request_ as { method: string }).method.startsWith('wallet_'))
-          throw new ox_Provider.UnsupportedMethodError()
-        return getClient().request(request_ as any)
-      }
-
-      const state = store.getState()
-
-      switch (request.method) {
-        case 'account_verifyEmail': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [parameters] = request._decoded.params
-          const { chainId, email, token, walletAddress } = parameters
-
-          const client = getClient(chainId)
-
-          if (chainId && chainId !== client.chain.id)
-            throw new ox_Provider.ChainDisconnectedError()
-
-          const account = walletAddress
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, walletAddress),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          return await getMode().actions.verifyEmail({
-            account,
-            chainId,
-            email,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            token,
-            walletAddress,
-          })
-        }
-
-        case 'wallet_addFunds': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const { address, value, token } = request.params[0] ?? {}
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          const result = await getMode().actions.addFunds({
-            address: account.address,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            token,
-            value,
-          })
-
-          emitter.emit('message', {
-            data: null,
-            type: 'assetsChanged',
-          })
-
-          return result
-        }
-
-        case 'eth_accounts': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-          return state.accounts.map(
-            (account) => account.address,
-          ) satisfies z.input<typeof Rpc.eth_accounts.Response>
-        }
-
-        case 'eth_chainId': {
-          return Hex.fromNumber(state.chainIds[0]) satisfies z.input<
-            typeof Rpc.eth_chainId.Response
-          >
-        }
-
-        case 'eth_requestAccounts': {
-          // Some apps will call `eth_requestAccounts` multiple times in a short period of time.
-          // Return the cached accounts if the request is locked.
-          if (state.accounts.length > 0 && lock.get('eth_requestAccounts'))
-            return state.accounts.map(
-              (account) => account.address,
-            ) satisfies z.input<typeof Rpc.eth_requestAccounts.Response>
-
-          const client = getClient()
-
-          const { accounts } = await getMode().actions.loadAccounts({
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-
-          store.setState((x) => ({ ...x, accounts }))
-
-          emitter.emit('connect', {
-            chainId: Hex.fromNumber(client.chain.id),
-          })
-
-          lock.set('eth_requestAccounts', true)
-          setTimeout(() => lock.delete('eth_requestAccounts'), 1_000)
-
-          return accounts.map((account) => account.address) satisfies z.input<
-            typeof Rpc.eth_requestAccounts.Response
-          >
-        }
-
-        case 'eth_sendTransaction': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ capabilities, chainId, data = '0x', from, to, value }] =
-            request._decoded.params
-
-          const client = getClient(chainId)
-
-          if (chainId && chainId !== client.chain.id)
-            throw new ox_Provider.ChainDisconnectedError()
-
-          const account = from
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, from),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const { id } = await getMode().actions.sendCalls({
-            account,
-            asTxHash: true,
-            calls: [
-              {
-                data,
-                to,
-                value,
-              },
-            ],
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            merchantUrl: UrlString.toAbsolute(
-              config.merchantUrl ?? capabilities?.merchantUrl,
-            ),
-          })
-
-          return id satisfies z.input<typeof Rpc.eth_sendTransaction.Response>
-        }
-
-        case 'eth_signTypedData_v4': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [address, data] = request._decoded.params
-
-          const account = state.accounts.find((account) =>
-            Address.isEqual(account.address, address),
-          )
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          const signature = await getMode().actions.signTypedData({
-            account,
-            data,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-
-          return signature satisfies z.input<
-            typeof Rpc.eth_signTypedData_v4.Response
-          >
-        }
-
-        case 'wallet_grantAdmin': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, capabilities, chainId, key: keyToAuthorize }] =
-            request._decoded.params ?? [{}]
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient(chainId)
-
-          const keyExists = getAdmins([...(account.keys ?? [])])?.some(
-            (key) =>
-              key.publicKey?.toLowerCase() ===
-              keyToAuthorize.publicKey.toLowerCase(),
-          )
-          if (keyExists)
-            throw new RpcResponse.InvalidParamsError({
-              message: 'Key already granted as admin.',
-            })
-
-          const { key } = await getMode().actions.grantAdmin({
-            account,
-            feeToken: capabilities?.feeToken,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            key: keyToAuthorize,
-          })
-
-          store.setState((x) => {
-            const index = x.accounts.findIndex((x) =>
-              account ? Address.isEqual(x.address, account.address) : true,
-            )
-            if (index === -1) return x
-            return {
-              ...x,
-              accounts: x.accounts.map((account, i) =>
-                i === index
-                  ? { ...account, keys: [...(account.keys ?? []), key] }
-                  : account,
-              ),
-            }
-          })
-
-          const admins = getAdmins([...(account.keys ?? []), key])
-
-          emitter.emit('message', {
-            data: null,
-            type: 'adminsChanged',
-          })
-
-          return z.encode(Rpc.wallet_grantAdmin.Response, {
-            address: account.address,
-            chainId: client.chain.id,
-            key: admins.at(-1)!,
-          })
-        }
-
-        case 'wallet_grantPermissions': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, chainId, ...permissions }] = request._decoded
-            .params ?? [{}]
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient(chainId)
-
-          const { key } = await getMode().actions.grantPermissions({
-            account,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            permissions,
-          })
-
-          store.setState((x) => {
-            const index = x.accounts.findIndex((x) =>
-              account ? Address.isEqual(x.address, account.address) : true,
-            )
-            if (index === -1) return x
-            return {
-              ...x,
-              accounts: x.accounts.map((account, i) =>
-                i === index
-                  ? { ...account, keys: [...(account.keys ?? []), key] }
-                  : account,
-              ),
-            }
-          })
-
-          emitter.emit('message', {
-            data: null,
-            type: 'permissionsChanged',
-          })
-
-          return z.encode(Rpc.wallet_grantPermissions.Response, {
-            ...Permissions.fromKey(key, {
-              address: account.address,
-            }),
-          })
-        }
-
-        case 'wallet_getAdmins': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, chainId }] = request._decoded.params ?? [{}]
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient(chainId)
-
-          const keys = await getMode().actions.getKeys({
-            account,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-          const admins = getAdmins(keys)
-
-          return z.encode(Rpc.wallet_getAdmins.Response, {
-            address: account.address,
-            chainId: client.chain.id,
-            keys: admins,
-          })
-        }
-
-        case 'wallet_prepareUpgradeAccount': {
-          const [{ address, capabilities, chainId }] = request._decoded
-            .params ?? [{}]
-
-          const {
-            email,
-            label,
-            grantPermissions: permissions,
-          } = capabilities ?? {}
-
-          const client = getClient(chainId)
-
-          const { context, digests } =
-            await getMode().actions.prepareUpgradeAccount({
-              address,
-              email,
-              internal: {
-                client,
-                config,
-                request,
-                store,
-              },
-              label,
-              permissions,
-            })
-
-          preparedAccounts_internal.push((context as any).account)
-
-          return {
-            context,
-            digests,
-          } satisfies z.input<typeof Rpc.wallet_prepareUpgradeAccount.Response>
-        }
-
-        case 'wallet_getAccountVersion': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address }] = request._decoded.params ?? [{}]
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          const { current, latest } = await getMode().actions.getAccountVersion(
-            {
-              address: account.address,
-              internal: {
-                client,
-                config,
-                request,
-                store,
-              },
-            },
-          )
-
-          return {
-            current,
-            latest,
-          } satisfies z.input<typeof Rpc.wallet_getAccountVersion.Response>
-        }
-
-        case 'wallet_getKeys': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, chainIds }] = request._decoded.params ?? [{}]
-
-          const account = state.accounts.find((account) =>
-            Address.isEqual(account.address, address),
-          )
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          const keys = await getMode().actions.getKeys({
-            account,
-            chainIds,
-            internal: { client, config, request, store },
-          })
-
-          return z.encode(Rpc.wallet_getKeys.Response, keys)
-        }
-
-        case 'wallet_getPermissions': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, chainIds }] = request._decoded.params ?? [{}]
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          const keys = await getMode().actions.getKeys({
-            account,
-            chainIds,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-          const permissions = getActivePermissions(keys, {
-            address: account.address,
-          })
-
-          return permissions satisfies z.input<
-            typeof Rpc.wallet_getPermissions.Response
-          >
-        }
-
-        case 'wallet_revokeAdmin': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, capabilities, id }] = request._decoded.params
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          await getMode().actions.revokeAdmin({
-            account,
-            feeToken: capabilities?.feeToken,
-            id,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-
-          const keys = account.keys?.filter(
-            (key) => key.id.toLowerCase() !== id.toLowerCase(),
-          )
-
-          store.setState((x) => ({
-            ...x,
-            accounts: x.accounts.map((x) =>
-              Address.isEqual(x.address, account.address)
-                ? {
-                    ...x,
-                    keys,
-                  }
-                : x,
-            ),
-          }))
-
-          emitter.emit('message', {
-            data: null,
-            type: 'adminsChanged',
-          })
-
-          return
-        }
-
-        case 'wallet_revokePermissions': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [{ address, capabilities, id }] = request._decoded.params
-
-          const account = address
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, address),
-              )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          await getMode().actions.revokePermissions({
-            account,
-            feeToken: capabilities?.feeToken,
-            id,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-
-          const keys = account.keys?.filter(
-            (key) => key.id.toLowerCase() !== id.toLowerCase(),
-          )
-
-          store.setState((x) => ({
-            ...x,
-            accounts: x.accounts.map((x) =>
-              Address.isEqual(x.address, account.address)
-                ? {
-                    ...x,
-                    keys,
-                  }
-                : x,
-            ),
-          }))
-
-          emitter.emit('message', {
-            data: null,
-            type: 'permissionsChanged',
-          })
-
-          return
-        }
-
-        case 'wallet_upgradeAccount': {
-          const [{ context, signatures }] = request._decoded.params ?? [{}]
-
-          const client = getClient()
-
-          const account_ = preparedAccounts_internal.find((account) =>
-            Address.isEqual(account.address, (context as any).account.address),
-          )
-          if (!account_) throw new ox_Provider.UnauthorizedError()
-
-          const { account } = await getMode().actions.upgradeAccount({
-            account: account_,
-            context,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            signatures,
-          })
-
-          const admins = getAdmins(account.keys ?? [])
-          const permissions = getActivePermissions(account.keys ?? [], {
-            address: account.address,
-          })
-
-          store.setState((x) => ({ ...x, accounts: [account] }))
-
-          emitter.emit('connect', {
-            chainId: Hex.fromNumber(client.chain.id),
-          })
-          return {
-            address: account.address,
-            capabilities: {
-              admins,
-              ...(permissions.length > 0 ? { permissions } : {}),
-            },
-          } satisfies z.input<typeof Rpc.wallet_upgradeAccount.Response>
-        }
-
-        case 'porto_ping': {
-          return 'pong' satisfies z.input<typeof Rpc.porto_ping.Response>
-        }
-
-        case 'personal_sign': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [data, address] = request._decoded.params
-
-          const account = state.accounts.find((account) =>
-            Address.isEqual(account.address, address),
-          )
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          const client = getClient()
-
-          const signature = await getMode().actions.signPersonalMessage({
-            account,
-            data,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
-
-          return signature satisfies z.input<typeof Rpc.personal_sign.Response>
-        }
-
-        case 'wallet_connect': {
-          const [{ capabilities, chainIds }] = request._decoded.params ?? [{}]
-
-          const client = getClient(chainIds?.[0])
-          const chainId = client.chain.id
-
-          const {
-            createAccount,
-            email,
-            grantAdmins: admins,
-            grantPermissions: permissions,
-            selectAccount,
-            signInWithEthereum,
-          } = capabilities ?? {}
-
-          const internal = {
-            client,
-            config,
-            request,
-            store,
+      // we should deduplicate all immutable public methods to avoid
+      // unnecessary perf overhead or dialog requests.
+      const shouldDedupe = [
+        'eth_accounts',
+        'eth_chainId',
+        'eth_requestAccounts',
+        'wallet_getAssets',
+        'wallet_getCapabilities',
+        'wallet_getKeys',
+        'wallet_getPermissions',
+        'wallet_getAccountVersion',
+        'wallet_connect',
+      ].includes(request_.method)
+
+      return withDedupe(
+        async () => {
+          let request: RpcRequest.Request
+          try {
+            request = RpcRequest.validate(RpcRequest.Request, request_)
+          } catch (e) {
+            const error = e as Error
+            if (!(error instanceof RpcResponse.MethodNotSupportedError))
+              throw error
+
+            // catch unsupported methods
+            if ((request_ as { method: string }).method.startsWith('wallet_'))
+              throw new ox_Provider.UnsupportedMethodError()
+            return getClient().request(request_ as any)
           }
 
-          const { accounts } = await (async () => {
-            if (email || createAccount) {
-              const { label = undefined } =
-                typeof createAccount === 'object' ? createAccount : {}
-              const { account } = await getMode().actions.createAccount({
-                admins,
+          const state = store.getState()
+
+          switch (request.method) {
+            case 'account_verifyEmail': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [parameters] = request._decoded.params
+              const { chainId, email, token, walletAddress } = parameters
+
+              const client = getClient(chainId)
+
+              if (chainId && chainId !== client.chain.id)
+                throw new ox_Provider.ChainDisconnectedError()
+
+              const account = walletAddress
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, walletAddress),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              return await getMode().actions.verifyEmail({
+                account,
+                chainId,
                 email,
-                internal,
-                label,
-                permissions,
-                signInWithEthereum,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                token,
+                walletAddress,
               })
-              return { accounts: [account] }
             }
-            const account = state.accounts[0]
-            const { address, key } = (() => {
-              if (selectAccount) {
-                if (typeof selectAccount === 'object') return selectAccount
-                return {
-                  address: undefined,
-                  key: undefined,
-                }
-              }
-              for (const key of account?.keys ?? []) {
-                if (key.type === 'webauthn-p256' && key.role === 'admin')
-                  return {
-                    address: account?.address,
-                    key: {
-                      credentialId:
-                        (key as any).credentialId ??
-                        key.privateKey?.credential?.id,
-                      publicKey: key.publicKey,
-                    },
-                  }
-              }
-              return {
-                address: undefined,
-                key: undefined,
-              }
-            })()
-            const loadAccountsParams = {
-              internal,
-              permissions,
-              signInWithEthereum,
-            }
-            try {
-              // try to restore from stored account (`address`/`key`) to avoid multiple prompts
-              return await getMode().actions.loadAccounts({
-                address,
-                key,
-                ...loadAccountsParams,
+
+            case 'wallet_addFunds': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const { address, value, token } = request.params[0] ?? {}
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              const result = await getMode().actions.addFunds({
+                address: account.address,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                token,
+                value,
               })
-            } catch (error) {
-              if (error instanceof ox_Provider.UserRejectedRequestError)
-                throw error
 
-              // error with `address`/`key` likely means one or both are stale, retry
-              if (address && key)
-                return await getMode().actions.loadAccounts(loadAccountsParams)
-              throw error
+              emitter.emit('message', {
+                data: null,
+                type: 'assetsChanged',
+              })
+
+              return result
             }
-          })()
 
-          store.setState((x) => ({ ...x, accounts }))
+            case 'eth_accounts': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+              return state.accounts.map(
+                (account) => account.address,
+              ) satisfies z.input<typeof Rpc.eth_accounts.Response>
+            }
 
-          const chainIds_response = [
-            chainId,
-            ...store.getState().chainIds.filter((id) => id !== chainId),
-          ] as const
+            case 'eth_chainId': {
+              return Hex.fromNumber(state.chainIds[0]) satisfies z.input<
+                typeof Rpc.eth_chainId.Response
+              >
+            }
 
-          emitter.emit('connect', {
-            chainId: Hex.fromNumber(chainIds_response[0]),
-          })
+            case 'eth_requestAccounts': {
+              // Some apps will call `eth_requestAccounts` multiple times in a short period of time.
+              // Return the cached accounts if the request is locked.
+              if (state.accounts.length > 0 && lock.get('eth_requestAccounts'))
+                return state.accounts.map(
+                  (account) => account.address,
+                ) satisfies z.input<typeof Rpc.eth_requestAccounts.Response>
 
-          return {
-            accounts: accounts.map((account) => ({
-              address: account.address,
-              capabilities: {
-                admins: account.keys ? getAdmins(account.keys) : [],
-                permissions: account.keys
-                  ? getActivePermissions(account.keys, {
-                      address: account.address,
-                    })
-                  : [],
-                ...(account.signInWithEthereum && {
-                  signInWithEthereum: account.signInWithEthereum,
-                }),
-              },
-            })),
-            chainIds: chainIds_response.map((chainId) =>
-              Hex.fromNumber(chainId),
-            ),
-          } satisfies z.input<typeof Rpc.wallet_connect.Response>
-        }
+              const client = getClient()
 
-        case 'wallet_disconnect': {
-          const client = getClient()
+              const { accounts } = await getMode().actions.loadAccounts({
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
 
-          await getMode().actions.disconnect?.({
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
+              store.setState((x) => ({ ...x, accounts }))
 
-          store.setState((x) => ({ ...x, accounts: [] }))
-          emitter.emit('disconnect', new ox_Provider.DisconnectedError())
-          return
-        }
+              emitter.emit('connect', {
+                chainId: Hex.fromNumber(client.chain.id),
+              })
 
-        case 'wallet_getAssets': {
-          const [parameters] = request._decoded.params ?? []
-          const { account, chainFilter, assetFilter, assetTypeFilter } =
-            parameters
+              lock.set('eth_requestAccounts', true)
+              setTimeout(() => lock.delete('eth_requestAccounts'), 1_000)
 
-          const client = getClient()
+              return accounts.map(
+                (account) => account.address,
+              ) satisfies z.input<typeof Rpc.eth_requestAccounts.Response>
+            }
 
-          const response = await getMode().actions.getAssets({
-            account,
-            assetFilter,
-            assetTypeFilter,
-            chainFilter,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
+            case 'eth_sendTransaction': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
 
-          const value = Object.entries(response).reduce(
-            (acc, [key, value]) => {
-              acc[Hex.fromNumber(Number(key))] = value
-              return acc
-            },
-            {} as Record<string, ValueOf<typeof response>>,
-          )
+              const [{ capabilities, chainId, data = '0x', from, to, value }] =
+                request._decoded.params
 
-          return z.encode(Rpc.wallet_getAssets.Response, value)
-        }
+              const client = getClient(chainId)
 
-        case 'wallet_getCallsStatus': {
-          const [id] = request._decoded.params ?? []
+              if (chainId && chainId !== client.chain.id)
+                throw new ox_Provider.ChainDisconnectedError()
 
-          const client = getClient()
+              const account = from
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, from),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
 
-          const response = await getMode().actions.getCallsStatus({
-            id,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
+              const { id } = await getMode().actions.sendCalls({
+                account,
+                asTxHash: true,
+                calls: [
+                  {
+                    data,
+                    to,
+                    value,
+                  },
+                ],
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                merchantUrl: UrlString.toAbsolute(
+                  config.merchantUrl ?? capabilities?.merchantUrl,
+                ),
+              })
 
-          return response satisfies z.input<
-            typeof Rpc.wallet_getCallsStatus.Response
-          >
-        }
+              return id satisfies z.input<
+                typeof Rpc.eth_sendTransaction.Response
+              >
+            }
 
-        case 'wallet_getCapabilities': {
-          const [_, chainIds] = request.params ?? []
+            case 'eth_signTypedData_v4': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
 
-          const capabilities = await getCapabilities({
-            chainIds,
-            request,
-          })
+              const [address, data] = request._decoded.params
 
-          return capabilities
-        }
-
-        case 'wallet_prepareCalls': {
-          const [parameters] = request._decoded.params
-          const { calls, capabilities, chainId, key, from } = parameters
-
-          const client = getClient(chainId)
-
-          const account = from ?? state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
-
-          if (chainId && chainId !== client.chain.id)
-            throw new ox_Provider.ChainDisconnectedError()
-
-          const { digest, ...rest } = await getMode().actions.prepareCalls({
-            account: Account.from(account),
-            calls,
-            feeToken: capabilities?.feeToken,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            key,
-            merchantUrl: UrlString.toAbsolute(
-              config.merchantUrl ?? capabilities?.merchantUrl,
-            ),
-            requiredFunds: capabilities?.requiredFunds,
-          })
-
-          return z.encode(Rpc.wallet_prepareCalls.Response, {
-            capabilities: rest.capabilities,
-            chainId: Hex.fromNumber(rest.chainId ?? client.chain.id),
-            context: {
-              ...rest.context,
-              account: {
-                address: rest.account.address,
-              },
-              calls: rest.context.calls ?? [],
-              nonce: rest.context.nonce ?? 0n,
-            },
-            digest,
-            key: rest.key,
-            typedData: rest.typedData,
-          })
-        }
-
-        case 'wallet_sendPreparedCalls': {
-          const [parameters] = request._decoded.params
-          const { chainId, context, key, signature } = parameters
-          const { account } = parameters.context
-
-          const client = getClient(chainId)
-
-          if (chainId && Hex.toNumber(chainId) !== client.chain.id)
-            throw new ox_Provider.ChainDisconnectedError()
-
-          const hash = await getMode().actions.sendPreparedCalls({
-            account: Account.from(account),
-            context,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            key,
-            signature,
-          })
-
-          return [{ id: hash }] satisfies z.input<
-            typeof Rpc.wallet_sendPreparedCalls.Response
-          >
-        }
-
-        case 'wallet_sendCalls': {
-          if (state.accounts.length === 0)
-            throw new ox_Provider.DisconnectedError()
-
-          const [parameters] = request._decoded.params
-          const { calls, capabilities, chainId, from } = parameters
-
-          const client = getClient(chainId)
-
-          if (chainId && chainId !== client.chain.id)
-            throw new ox_Provider.ChainDisconnectedError()
-
-          const account = from
-            ? state.accounts.find((account) =>
-                Address.isEqual(account.address, from),
+              const account = state.accounts.find((account) =>
+                Address.isEqual(account.address, address),
               )
-            : state.accounts[0]
-          if (!account) throw new ox_Provider.UnauthorizedError()
+              if (!account) throw new ox_Provider.UnauthorizedError()
 
-          const { id } = await getMode().actions.sendCalls({
-            account,
-            calls,
-            feeToken: capabilities?.feeToken,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-            merchantUrl: UrlString.toAbsolute(
-              config.merchantUrl ?? capabilities?.merchantUrl,
-            ),
-            permissionsId: capabilities?.permissions?.id,
-            requiredFunds: capabilities?.requiredFunds,
-          })
+              const client = getClient()
 
-          return { id } satisfies z.input<typeof Rpc.wallet_sendCalls.Response>
-        }
+              const signature = await getMode().actions.signTypedData({
+                account,
+                data,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
 
-        case 'wallet_switchEthereumChain': {
-          const [parameters] = request._decoded.params
-          const { chainId } = parameters
-          const chainId_number = Hex.toNumber(chainId)
+              return signature satisfies z.input<
+                typeof Rpc.eth_signTypedData_v4.Response
+              >
+            }
 
-          const chain = config.chains.find(
-            (chain) => chain.id === chainId_number,
-          )
-          if (!chain) throw new ox_Provider.UnsupportedChainIdError()
+            case 'wallet_grantAdmin': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
 
-          const client = getClient(chainId)
-          await getMode().actions.switchChain?.({
-            chainId: client.chain.id,
-            internal: {
-              client,
-              config,
-              request,
-              store,
-            },
-          })
+              const [{ address, capabilities, chainId, key: keyToAuthorize }] =
+                request._decoded.params ?? [{}]
 
-          store.setState((state) => ({
-            ...state,
-            chainIds: [
-              chainId_number,
-              ...state.chainIds.filter((id) => id !== chainId_number),
-            ],
-          }))
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
 
-          return undefined
-        }
+              const client = getClient(chainId)
 
-        case 'wallet_verifySignature': {
-          const [parameters] = request._decoded.params
-          const { address, chainId, digest, signature } = parameters
+              const keyExists = getAdmins([...(account.keys ?? [])])?.some(
+                (key) =>
+                  key.publicKey?.toLowerCase() ===
+                  keyToAuthorize.publicKey.toLowerCase(),
+              )
+              if (keyExists)
+                throw new RpcResponse.InvalidParamsError({
+                  message: 'Key already granted as admin.',
+                })
 
-          const client = getClient(chainId)
+              const { key } = await getMode().actions.grantAdmin({
+                account,
+                feeToken: capabilities?.feeToken,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                key: keyToAuthorize,
+              })
 
-          const result = await Actions.verifySignature(client, {
-            address,
-            digest,
-            signature,
-          })
+              store.setState((x) => {
+                const index = x.accounts.findIndex((x) =>
+                  account ? Address.isEqual(x.address, account.address) : true,
+                )
+                if (index === -1) return x
+                return {
+                  ...x,
+                  accounts: x.accounts.map((account, i) =>
+                    i === index
+                      ? { ...account, keys: [...(account.keys ?? []), key] }
+                      : account,
+                  ),
+                }
+              })
 
-          return {
-            ...result,
-            address,
-            chainId: Hex.fromNumber(client.chain.id),
-          } satisfies z.input<typeof Rpc.wallet_verifySignature.Response>
-        }
-      }
+              const admins = getAdmins([...(account.keys ?? []), key])
+
+              emitter.emit('message', {
+                data: null,
+                type: 'adminsChanged',
+              })
+
+              return z.encode(Rpc.wallet_grantAdmin.Response, {
+                address: account.address,
+                chainId: client.chain.id,
+                key: admins.at(-1)!,
+              })
+            }
+
+            case 'wallet_grantPermissions': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address, chainId, ...permissions }] = request._decoded
+                .params ?? [{}]
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient(chainId)
+
+              const { key } = await getMode().actions.grantPermissions({
+                account,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                permissions,
+              })
+
+              store.setState((x) => {
+                const index = x.accounts.findIndex((x) =>
+                  account ? Address.isEqual(x.address, account.address) : true,
+                )
+                if (index === -1) return x
+                return {
+                  ...x,
+                  accounts: x.accounts.map((account, i) =>
+                    i === index
+                      ? { ...account, keys: [...(account.keys ?? []), key] }
+                      : account,
+                  ),
+                }
+              })
+
+              emitter.emit('message', {
+                data: null,
+                type: 'permissionsChanged',
+              })
+
+              return z.encode(Rpc.wallet_grantPermissions.Response, {
+                ...Permissions.fromKey(key, {
+                  address: account.address,
+                }),
+              })
+            }
+
+            case 'wallet_getAdmins': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address, chainId }] = request._decoded.params ?? [{}]
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient(chainId)
+
+              const keys = await getMode().actions.getKeys({
+                account,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+              const admins = getAdmins(keys)
+
+              return z.encode(Rpc.wallet_getAdmins.Response, {
+                address: account.address,
+                chainId: client.chain.id,
+                keys: admins,
+              })
+            }
+
+            case 'wallet_prepareUpgradeAccount': {
+              const [{ address, capabilities, chainId }] = request._decoded
+                .params ?? [{}]
+
+              const {
+                email,
+                label,
+                grantPermissions: permissions,
+              } = capabilities ?? {}
+
+              const client = getClient(chainId)
+
+              const { context, digests } =
+                await getMode().actions.prepareUpgradeAccount({
+                  address,
+                  email,
+                  internal: {
+                    client,
+                    config,
+                    request,
+                    store,
+                  },
+                  label,
+                  permissions,
+                })
+
+              preparedAccounts_internal.push((context as any).account)
+
+              return {
+                context,
+                digests,
+              } satisfies z.input<
+                typeof Rpc.wallet_prepareUpgradeAccount.Response
+              >
+            }
+
+            case 'wallet_getAccountVersion': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address }] = request._decoded.params ?? [{}]
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              const { current, latest } =
+                await getMode().actions.getAccountVersion({
+                  address: account.address,
+                  internal: {
+                    client,
+                    config,
+                    request,
+                    store,
+                  },
+                })
+
+              return {
+                current,
+                latest,
+              } satisfies z.input<typeof Rpc.wallet_getAccountVersion.Response>
+            }
+
+            case 'wallet_getKeys': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address, chainIds }] = request._decoded.params ?? [{}]
+
+              const account = state.accounts.find((account) =>
+                Address.isEqual(account.address, address),
+              )
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              const keys = await getMode().actions.getKeys({
+                account,
+                chainIds,
+                internal: { client, config, request, store },
+              })
+
+              return z.encode(Rpc.wallet_getKeys.Response, keys)
+            }
+
+            case 'wallet_getPermissions': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address, chainIds }] = request._decoded.params ?? [{}]
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              const keys = await getMode().actions.getKeys({
+                account,
+                chainIds,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+              const permissions = getActivePermissions(keys, {
+                address: account.address,
+              })
+
+              return permissions satisfies z.input<
+                typeof Rpc.wallet_getPermissions.Response
+              >
+            }
+
+            case 'wallet_revokeAdmin': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address, capabilities, id }] = request._decoded.params
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              await getMode().actions.revokeAdmin({
+                account,
+                feeToken: capabilities?.feeToken,
+                id,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              const keys = account.keys?.filter(
+                (key) => key.id.toLowerCase() !== id.toLowerCase(),
+              )
+
+              store.setState((x) => ({
+                ...x,
+                accounts: x.accounts.map((x) =>
+                  Address.isEqual(x.address, account.address)
+                    ? {
+                        ...x,
+                        keys,
+                      }
+                    : x,
+                ),
+              }))
+
+              emitter.emit('message', {
+                data: null,
+                type: 'adminsChanged',
+              })
+
+              return
+            }
+
+            case 'wallet_revokePermissions': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [{ address, capabilities, id }] = request._decoded.params
+
+              const account = address
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, address),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              await getMode().actions.revokePermissions({
+                account,
+                feeToken: capabilities?.feeToken,
+                id,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              const keys = account.keys?.filter(
+                (key) => key.id.toLowerCase() !== id.toLowerCase(),
+              )
+
+              store.setState((x) => ({
+                ...x,
+                accounts: x.accounts.map((x) =>
+                  Address.isEqual(x.address, account.address)
+                    ? {
+                        ...x,
+                        keys,
+                      }
+                    : x,
+                ),
+              }))
+
+              emitter.emit('message', {
+                data: null,
+                type: 'permissionsChanged',
+              })
+
+              return
+            }
+
+            case 'wallet_upgradeAccount': {
+              const [{ context, signatures }] = request._decoded.params ?? [{}]
+
+              const client = getClient()
+
+              const account_ = preparedAccounts_internal.find((account) =>
+                Address.isEqual(
+                  account.address,
+                  (context as any).account.address,
+                ),
+              )
+              if (!account_) throw new ox_Provider.UnauthorizedError()
+
+              const { account } = await getMode().actions.upgradeAccount({
+                account: account_,
+                context,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                signatures,
+              })
+
+              const admins = getAdmins(account.keys ?? [])
+              const permissions = getActivePermissions(account.keys ?? [], {
+                address: account.address,
+              })
+
+              store.setState((x) => ({ ...x, accounts: [account] }))
+
+              emitter.emit('connect', {
+                chainId: Hex.fromNumber(client.chain.id),
+              })
+              return {
+                address: account.address,
+                capabilities: {
+                  admins,
+                  ...(permissions.length > 0 ? { permissions } : {}),
+                },
+              } satisfies z.input<typeof Rpc.wallet_upgradeAccount.Response>
+            }
+
+            case 'porto_ping': {
+              return 'pong' satisfies z.input<typeof Rpc.porto_ping.Response>
+            }
+
+            case 'personal_sign': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [data, address] = request._decoded.params
+
+              const account = state.accounts.find((account) =>
+                Address.isEqual(account.address, address),
+              )
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const client = getClient()
+
+              const signature = await getMode().actions.signPersonalMessage({
+                account,
+                data,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              return signature satisfies z.input<
+                typeof Rpc.personal_sign.Response
+              >
+            }
+
+            case 'wallet_connect': {
+              const [{ capabilities, chainIds }] = request._decoded.params ?? [
+                {},
+              ]
+
+              const client = getClient(chainIds?.[0])
+              const chainId = client.chain.id
+
+              const {
+                createAccount,
+                email,
+                grantAdmins: admins,
+                grantPermissions: permissions,
+                selectAccount,
+                signInWithEthereum,
+              } = capabilities ?? {}
+
+              const internal = {
+                client,
+                config,
+                request,
+                store,
+              }
+
+              const { accounts } = await (async () => {
+                if (email || createAccount) {
+                  const { label = undefined } =
+                    typeof createAccount === 'object' ? createAccount : {}
+                  const { account } = await getMode().actions.createAccount({
+                    admins,
+                    email,
+                    internal,
+                    label,
+                    permissions,
+                    signInWithEthereum,
+                  })
+                  return { accounts: [account] }
+                }
+                const account = state.accounts[0]
+                const { address, key } = (() => {
+                  if (selectAccount) {
+                    if (typeof selectAccount === 'object') return selectAccount
+                    return {
+                      address: undefined,
+                      key: undefined,
+                    }
+                  }
+                  for (const key of account?.keys ?? []) {
+                    if (key.type === 'webauthn-p256' && key.role === 'admin')
+                      return {
+                        address: account?.address,
+                        key: {
+                          credentialId:
+                            (key as any).credentialId ??
+                            key.privateKey?.credential?.id,
+                          publicKey: key.publicKey,
+                        },
+                      }
+                  }
+                  return {
+                    address: undefined,
+                    key: undefined,
+                  }
+                })()
+                const loadAccountsParams = {
+                  internal,
+                  permissions,
+                  signInWithEthereum,
+                }
+                try {
+                  // try to restore from stored account (`address`/`key`) to avoid multiple prompts
+                  return await getMode().actions.loadAccounts({
+                    address,
+                    key,
+                    ...loadAccountsParams,
+                  })
+                } catch (error) {
+                  if (error instanceof ox_Provider.UserRejectedRequestError)
+                    throw error
+
+                  // error with `address`/`key` likely means one or both are stale, retry
+                  if (address && key)
+                    return await getMode().actions.loadAccounts(
+                      loadAccountsParams,
+                    )
+                  throw error
+                }
+              })()
+
+              store.setState((x) => ({ ...x, accounts }))
+
+              const chainIds_response = [
+                chainId,
+                ...store.getState().chainIds.filter((id) => id !== chainId),
+              ] as const
+
+              emitter.emit('connect', {
+                chainId: Hex.fromNumber(chainIds_response[0]),
+              })
+
+              return {
+                accounts: accounts.map((account) => ({
+                  address: account.address,
+                  capabilities: {
+                    admins: account.keys ? getAdmins(account.keys) : [],
+                    permissions: account.keys
+                      ? getActivePermissions(account.keys, {
+                          address: account.address,
+                        })
+                      : [],
+                    ...(account.signInWithEthereum && {
+                      signInWithEthereum: account.signInWithEthereum,
+                    }),
+                  },
+                })),
+                chainIds: chainIds_response.map((chainId) =>
+                  Hex.fromNumber(chainId),
+                ),
+              } satisfies z.input<typeof Rpc.wallet_connect.Response>
+            }
+
+            case 'wallet_disconnect': {
+              const client = getClient()
+
+              await getMode().actions.disconnect?.({
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              store.setState((x) => ({ ...x, accounts: [] }))
+              emitter.emit('disconnect', new ox_Provider.DisconnectedError())
+              return
+            }
+
+            case 'wallet_getAssets': {
+              const [parameters] = request._decoded.params ?? []
+              const { account, chainFilter, assetFilter, assetTypeFilter } =
+                parameters
+
+              const client = getClient()
+
+              const response = await getMode().actions.getAssets({
+                account,
+                assetFilter,
+                assetTypeFilter,
+                chainFilter,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              const value = Object.entries(response).reduce(
+                (acc, [key, value]) => {
+                  acc[Hex.fromNumber(Number(key))] = value
+                  return acc
+                },
+                {} as Record<string, ValueOf<typeof response>>,
+              )
+
+              return z.encode(Rpc.wallet_getAssets.Response, value)
+            }
+
+            case 'wallet_getCallsStatus': {
+              const [id] = request._decoded.params ?? []
+
+              const client = getClient()
+
+              const response = await getMode().actions.getCallsStatus({
+                id,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              return response satisfies z.input<
+                typeof Rpc.wallet_getCallsStatus.Response
+              >
+            }
+
+            case 'wallet_getCapabilities': {
+              const [_, chainIds] = request.params ?? []
+
+              const capabilities = await getCapabilities({
+                chainIds,
+                request,
+              })
+
+              return capabilities
+            }
+
+            case 'wallet_prepareCalls': {
+              const [parameters] = request._decoded.params
+              const { calls, capabilities, chainId, key, from } = parameters
+
+              const client = getClient(chainId)
+
+              const account = from ?? state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              if (chainId && chainId !== client.chain.id)
+                throw new ox_Provider.ChainDisconnectedError()
+
+              const { digest, ...rest } = await getMode().actions.prepareCalls({
+                account: Account.from(account),
+                calls,
+                feeToken: capabilities?.feeToken,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                key,
+                merchantUrl: UrlString.toAbsolute(
+                  config.merchantUrl ?? capabilities?.merchantUrl,
+                ),
+                requiredFunds: capabilities?.requiredFunds,
+              })
+
+              return z.encode(Rpc.wallet_prepareCalls.Response, {
+                capabilities: rest.capabilities,
+                chainId: Hex.fromNumber(rest.chainId ?? client.chain.id),
+                context: {
+                  ...rest.context,
+                  account: {
+                    address: rest.account.address,
+                  },
+                  calls: rest.context.calls ?? [],
+                  nonce: rest.context.nonce ?? 0n,
+                },
+                digest,
+                key: rest.key,
+                typedData: rest.typedData,
+              })
+            }
+
+            case 'wallet_sendPreparedCalls': {
+              const [parameters] = request._decoded.params
+              const { chainId, context, key, signature } = parameters
+              const { account } = parameters.context
+
+              const client = getClient(chainId)
+
+              if (chainId && Hex.toNumber(chainId) !== client.chain.id)
+                throw new ox_Provider.ChainDisconnectedError()
+
+              const hash = await getMode().actions.sendPreparedCalls({
+                account: Account.from(account),
+                context,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                key,
+                signature,
+              })
+
+              return [{ id: hash }] satisfies z.input<
+                typeof Rpc.wallet_sendPreparedCalls.Response
+              >
+            }
+
+            case 'wallet_sendCalls': {
+              if (state.accounts.length === 0)
+                throw new ox_Provider.DisconnectedError()
+
+              const [parameters] = request._decoded.params
+              const { calls, capabilities, chainId, from } = parameters
+
+              const client = getClient(chainId)
+
+              if (chainId && chainId !== client.chain.id)
+                throw new ox_Provider.ChainDisconnectedError()
+
+              const account = from
+                ? state.accounts.find((account) =>
+                    Address.isEqual(account.address, from),
+                  )
+                : state.accounts[0]
+              if (!account) throw new ox_Provider.UnauthorizedError()
+
+              const { id } = await getMode().actions.sendCalls({
+                account,
+                calls,
+                feeToken: capabilities?.feeToken,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+                merchantUrl: UrlString.toAbsolute(
+                  config.merchantUrl ?? capabilities?.merchantUrl,
+                ),
+                permissionsId: capabilities?.permissions?.id,
+                requiredFunds: capabilities?.requiredFunds,
+              })
+
+              return { id } satisfies z.input<
+                typeof Rpc.wallet_sendCalls.Response
+              >
+            }
+
+            case 'wallet_switchEthereumChain': {
+              const [parameters] = request._decoded.params
+              const { chainId } = parameters
+              const chainId_number = Hex.toNumber(chainId)
+
+              const chain = config.chains.find(
+                (chain) => chain.id === chainId_number,
+              )
+              if (!chain) throw new ox_Provider.UnsupportedChainIdError()
+
+              const client = getClient(chainId)
+              await getMode().actions.switchChain?.({
+                chainId: client.chain.id,
+                internal: {
+                  client,
+                  config,
+                  request,
+                  store,
+                },
+              })
+
+              store.setState((state) => ({
+                ...state,
+                chainIds: [
+                  chainId_number,
+                  ...state.chainIds.filter((id) => id !== chainId_number),
+                ],
+              }))
+
+              return undefined
+            }
+
+            case 'wallet_verifySignature': {
+              const [parameters] = request._decoded.params
+              const { address, chainId, digest, signature } = parameters
+
+              const client = getClient(chainId)
+
+              const result = await Actions.verifySignature(client, {
+                address,
+                digest,
+                signature,
+              })
+
+              return {
+                ...result,
+                address,
+                chainId: Hex.fromNumber(client.chain.id),
+              } satisfies z.input<typeof Rpc.wallet_verifySignature.Response>
+            }
+          }
+        },
+        {
+          enabled: shouldDedupe,
+          id: Json.stringify(request_),
+        },
+      )
     },
   })
 


### PR DESCRIPTION
### Summary

Added EIP-1193 Provider deduplication mechanism to prevent duplicate requests from applications that send the same requests multiple times in short periods.

### Details

- Added `withDedupe` utility function to deduplicate async operations by serialized parameters and method
- Wrapped provider request method with deduplication for immutable public methods
- Includes methods like `eth_accounts`, `eth_chainId`, `eth_requestAccounts`, and wallet capabilities methods
- Uses JSON serialization for cache keys to handle complex parameter objects
- Cache entries auto-expire after 5 seconds to prevent stale data

### Areas Touched

- `porto` Library (`src/`)
  - Core provider implementation (`src/core/internal/provider.ts`)
  - Utility functions (`src/core/internal/utils.ts`)
  - Remote events (`src/remote/Events.ts`)