### PR TITLE
chore: fix folder deletion order with `-depth`

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 # remove all node_modules, recursively
-/usr/bin/find . -name "node_modules" -type d -exec rm -rf {} +
+/usr/bin/find . -depth -type d -name "node_modules" -exec rm -rf {} +
 
 # remove all dist, recursively
-/usr/bin/find . -name "dist" -type d -exec rm -rf {} +
+/usr/bin/find . -depth -type d -name "dist" -exec rm -rf {} +
 
 # remove all build, recursively
-/usr/bin/find . -name "build" -type d -exec rm -rf {} +
+/usr/bin/find . -depth -type d -name "build" -exec rm -rf {} +


### PR DESCRIPTION
added `-depth` to `find` so nested folders get handled before their parents.
stops errors when removing folders like `node_modules`, `dist`, or `build`.