### PR TITLE
fix(docs): correct spend.limit type in grantPermissions.mdx

### DIFF
--- a/apps/docs/pages/sdk/wagmi/grantPermissions.mdx
+++ b/apps/docs/pages/sdk/wagmi/grantPermissions.mdx
@@ -144,7 +144,7 @@ type Permissions = {
   /** Spend permissions */
   spend: {
     /** Spending limit (in wei) per period */
-    limit: `0x${string}`
+    limit: bigint
     /** Period of the spend limit */
     period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
     /** ERC20 token to set the limit on (defaults to native token) */
@@ -209,7 +209,7 @@ type Permissions = {
   /** Spend permissions */
   spend: {
     /** Spending limit (in wei) per period */
-    limit: `0x${string}`
+    limit: bigint
     /** Period of the spend limit */
     period: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
     /** ERC20 token to set the limit on (defaults to native token) */


### PR DESCRIPTION
### Summary

Fixed incorrect type definition for `spend.limit` in the grantPermissions documentation.

### Details

- Corrected `spend.limit` type from `\`0x${string}\`` (hex string) to `bigint` in both Parameters and Return Value sections
- The documentation's type definitions (lines 147 and 212) were inconsistent with the actual implementation
- The example code was already correct (`parseEther('50')` returns bigint)
- Implementation reference: https://github.com/ithacaxyz/porto/blob/main/src/core/internal/schema/key.ts#L71

### Areas Touched

- Documentation (`apps/docs`)