### PR TITLE
fix: handle trimmed last line

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,9 @@
     "vitest": "catalog:",
     "wagmi": "catalog:",
     "yaml": "^2.8.1",
-    "zile": "^0.0.5"
+    "zile": "^0.0.7"
   },
-  "packageManager": "pnpm@10.18.3",
+  "packageManager": "pnpm@10.19.0",
   "engines": {
     "node": ">=22.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,8 +310,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       zile:
-        specifier: ^0.0.5
-        version: 0.0.5(typescript@5.9.3)
+        specifier: ^0.0.7
+        version: 0.0.7(typescript@5.9.3)
 
   apps/dialog:
     dependencies:
@@ -15137,8 +15137,8 @@ packages:
     resolution: {integrity: sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==}
     engines: {node: '>=10'}
 
-  zile@0.0.5:
-    resolution: {integrity: sha512-PCIYo0pomR6xlG+1ybmQ1gcn74plcuJptv4p9kVUhnSfGyTdc8tyDuxNvWurEK6ADnU1lK+FuMEJX97UoOKM+w==}
+  zile@0.0.7:
+    resolution: {integrity: sha512-ryBgowMTX83ptzVdTPPJZ7o7aTEfMy2EGg2pilkUZLuYoYeTIi2Xw7CLG9wCXw1moe/Kw/tz9xwC/IBAfO/dJg==}
     hasBin: true
     peerDependencies:
       '@typescript/native-preview': '>=7.0.0'
@@ -32915,7 +32915,7 @@ snapshots:
       property-expr: 2.0.6
       toposort: 2.0.2
 
-  zile@0.0.5(typescript@5.9.3):
+  zile@0.0.7(typescript@5.9.3):
     dependencies:
       cac: 6.7.14
       tsconfck: 3.1.6(typescript@5.9.3)


### PR DESCRIPTION
current extra line appending in `gen:exports.ts` gets cancelled out when running `build:dist` script. This change ensures the final line is present after the that script is completed.