### PR TITLE
feat(siwe): add P-256 public key support to SIWE authentication

### DIFF
--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -232,6 +232,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
                 address: account.address,
                 authUrl,
                 message,
+                publicKey: account.capabilities?.admins?.[0]?.publicKey,
                 signature,
               })
               return {

--- a/src/core/internal/siwe.ts
+++ b/src/core/internal/siwe.ts
@@ -17,7 +17,7 @@ export type AuthUrl = {
 export async function authenticate(
   parameters: authenticate.Parameters,
 ): Promise<authenticate.ReturnType> {
-  const { address, authUrl, message, signature } = parameters
+  const { address, authUrl, message, signature, publicKey } = parameters
 
   const { chainId } = Siwe.parseMessage(message)
 
@@ -28,6 +28,7 @@ export async function authenticate(
       message,
       signature,
       walletAddress: address,
+      ...(publicKey && { publicKey }),
     }),
     credentials: 'include',
     headers: {
@@ -43,6 +44,18 @@ export declare namespace authenticate {
     authUrl: AuthUrl
     message: string
     signature: Hex.Hex
+    /**
+     * Optional P-256 public key for the signing key.
+     * This allows the server to verify which specific key signed the message,
+     * which is useful for:
+     * - Multi-key account management
+     * - Key-specific authorization policies
+     * - Linking passkeys to user accounts
+     *
+     * The public key should be the uncompressed P-256 public key in hex format
+     * (e.g., "0x04..." for uncompressed, or "0x02/03..." for compressed).
+     */
+    publicKey?: Hex.Hex | undefined
   }
 
   type ReturnType = {


### PR DESCRIPTION
- Add publicKey parameter to Siwe.authenticate() function
- Include publicKey in authUrl.verify request payload when provided
- Update dialog.ts to extract and pass adminKey.publicKey during authentication
- Add JSDoc documentation for publicKey parameter use cases
- Add test coverage for publicKey parameter behavior (includes/omits)
- Fix code formatting (indentation and empty catch blocks)

This allows servers to identify which specific P-256 key signed the SIWE message, enabling multi-key account management, key-specific authorization policies, and passkey-to-account linking workflows.

Breaking Changes: None - publicKey is optional and backward compatible