### PR TITLE
fix(dialog): only clear accounts on explicit wallet_disconnect

### DIFF
--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -35,6 +35,10 @@ if (import.meta.env.PROD) {
 const offInitialized = Events.onInitialized(porto, async (payload, event) => {
   const { chainIds, features, labels, mode, referrer, theme } = payload
 
+  // Clear accounts on dialog init. If the parent has a connected account,
+  // it will be synced via when the first request comes in (requireAccountSync).
+  porto._internal.store.setState((x) => ({ ...x, accounts: [] }))
+
   // Prevent showing stale route from a previous action.
   const pathname = Router.router.state.location.pathname.replace(/\/+$/, '')
   if (pathname !== '/dialog') await Router.router.navigate({ to: '/dialog' })

--- a/apps/dialog/src/main.tsx
+++ b/apps/dialog/src/main.tsx
@@ -88,8 +88,12 @@ const offDialogRequest = Events.onDialogRequest(
 
     const connectedAccount = porto._internal.store.getState().accounts[0]
 
-    // Clear the dialog accounts if disconnected
-    if (!account && connectedAccount?.address)
+    // Only clear dialog accounts on explicit disconnect request.
+    // We do NOT clear accounts just because `account` is undefined in the request -
+    // that just means the request didn't specify a `from` address (e.g. wallet_sendCalls
+    // without `from`). The connected account should persist through such requests.
+    // See: https://github.com/ithacaxyz/porto/pull/1009
+    if (request?.method === 'wallet_disconnect' && connectedAccount?.address)
       porto._internal.store.setState((x) => ({ ...x, accounts: [] }))
 
     const requireAccountSync =


### PR DESCRIPTION
Previously, dialog accounts were cleared whenever a request came in without an explicit `account` field (e.g. wallet_sendCalls without `from`). This caused accounts to be incorrectly cleared on normal requests, requiring re-authentication.

Now accounts are only cleared when the request method is explicitly `wallet_disconnect`, preserving account state through requests that simply don't specify a `from` address.

Fixes regression from #1009

NOTE:  The original condition `!account && connectedAccount?.address` used the account parameter from `onDialogRequest`, which is derived `from` request fields like `from`. This was intended to detect "user no longer has an account," but it conflated "request doesn't specify an account" with "user disconnected." The fix makes this distinction explicit by checking the request method.

However, there may be edge cases where disconnection occurs and we don't detect it:
- If the parent app's Porto instance loses its account state unexpectedly (e.g., localStorage cleared, storage corruption, or a bug) without calling wallet_disconnect, the dialog would retain stale account state.
- In such cases, the dialog and parent would be out of sync until the user explicitly disconnects or the dialog is reloaded.
