### PR TITLE
feat: add villa.cash domains to trusted hosts

### DIFF
--- a/src/trusted-hosts.ts
+++ b/src/trusted-hosts.ts
@@ -45,4 +45,9 @@ export const hostnames = [
   'honey.berachain.com',
   'privote.live',
   'portkey.bsky.nyc',
+  'villa.cash',
+  'beta.villa.cash',
+  'dev-1.villa.cash',
+  'dev-2.villa.cash',
+  'dev-3.villa.cash',
 ]


### PR DESCRIPTION
### Summary

Add Villa domains to trusted hosts for Porto auth integration.

### Details

- Added `villa.cash` (production)
- Added `beta.villa.cash` (staging)
- Added `dev-1.villa.cash`, `dev-2.villa.cash`, `dev-3.villa.cash` (dev environments)

### Context

[Villa](https://github.com/rockfridrich/villa) is open source passkey auth for pop-up villages and temporary communities. Building this while at [Proof of Retreat](https://proofofretreat.me).

Related issue: https://github.com/rockfridrich/villa/issues/19

### Areas Touched

- `porto` Library (`src/`)