### PR TITLE
feat: support multiple session key grants in single request

### DIFF
--- a/src/core/internal/mode.ts
+++ b/src/core/internal/mode.ts
@@ -58,8 +58,11 @@ export type Mode = {
       internal: ActionsInternal
       /** Label to associate with the WebAuthn credential. */
       label?: string | undefined
-      /** Permissions to grant. */
-      permissions?: PermissionsRequest.PermissionsRequest | undefined
+      /** Permissions to grant. Can be a single request or an array for batching multiple session keys. */
+      permissions?:
+        | PermissionsRequest.PermissionsRequest
+        | readonly PermissionsRequest.PermissionsRequest[]
+        | undefined
       /** Adds support for offchain authentication using ERC-4361. */
       signInWithEthereum?: Capabilities.signInWithEthereum.Request | undefined
     }) => Promise<{
@@ -170,8 +173,11 @@ export type Mode = {
         | undefined
       /** Internal properties. */
       internal: ActionsInternal
-      /** Permissions to grant. */
-      permissions?: PermissionsRequest.PermissionsRequest | undefined
+      /** Permissions to grant. Can be a single request or an array for batching multiple session keys. */
+      permissions?:
+        | PermissionsRequest.PermissionsRequest
+        | readonly PermissionsRequest.PermissionsRequest[]
+        | undefined
       /** Adds support for offchain authentication using ERC-4361. */
       signInWithEthereum?: Capabilities.signInWithEthereum.Request | undefined
     }) => Promise<{
@@ -231,8 +237,11 @@ export type Mode = {
       label?: string | undefined
       /** Internal properties. */
       internal: ActionsInternal
-      /** Permissions to grant. */
-      permissions?: PermissionsRequest.PermissionsRequest | undefined
+      /** Permissions to grant. Can be a single request or an array for batching multiple session keys. */
+      permissions?:
+        | PermissionsRequest.PermissionsRequest
+        | readonly PermissionsRequest.PermissionsRequest[]
+        | undefined
     }) => Promise<{
       /** Digests to sign. */
       digests: {

--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -159,21 +159,30 @@ export function dialog(parameters: dialog.Parameters = {}) {
             const signInWithEthereum =
               request.params?.[0]?.capabilities?.signInWithEthereum
 
-            // Parse the authorize key into a structured key.
-            const key = await PermissionsRequest.toKey(
-              capabilities?.grantPermissions,
+            // Parse the authorize key(s) into structured keys.
+            const grantPermissionsInput = capabilities?.grantPermissions
+            const permissionsInputArray = Array.isArray(grantPermissionsInput)
+              ? grantPermissionsInput
+              : grantPermissionsInput
+                ? [grantPermissionsInput]
+                : []
+            const generatedKeys = await PermissionsRequest.toKeys(
+              permissionsInputArray,
               {
                 chainId: client.chain.id,
               },
             )
 
-            // Convert the key into a permission.
-            const permissionsRequest = key
-              ? z.encode(
-                  PermissionsRequest.Schema,
-                  PermissionsRequest.fromKey(key),
-                )
-              : undefined
+            // Convert the keys back into permission requests (with generated key info).
+            const permissionsPayload =
+              generatedKeys.length === 0
+                ? undefined
+                : generatedKeys.map((k) =>
+                    z.encode(
+                      PermissionsRequest.Schema,
+                      PermissionsRequest.fromKey(k),
+                    ),
+                  )
 
             // Send a request off to the dialog to create an account.
             const { accounts } = await provider.request({
@@ -182,7 +191,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
                 {
                   capabilities: {
                     ...request.params?.[0]?.capabilities,
-                    grantPermissions: permissionsRequest,
+                    grantPermissions: permissionsPayload,
                     signInWithEthereum:
                       authUrl || signInWithEthereum
                         ? {
@@ -210,10 +219,13 @@ export function dialog(parameters: dialog.Parameters = {}) {
                   const key_permission = Permissions.toKey(
                     z.decode(Permissions.Schema, permission),
                   )
-                  if (key_permission.id === key?.id)
+                  const matchedKey = generatedKeys.find(
+                    (gk) => gk.id === key_permission.id,
+                  )
+                  if (matchedKey)
                     return {
                       ...key_permission,
-                      ...key,
+                      ...matchedKey,
                       permissions: key_permission.permissions,
                     }
                   return key_permission
@@ -488,21 +500,30 @@ export function dialog(parameters: dialog.Parameters = {}) {
           const signInWithEthereum =
             request.params?.[0]?.capabilities?.signInWithEthereum
 
-          // Parse provided (RPC) key into a structured key.
-          const key = await PermissionsRequest.toKey(
-            capabilities?.grantPermissions,
+          // Parse provided (RPC) key(s) into structured keys.
+          const grantPermissionsInput = capabilities?.grantPermissions
+          const permissionsInputArray = Array.isArray(grantPermissionsInput)
+            ? grantPermissionsInput
+            : grantPermissionsInput
+              ? [grantPermissionsInput]
+              : []
+          const generatedKeys = await PermissionsRequest.toKeys(
+            permissionsInputArray,
             {
               chainId: client.chain.id,
             },
           )
 
-          // Convert the key into a permissions request.
-          const permissionsRequest = key
-            ? z.encode(
-                PermissionsRequest.Schema,
-                PermissionsRequest.fromKey(key),
-              )
-            : undefined
+          // Convert the keys back into permission requests (with generated key info).
+          const permissionsPayload =
+            generatedKeys.length === 0
+              ? undefined
+              : generatedKeys.map((k) =>
+                  z.encode(
+                    PermissionsRequest.Schema,
+                    PermissionsRequest.fromKey(k),
+                  ),
+                )
 
           // Send a request to the dialog.
           const { accounts } = await provider.request({
@@ -512,7 +533,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
                 ...request.params?.[0],
                 capabilities: {
                   ...request.params?.[0]?.capabilities,
-                  grantPermissions: permissionsRequest,
+                  grantPermissions: permissionsPayload,
                   signInWithEthereum:
                     authUrl || signInWithEthereum
                       ? {
@@ -536,10 +557,13 @@ export function dialog(parameters: dialog.Parameters = {}) {
                     const key_permission = Permissions.toKey(
                       z.decode(Permissions.Schema, permission),
                     )
-                    if (key_permission.id === key?.id)
+                    const matchedKey = generatedKeys.find(
+                      (gk) => gk.id === key_permission.id,
+                    )
+                    if (matchedKey)
                       return {
                         ...key_permission,
-                        ...key,
+                        ...matchedKey,
                         permissions: key_permission.permissions,
                       }
                     return key_permission
@@ -644,18 +668,30 @@ export function dialog(parameters: dialog.Parameters = {}) {
         // Extract the capabilities from the request.
         const [{ capabilities }] = request._decoded.params ?? [{}]
 
-        // Parse the authorize key into a structured key.
-        const key = await PermissionsRequest.toKey(
-          capabilities?.grantPermissions,
+        // Parse the authorize key(s) into structured keys.
+        const grantPermissionsInput = capabilities?.grantPermissions
+        const permissionsInputArray = Array.isArray(grantPermissionsInput)
+          ? grantPermissionsInput
+          : grantPermissionsInput
+            ? [grantPermissionsInput]
+            : []
+        const generatedKeys = await PermissionsRequest.toKeys(
+          permissionsInputArray,
           {
             chainId: client.chain.id,
           },
         )
 
-        // Convert the key into a permission.
-        const permissionsRequest = key
-          ? z.encode(PermissionsRequest.Schema, PermissionsRequest.fromKey(key))
-          : undefined
+        // Convert the keys back into permission requests (with generated key info).
+        const permissionsPayload =
+          generatedKeys.length === 0
+            ? undefined
+            : generatedKeys.map((k) =>
+                z.encode(
+                  PermissionsRequest.Schema,
+                  PermissionsRequest.fromKey(k),
+                ),
+              )
 
         // Send a request off to the dialog to prepare the upgrade.
         const provider = getProvider(store)
@@ -666,7 +702,7 @@ export function dialog(parameters: dialog.Parameters = {}) {
               ...request.params?.[0],
               capabilities: {
                 ...request.params?.[0]?.capabilities,
-                grantPermissions: permissionsRequest,
+                grantPermissions: permissionsPayload,
               },
             },
           ],
@@ -674,7 +710,8 @@ export function dialog(parameters: dialog.Parameters = {}) {
 
         type Context = { account: Account.Account }
         const keys = (context as Context).account.keys?.map((k) => {
-          if (k.id === key?.id) return { ...k, ...key }
+          const matchedKey = generatedKeys.find((gk) => gk.id === k.id)
+          if (matchedKey) return { ...k, ...matchedKey }
           return k
         })
 

--- a/src/core/internal/modes/relay.ts
+++ b/src/core/internal/modes/relay.ts
@@ -80,7 +80,12 @@ export function relay(parameters: relay.Parameters = {}) {
               userId: Bytes.from(eoa.address),
             })
           : Key.createHeadlessWebAuthnP256()
-        const sessionKey = await PermissionsRequest.toKey(permissions, {
+        const permissionsArray = Array.isArray(permissions)
+          ? permissions
+          : permissions
+            ? [permissions]
+            : []
+        const sessionKeys = await PermissionsRequest.toKeys(permissionsArray, {
           chainId: client.chain.id,
           feeTokens,
         })
@@ -89,11 +94,7 @@ export function relay(parameters: relay.Parameters = {}) {
 
         const account = await RelayActions.upgradeAccount(client, {
           account: eoa,
-          authorizeKeys: [
-            adminKey,
-            ...(adminKeys ?? []),
-            ...(sessionKey ? [sessionKey] : []),
-          ],
+          authorizeKeys: [adminKey, ...(adminKeys ?? []), ...sessionKeys],
         })
 
         address_internal = eoa.address
@@ -325,6 +326,7 @@ export function relay(parameters: relay.Parameters = {}) {
         const signature = await Key.sign(adminKey, {
           address: null,
           payload: digest,
+          webAuthn,
         })
         await RelayActions.sendPreparedCalls(client, {
           context,
@@ -341,10 +343,18 @@ export function relay(parameters: relay.Parameters = {}) {
 
         const feeTokens = await Tokens.getTokens(client)
 
-        const authorizeKey = await PermissionsRequest.toKey(permissions, {
-          chainId: client.chain.id,
-          feeTokens,
-        })
+        const permissionsArray = Array.isArray(permissions)
+          ? permissions
+          : permissions
+            ? [permissions]
+            : []
+        const authorizeKeys_ = await PermissionsRequest.toKeys(
+          permissionsArray,
+          {
+            chainId: client.chain.id,
+            feeTokens,
+          },
+        )
 
         // Prepare calls to sign over the session key or SIWE message to authorize.
         // TODO: figure out with relay if we can prepare the "precall" here also.
@@ -417,24 +427,22 @@ export function relay(parameters: relay.Parameters = {}) {
         // Instantiate the account based off the extracted address and keys.
         const account = Account.from({
           address,
-          keys: [...keys, ...(authorizeKey ? [authorizeKey] : [])].map(
-            (key, i) => {
-              // Assume that the first key is the admin WebAuthn key.
-              if (i === 0) {
-                if (key.type === 'webauthn-p256')
-                  return Key.fromWebAuthnP256({
-                    ...key,
-                    credential: {
-                      id: credentialId!,
-                      publicKey: PublicKey.fromHex(key.publicKey),
-                    },
-                    id: address,
-                    rpId: keystoreHost,
-                  })
-              }
-              return key
-            },
-          ),
+          keys: [...keys, ...authorizeKeys_].map((key, i) => {
+            // Assume that the first key is the admin WebAuthn key.
+            if (i === 0) {
+              if (key.type === 'webauthn-p256')
+                return Key.fromWebAuthnP256({
+                  ...key,
+                  credential: {
+                    id: credentialId!,
+                    publicKey: PublicKey.fromHex(key.publicKey),
+                  },
+                  id: address,
+                  rpId: keystoreHost,
+                })
+            }
+            return key
+          }),
         })
 
         const adminKey = Account.getKey(account, { role: 'admin' })!
@@ -464,11 +472,11 @@ export function relay(parameters: relay.Parameters = {}) {
           })
         })()
 
-        // Prepare and send the authorize key pre-call.
-        if (authorizeKey) {
+        // Prepare and send the authorize keys pre-call.
+        if (authorizeKeys_.length > 0) {
           const { context, digest } = await RelayActions.prepareCalls(client, {
             account,
-            authorizeKeys: [authorizeKey],
+            authorizeKeys: authorizeKeys_,
             preCalls: true,
           })
           const signature = await Key.sign(adminKey, {
@@ -606,7 +614,12 @@ export function relay(parameters: relay.Parameters = {}) {
               userId: Bytes.from(address),
             })
           : Key.createHeadlessWebAuthnP256()
-        const sessionKey = await PermissionsRequest.toKey(permissions, {
+        const permissionsArray = Array.isArray(permissions)
+          ? permissions
+          : permissions
+            ? [permissions]
+            : []
+        const sessionKeys = await PermissionsRequest.toKeys(permissionsArray, {
           chainId: client.chain.id,
           feeTokens: tokens,
         })
@@ -615,7 +628,7 @@ export function relay(parameters: relay.Parameters = {}) {
           client,
           {
             address,
-            authorizeKeys: [adminKey, ...(sessionKey ? [sessionKey] : [])],
+            authorizeKeys: [adminKey, ...sessionKeys],
             feeToken: feeToken?.address,
           },
         )

--- a/src/core/internal/permissionsRequest.ts
+++ b/src/core/internal/permissionsRequest.ts
@@ -76,6 +76,14 @@ export declare namespace toKey {
   }
 }
 
+export async function toKeys(
+  requests: readonly PermissionsRequest[],
+  options: toKey.Options = {},
+): Promise<Key.Key[]> {
+  const results = await Promise.all(requests.map((r) => toKey(r, options)))
+  return results.filter((k): k is Key.Key => k !== undefined)
+}
+
 function isWebCryptoUnavailable(error: unknown) {
   if (!(error instanceof Error)) return false
   const message = error.message?.toLowerCase() ?? ''

--- a/src/core/internal/schema/capabilities.ts
+++ b/src/core/internal/schema/capabilities.ts
@@ -86,7 +86,10 @@ export namespace feeToken {
 }
 
 export namespace grantPermissions {
-  export const Request = Permissions.Request
+  export const Request = z.union([
+    Permissions.Request,
+    z.readonly(z.array(Permissions.Request)),
+  ])
   export type Request = z.infer<typeof Request>
 }
 


### PR DESCRIPTION
## Summary

Apps that need multiple session keys (e.g. server-side automation keys + local biometric-gated key) currently require N separate passkey prompts — one per `grantPermissions` call. This PR allows batching multiple permission grants into a single `wallet_connect` call, so all session keys are registered atomically in one passkey prompt.

- **`grantPermissions` capability** now accepts `Request | readonly Request[]` (backward compatible — single objects still work)
- **New `PermissionsRequest.toKeys()`** batch helper for parallel key generation
- **Relay mode** `createAccount`, `loadAccounts`, and `prepareUpgradeAccount` normalize permissions to arrays and spread all session keys into `authorizeKeys`
- **Dialog mode** updated with the same array normalization pattern
- **Bug fix**: Pass `webAuthn` config to `Key.sign()` in relay `grantPermissions` handler (prevents crash in React Native WebAuthn environments)

### Motivation

Our wallet creates 3 distinct session keys at account creation:
1. **Server-side vault operations** (P256, server-held private key)
2. **Server-side reward claiming** (P256, server-held private key)  
3. **Local user transactions** (P256, biometric-gated on device)

Today this requires 3 passkey prompts — terrible UX. With this change:

```ts
const response = await WalletActions.connect(walletClient, {
  createAccount: { label: 'My Wallet' },
  grantPermissions: [
    { expiry, key: key1, permissions: perms1, feeToken },
    { expiry, key: key2, permissions: perms2, feeToken },
    { expiry, key: key3, permissions: perms3, feeToken },
  ],
})
// 1 passkey prompt → 3 session keys registered atomically
```

### Why this works

The relay infrastructure already supports this — `authorizeKeys: Key[]` is an array at every layer:
- `relay/schema/capabilities.ts` — `authorizeKeys = z.readonly(z.array(Key.WithPermissions))`
- `RelayActions.prepareCalls()` — `authorizeKeys?: readonly Key.Key[]`
- `createAccount` already sends `[adminKey, ...adminKeys, sessionKey]` today

This PR just removes the artificial singular constraint at the SDK TypeScript/schema layer.

### Files changed (5)

| File | Change |
|---|---|
| `schema/capabilities.ts` | `grantPermissions.Request` accepts `Request \| readonly Request[]` |
| `permissionsRequest.ts` | New `toKeys()` batch helper |
| `mode.ts` | `permissions` param accepts arrays on 3 actions |
| `modes/relay.ts` | Array normalization in 3 handlers + webAuthn bug fix |
| `modes/dialog.ts` | Array normalization in 3 locations |

## Test plan

- [x] `tsc --noEmit` passes with zero type errors
- [x] Biome check passes
- [ ] Existing tests pass (single permission still works — union accepts both forms)
- [ ] Manual test: `wallet_connect` with array of 3 permission requests creates account with 3 session keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)