### PR TITLE
fix: propagate merchantUrl in _decoded for eth_sendTransaction dialog mode

### DIFF
--- a/src/core/internal/modes/dialog.ts
+++ b/src/core/internal/modes/dialog.ts
@@ -855,16 +855,23 @@ export function dialog(parameters: dialog.Parameters = {}) {
 
         if (request.method === 'eth_sendTransaction') {
           // Send a transaction request to the dialog.
+          const caps = { feeToken, merchantUrl }
           const id = await provider.request({
             ...request,
+            _decoded: {
+              ...request._decoded,
+              params: [
+                {
+                  ...request._decoded?.params?.[0],
+                  capabilities: caps,
+                },
+              ],
+            },
             params: [
               {
                 ...request.params?.[0],
                 // @ts-expect-error
-                capabilities: {
-                  feeToken,
-                  merchantUrl,
-                },
+                capabilities: caps,
                 ...(chainId ? { chainId: Hex.fromNumber(chainId) } : {}),
               },
             ],


### PR DESCRIPTION
Fixes #1058

When using Route.merchant() with dialog mode, eth_sendTransaction adds capabilities (including merchantUrl) to params but spreads the original request which contains a stale _decoded without capabilities. The dialog iframe reads from _decoded.params[0].capabilities, so merchantUrl is always undefined and merchant sponsorship silently fails.

This updates _decoded alongside params so capabilities propagate correctly.