### PR TITLE
docs(examples): add Porto sunsetting notices

### DIFF
--- a/examples/authentication-better-auth/README.md
+++ b/examples/authentication-better-auth/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/authentication-better-auth porto-better-auth && cd porto-better-auth
 pnpm i

--- a/examples/authentication-rainbowkit/README.md
+++ b/examples/authentication-rainbowkit/README.md
@@ -1,5 +1,8 @@
 # Authentication Example (SIWE with RainbowKit)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/authentication-rainbowkit porto-rainbowkit && cd porto-rainbowkit
 pnpm i

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -1,5 +1,8 @@
 # Authentication Example (SIWE with PWA)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/authentication porto-auth && cd porto-auth
 pnpm i

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/cli porto-cli && cd porto-cli
 pnpm i

--- a/examples/dynamic/README.md
+++ b/examples/dynamic/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/dynamic porto-dynamic && cd porto-dynamic
 pnpm i

--- a/examples/guest-checkout/README.md
+++ b/examples/guest-checkout/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/guest-checkout porto-guest-checkout && cd porto-guest-checkout
 pnpm i

--- a/examples/next.js/README.md
+++ b/examples/next.js/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/next.js porto-next && cd porto-next
 pnpm i

--- a/examples/payments/README.md
+++ b/examples/payments/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/payments porto-payments && cd porto-payments
 pnpm i

--- a/examples/permissions/README.md
+++ b/examples/permissions/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/permissions porto-permissions && cd porto-permissions
 pnpm i

--- a/examples/react-native-relay-mode/README.md
+++ b/examples/react-native-relay-mode/README.md
@@ -1,5 +1,8 @@
 # React Native Relay Mode (with SIWE)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ## 1. Setup
 
 ```sh

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -1,5 +1,8 @@
 # React Native Mode
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ## 1. Setup
 
 ```sh

--- a/examples/sponsoring-express/README.md
+++ b/examples/sponsoring-express/README.md
@@ -1,5 +1,8 @@
 # Merchant Sponsoring (Express)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ## 1. Setup
 
 ```sh

--- a/examples/sponsoring-next.js/README.md
+++ b/examples/sponsoring-next.js/README.md
@@ -1,5 +1,8 @@
 # Merchant Sponsoring (Next.js)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ## 1. Setup
 
 ```sh

--- a/examples/sponsoring-privy/README.md
+++ b/examples/sponsoring-privy/README.md
@@ -1,5 +1,8 @@
 # Merchant Sponsoring (Privy)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 [Live Demo](https://sponsoring-privy-example.porto.workers.dev)
 
 ## 1. Setup

--- a/examples/sponsoring-vite/README.md
+++ b/examples/sponsoring-vite/README.md
@@ -1,5 +1,8 @@
 # Merchant Sponsoring (Vite)
 
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 [Live Demo](https://sponsoring-vite-example.porto.workers.dev)
 
 ## 1. Setup

--- a/examples/theming/README.md
+++ b/examples/theming/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/theming porto-theming && cd porto-theming
 pnpm i

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Porto is sunsetting. Please move any funds out before July 24, 2026. See the [sunsetting details](https://ithaca.xyz/updates/sunsetting-porto).
+
 ```sh
 pnpx gitpick ithacaxyz/porto/tree/main/examples/vite-react porto-vite && cd porto-vite
 pnpm i


### PR DESCRIPTION
## Summary
- add the Porto sunsetting notice to each example README
- keep the wording aligned with the top-level README/docs notice

## Why
The examples can be copied directly with `gitpick`, so developers may land in an example README without seeing the repository README or docs banner first. This makes the fund-migration deadline visible in those standalone flows too.

## Validation
- `git diff --check`

Docs-only change.